### PR TITLE
Refactor: Minor changes

### DIFF
--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -55,8 +55,8 @@ class Analysis(Identifiable, Loggable, Serialisable, Taggable):
         self.twine = twine
 
         # Pop any possible strand data sources before init superclasses (and tie them to protected attributes)
-        strand_kwargs = {name: kwargs.pop(name, None) for name in ALL_STRANDS}
-        for strand_name, strand_data in strand_kwargs.items():
+        strand_kwargs = ((name, kwargs.pop(name, None)) for name in ALL_STRANDS)
+        for strand_name, strand_data in strand_kwargs:
             self.__setattr__(f"_{strand_name}", strand_data)
 
         # Init superclasses

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -55,7 +55,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Taggable):
         self.twine = twine
 
         # Pop any possible strand data sources before init superclasses (and tie them to protected attributes)
-        strand_kwargs = dict((name, kwargs.pop(name, None)) for name in ALL_STRANDS)
+        strand_kwargs = {name: kwargs.pop(name, None) for name in ALL_STRANDS}
         for strand_name, strand_data in strand_kwargs.items():
             self.__setattr__(f"_{strand_name}", strand_data)
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -89,25 +89,22 @@ class Dataset(Taggable, Serialisable, Loggable, Identifiable):
         if "__" not in field_lookup:
             raise InvalidInputException("Field lookups should be in the form '<field_name>__'<filter_kind>")
 
+        field_lookups = {
+            "name__icontains": lambda lookup, value, file: lookup == "name__icontains" and value.lower() in file.name.lower(),
+            "name__contains": lambda lookup, value, file: lookup == "name__contains" and value in file.name,
+            "name__endswith": lambda lookup, value, file: lookup == "name__endswith" and file.name.endswith(value),
+            "name__startswith": lambda lookup, value, file: lookup == "name__startswith" and file.name.startswith(value),
+            "tag__exact": lambda lookup, value, file: lookup == "tag__exact" and value in file.tags,
+            "tag__startswith": lambda lookup, value, file: lookup == "tag__startswith" and file.tags.startswith(value),
+            "tag__endswith": lambda lookup, value, file: lookup == "tag__endswith" and file.tags.endswith(value),
+            "tag__contains": lambda lookup, value, file: lookup == "tag__contains" and file.tags.contains(value),
+            "sequence__notnone": lambda lookup, value, file: lookup == "sequence__notnone" and file.sequence is not None
+        }
+
         results = []
+
         for file in files:
-            if field_lookup == "name__icontains" and filter_value.lower() in file.name.lower():
-                results.append(file)
-            if field_lookup == "name__contains" and filter_value in file.name:
-                results.append(file)
-            if field_lookup == "name__endswith" and file.name.endswith(filter_value):
-                results.append(file)
-            if field_lookup == "name__startswith" and file.name.startswith(filter_value):
-                results.append(file)
-            if field_lookup == "tag__exact" and filter_value in file.tags:
-                results.append(file)
-            if field_lookup == "tag__startswith" and file.tags.startswith(filter_value):
-                results.append(file)
-            if field_lookup == "tag__endswith" and file.tags.endswith(filter_value):
-                results.append(file)
-            if field_lookup == "tag__contains" and file.tags.contains(filter_value):
-                results.append(file)
-            if field_lookup == "sequence__notnone" and file.sequence is not None:
+            if field_lookups[field_lookup](field_lookup, filter_value, file):
                 results.append(file)
 
         return results

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -90,21 +90,21 @@ class Dataset(Taggable, Serialisable, Loggable, Identifiable):
             raise InvalidInputException("Field lookups should be in the form '<field_name>__'<filter_kind>")
 
         field_lookups = {
-            "name__icontains": lambda lookup, value, file: lookup == "name__icontains" and value.lower() in file.name.lower(),
-            "name__contains": lambda lookup, value, file: lookup == "name__contains" and value in file.name,
-            "name__endswith": lambda lookup, value, file: lookup == "name__endswith" and file.name.endswith(value),
-            "name__startswith": lambda lookup, value, file: lookup == "name__startswith" and file.name.startswith(value),
-            "tag__exact": lambda lookup, value, file: lookup == "tag__exact" and value in file.tags,
-            "tag__startswith": lambda lookup, value, file: lookup == "tag__startswith" and file.tags.startswith(value),
-            "tag__endswith": lambda lookup, value, file: lookup == "tag__endswith" and file.tags.endswith(value),
-            "tag__contains": lambda lookup, value, file: lookup == "tag__contains" and file.tags.contains(value),
-            "sequence__notnone": lambda lookup, value, file: lookup == "sequence__notnone" and file.sequence is not None
+            "name__icontains": lambda filter_value, file: filter_value.lower() in file.name.lower(),
+            "name__contains": lambda filter_value, file: filter_value in file.name,
+            "name__endswith": lambda filter_value, file: file.name.endswith(filter_value),
+            "name__startswith": lambda filter_value, file: file.name.startswith(filter_value),
+            "tag__exact": lambda filter_value, file: filter_value in file.tags,
+            "tag__startswith": lambda filter_value, file: file.tags.startswith(filter_value),
+            "tag__endswith": lambda filter_value, file: file.tags.endswith(filter_value),
+            "tag__contains": lambda filter_value, file: file.tags.contains(filter_value),
+            "sequence__notnone": lambda filter_value, file: file.sequence is not None
         }
 
         results = []
 
         for file in files:
-            if field_lookups[field_lookup](field_lookup, filter_value, file):
+            if field_lookups[field_lookup](filter_value, file):
                 results.append(file)
 
         return results

--- a/octue/templates/templates.py
+++ b/octue/templates/templates.py
@@ -8,7 +8,7 @@ from octue import exceptions
 # TODO add ONLINE_TEMPLATES and combine to AVAILABLE_TEMPLATES, to enable us to seamlessly deliver templates that are
 #  more complex (or have lots of data that we don't want packaged with the module).
 
-PACKAGED_TEMPLATES = tuple(filter(lambda name: name.startswith("template-"), resource_listdir("octue", "templates")))
+PACKAGED_TEMPLATES = tuple(name for name in resource_listdir("octue", "templates") if name.startswith("template-"))
 
 
 def copy_template(template_name, destination_dir="."):

--- a/octue/utils/folders.py
+++ b/octue/utils/folders.py
@@ -23,7 +23,7 @@ def from_path(path_hints, folders=FOLDERS):
         if not os.path.isdir(path_hints):
             raise exceptions.FolderNotFoundException(f"Specified data folder '{path_hints}' not present")
 
-        paths = dict([(folder, os.path.join(path_hints, folder)) for folder in folders])
+        paths = {folder: os.path.join(path_hints, folder) for folder in folders}
 
     else:
         if (

--- a/tests/test_datafile.py
+++ b/tests/test_datafile.py
@@ -35,7 +35,7 @@ class DatafileTestCase(BaseTestCase):
     def test_default_local_path_prefix(self):
         """ Ensures the local path, by default, is set to the current working directory
         """
-        df = Datafile(path=os.path.join("/", self.PATH), skip_checks=True)
+        df = Datafile(path=os.sep + self.PATH, skip_checks=True)
         self.assertEqual(self.PATH, df.path)
         self.assertEqual(str(os.getcwd()), df.local_path_prefix.rstrip("\\/"))
 
@@ -49,7 +49,7 @@ class DatafileTestCase(BaseTestCase):
     def test_leading_slashes_on_path_are_stripped(self):
         """ Ensures the path is always relative
         """
-        df = Datafile(path=os.path.join("/", self.PATH), skip_checks=True)
+        df = Datafile(path=os.sep + self.PATH, skip_checks=True)
         self.assertEqual(self.PATH, df.path)
 
         df = Datafile(path=self.PATH, skip_checks=True)

--- a/tests/test_datafile.py
+++ b/tests/test_datafile.py
@@ -7,12 +7,20 @@ from .base import BaseTestCase
 
 
 class DatafileTestCase(BaseTestCase):
+
+    LOCAL_PATH_PREFIX = os.path.join("basic_files", "configuration", "test-dataset")
+    PATH = os.path.join("path-within-dataset", "a_test_file.csv")
+
+    def create_valid_datafile(self):
+        local_path_prefix = os.path.join(self.data_path, self.LOCAL_PATH_PREFIX)
+        return Datafile(local_path_prefix=local_path_prefix, path=self.PATH, skip_checks=False)
+
     def test_instantiates(self):
         """ Ensures a Datafile instantiates using only a path and generates a uuid ID
         """
         df = Datafile(path="a_path")
         self.assertTrue(isinstance(df.id, str))
-        uuid.UUID(df.id)
+        self.assertEqual(type(uuid.UUID(df.id)), uuid.UUID)
         self.assertIsNone(df.sequence)
         self.assertEqual(0, df.cluster)
 
@@ -27,55 +35,49 @@ class DatafileTestCase(BaseTestCase):
     def test_default_local_path_prefix(self):
         """ Ensures the local path, by default, is set to the current working directory
         """
-        df = Datafile(path="/path-within-dataset/a_test_file.csv", skip_checks=True)
-        self.assertEqual("path-within-dataset/a_test_file.csv", df.path)
+        df = Datafile(path=os.path.join("/", self.PATH), skip_checks=True)
+        self.assertEqual(self.PATH, df.path)
         self.assertEqual(str(os.getcwd()), df.local_path_prefix.rstrip("\\/"))
 
     def test_local_path_prefix_with_checks(self):
         """ Ensures the local path can be specified and that checks pass on instantiation
         """
-        local_path = os.path.join(self.data_path, "basic_files/configuration/test-dataset")
-        df = Datafile(path="path-within-dataset/a_test_file.csv", local_path_prefix=local_path, skip_checks=False)
+        local_path = os.path.join(self.data_path, self.LOCAL_PATH_PREFIX)
+        df = Datafile(path=self.PATH, local_path_prefix=local_path, skip_checks=False)
         self.assertEqual("csv", df.extension)
 
     def test_leading_slashes_on_path_are_stripped(self):
         """ Ensures the path is always relative
         """
-        df = Datafile(path="/path-within-dataset/a_test_file.csv", skip_checks=True)
-        self.assertEqual("path-within-dataset/a_test_file.csv", df.path)
+        df = Datafile(path=os.path.join("/", self.PATH), skip_checks=True)
+        self.assertEqual(self.PATH, df.path)
 
-        df = Datafile(path="path-within-dataset/a_test_file.csv", skip_checks=True)
-        self.assertEqual("path-within-dataset/a_test_file.csv", df.path)
+        df = Datafile(path=self.PATH, skip_checks=True)
+        self.assertEqual(self.PATH, df.path)
 
     def test_checks_pass_when_file_exists(self):
-        local_path_prefix = os.path.join(self.data_path, "basic_files/configuration/test-dataset")
-        path = "path-within-dataset/a_test_file.csv"
-        df = Datafile(local_path_prefix=local_path_prefix, path=path, skip_checks=False)
-        self.assertEqual("path-within-dataset/a_test_file.csv", df.path)
-        self.assertEqual(os.path.join(local_path_prefix, path), df.full_path)
+        df = self.create_valid_datafile()
+        self.assertEqual(self.PATH, df.path)
+        self.assertEqual(os.path.join(self.data_path, self.LOCAL_PATH_PREFIX, self.PATH), df.full_path)
         self.assertEqual("csv", df.extension)
 
     def test_checks_fail_when_file_doesnt_exist(self):
-
         path = "not_a_real_file.csv"
         with self.assertRaises(exceptions.FileNotFoundException) as error:
             Datafile(path=path, skip_checks=False)
         self.assertIn("No file found at", error.exception.args[0])
 
     def test_conflicting_extension_fails_check(self):
-        local_path_prefix = os.path.join(self.data_path, "basic_files/configuration/test-dataset")
-        path = "path-within-dataset/a_test_file.csv"
+        local_path_prefix = os.path.join(self.data_path, self.LOCAL_PATH_PREFIX)
         with self.assertRaises(exceptions.InvalidInputException) as error:
-            Datafile(local_path_prefix=local_path_prefix, path=path, skip_checks=False, extension="notcsv")
+            Datafile(local_path_prefix=local_path_prefix, path=self.PATH, skip_checks=False, extension="notcsv")
 
         self.assertIn("Extension provided (notcsv) does not match file extension", error.exception.args[0])
 
     def test_file_attributes_accessible(self):
         """ Ensures that its possible to set the sequence, cluster and timestamp
         """
-        local_path_prefix = os.path.join(self.data_path, "basic_files/configuration/test-dataset")
-        path = "path-within-dataset/a_test_file.csv"
-        df = Datafile(local_path_prefix=local_path_prefix, path=path, skip_checks=False)
+        df = self.create_valid_datafile()
         self.assertIsInstance(df.size_bytes, int)
         self.assertGreaterEqual(df.last_modified, 1598200190.5771205)
         self.assertEqual("a_test_file.csv", df.name)
@@ -87,9 +89,7 @@ class DatafileTestCase(BaseTestCase):
     def test_cannot_set_calculated_file_attributes(self):
         """ Ensures that calculated attributes cannot be set
         """
-        local_path_prefix = os.path.join(self.data_path, "basic_files/configuration/test-dataset")
-        path = "path-within-dataset/a_test_file.csv"
-        df = Datafile(local_path_prefix=local_path_prefix, path=path, skip_checks=False)
+        df = self.create_valid_datafile()
 
         with self.assertRaises(AttributeError):
             df.size_bytes = 1
@@ -100,9 +100,7 @@ class DatafileTestCase(BaseTestCase):
     def test_serialisable(self):
         """ Ensures a datafile can serialise to json format
         """
-        local_path_prefix = os.path.join(self.data_path, "basic_files/configuration/test-dataset")
-        path = "path-within-dataset/a_test_file.csv"
-        df = Datafile(local_path_prefix=local_path_prefix, path=path, skip_checks=False)
+        df = self.create_valid_datafile()
         df_dict = df.serialise()
 
         for k in df_dict.keys():

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -153,17 +153,16 @@ class DatafileTestCase(BaseTestCase):
     def test_get_file_by_tag(self):
         """ Ensures that get_files works with tag lookups
         """
-        resource = Dataset(
-            files=[
-                Datafile(path="path-within-dataset/a_my_file.csv", tags="one a:2 b:3 all"),
-                Datafile(path="path-within-dataset/a_your_file.csv", tags="two a:2 b:3 all"),
-                Datafile(path="path-within-dataset/a_your_file.csv", tags="three all"),
-            ]
-        )
+        files = [
+            Datafile(path="path-within-dataset/a_my_file.csv", tags="one a:2 b:3 all"),
+            Datafile(path="path-within-dataset/a_your_file.csv", tags="two a:2 b:3 all"),
+            Datafile(path="path-within-dataset/a_your_file.csv", tags="three all"),
+        ]
+
+        resource = Dataset(files=files)
 
         # Check working for single result
-        df = resource.get_file_by_tag("three")
-        self.assertTrue(isinstance(df, Datafile))
+        self.assertIs(resource.get_file_by_tag("three"), files[2])
 
         # Check raises for too many results
         with self.assertRaises(exceptions.UnexpectedNumberOfResultsException) as e:
@@ -193,15 +192,14 @@ class DatafileTestCase(BaseTestCase):
     def test_get_file_sequence(self):
         """ Ensures that get_files works with sequence lookups
         """
-        resource = Dataset(
-            files=[
-                Datafile(path="path-within-dataset/a_my_file.csv", sequence=0),
-                Datafile(path="path-within-dataset/a_your_file.csv", sequence=1),
-                Datafile(path="path-within-dataset/a_your_file.csv", sequence=None),
-            ]
-        )
-        files = resource.get_file_sequence("name__endswith", filter_value=".csv", strict=True)
-        self.assertEqual(2, len(files))
+        files = [
+            Datafile(path="path-within-dataset/a_my_file.csv", sequence=0),
+            Datafile(path="path-within-dataset/a_your_file.csv", sequence=1),
+            Datafile(path="path-within-dataset/a_your_file.csv", sequence=None),
+        ]
+
+        got_files = Dataset(files=files).get_file_sequence("name__endswith", filter_value=".csv", strict=True)
+        self.assertEqual(got_files, files[:2])
 
     def test_get_broken_file_sequence(self):
         """ Ensures that get_files works with sequence lookups
@@ -219,14 +217,12 @@ class DatafileTestCase(BaseTestCase):
     def test_get_files_name_filters_include_extension(self):
         """ Ensures that filters applied to the name will catch terms in the extension
         """
-        resource = Dataset(
-            files=[
-                Datafile(path="path-within-dataset/a_test_file.csv"),
-                Datafile(path="path-within-dataset/a_test_file.txt"),
-            ]
-        )
-        files = resource.get_files("name__icontains", filter_value="txt")
-        self.assertEqual(1, len(files))
+        files = [
+            Datafile(path="path-within-dataset/a_test_file.csv"),
+            Datafile(path="path-within-dataset/a_test_file.txt"),
+        ]
+
+        self.assertEqual(Dataset(files=files).get_files("name__icontains", filter_value="txt"), [files[1]])
 
     def test_get_files_name_filters_exclude_path(self):
         """ Ensures that filters applied to the name will not catch terms in the extension

--- a/tests/test_loggable.py
+++ b/tests/test_loggable.py
@@ -4,9 +4,6 @@ from octue.mixins import Loggable
 from .base import BaseTestCase
 
 
-module_logger = logging.getLogger(__name__)
-
-
 class InheritLoggable(Loggable):
     """ Class used purely for testing to check the logger is instantiated
     """

--- a/tests/test_serialisable.py
+++ b/tests/test_serialisable.py
@@ -7,6 +7,20 @@ from octue.mixins import Serialisable
 from .base import BaseTestCase
 
 
+class Inherit(Serialisable):
+
+    def __init__(self):
+        super().__init__()
+        self.id = "id"
+        self.logger = logging.getLogger("test_returns_primitive_without_logger_or_protected_fields")
+        self.field_to_serialise = 0
+        self._field_not_to_serialise = 1
+
+
+class InheritWithFieldsToSerialise(Inherit):
+    _serialise_fields = ("field_to_serialise",)
+
+
 class SerialisableTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
         """ Ensures the class instantiates without arguments
@@ -25,15 +39,6 @@ class SerialisableTestCase(BaseTestCase):
     def test_returns_primitive_without_logger_or_protected_fields(self):
         """ Ensures class instantiates with a UUID()
         """
-
-        class Inherit(Serialisable):
-            def __init__(self):
-                super().__init__()
-                self.id = "id"
-                self.logger = logging.getLogger("test_returns_primitive_without_logger_or_protected_fields")
-                self.field_to_serialise = 0
-                self._field_not_to_serialise = 1
-
         resource = Inherit()
         serialised = resource.serialise()
         self.assertTrue("id" in serialised.keys())
@@ -44,18 +49,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_serialise_only_attrs(self):
         """ Restricts the id field, which would normally be serialised
         """
-
-        class Inherit(Serialisable):
-            _serialise_fields = ("field_to_serialise",)
-
-            def __init__(self):
-                super().__init__()
-                self.id = "id"
-                self.logger = logging.getLogger("test_returns_primitive_without_logger_or_protected_fields")
-                self.field_to_serialise = 0
-                self._field_not_to_serialise = 1
-
-        resource = Inherit()
+        resource = InheritWithFieldsToSerialise()
         serialised = resource.serialise()
         self.assertFalse("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
@@ -65,32 +59,13 @@ class SerialisableTestCase(BaseTestCase):
     def test_serialise_to_string(self):
         """ Restricts the id field, which would normally be serialised
         """
-
-        class Inherit(Serialisable):
-            _serialise_fields = ("field_to_serialise",)
-
-            def __init__(self):
-                super().__init__()
-                self.id = "id"
-                self.logger = logging.getLogger("test_returns_primitive_without_logger_or_protected_fields")
-                self.field_to_serialise = 0
-                self._field_not_to_serialise = 1
-
-        resource = Inherit()
+        resource = InheritWithFieldsToSerialise()
         serialised = resource.serialise(to_string=True)
         self.assertIsInstance(serialised, str)
 
     def test_serialise_to_file(self):
         """ Restricts the id field, which would normally be serialised
         """
-
-        class Inherit(Serialisable):
-            def __init__(self):
-                super().__init__()
-                self.id = "id"
-                self.logger = logging.getLogger("test_returns_primitive_without_logger_or_protected_fields")
-                self.field_to_serialise = 0
-                self._field_not_to_serialise = 1
 
         with TemporaryDirectory() as dir_name:
             file_name = os.path.join(dir_name, "test_serialise_to_file.json")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -42,7 +42,7 @@ class TemplatesTestCase(BaseTestCase):
     def test_copy_template_raises_if_unknown(self):
         """ Ensures that a known template will copy to a given directory
         """
-        with TemporaryDirectory() as dir:
+        with TemporaryDirectory() as tmp_dir:
             with self.assertRaises(exceptions.InvalidInputException) as error:
-                copy_template("template-which-isnt-there", dir)
+                copy_template("template-which-isnt-there", tmp_dir)
             self.assertIn("Unknown template name 'template-which-isnt-there', try one of", error.exception.args[0])


### PR DESCRIPTION
## Summary
### Main code
* Use dictionary comprehensions for simpler `dict` construction
* Use generator of `tuple`s rather than `dict` if the pairs are only iterated through (saves memory without losing any function)
* Use mapping of `lambda`s instead of chain of `if`s for field lookup selection
* Simplify `PACKAGED_TEMPLATES` tuple construction using a generator comprehension

### Tests
* Reduce repeated literals and code
* Use `os.sep` for path part separators
* Narrow assertions in `DataSet` tests
* Remove unused module logger
* Factor out repeated class definitions
* Avoid overriding built-in `dir` function