### PR TITLE
Fix/issue 27

### DIFF
--- a/octue/runner.py
+++ b/octue/runner.py
@@ -199,7 +199,6 @@ class AppFrom:
 
     def __enter__(self):
         # Warn on an app present on the system path
-        print(sys.modules.keys())
         if "app" in sys.modules.keys():
             module_logger.warning(
                 "Module 'app' already on system path. Using 'AppFrom' context will yield unexpected results. Avoid using 'app' as a python module, except for your main entrypoint"

--- a/tests/app.py
+++ b/tests/app.py
@@ -2,4 +2,4 @@ CUSTOM_APP_RUN_MESSAGE = "This is a custom app run function"
 
 
 def run(analysis):
-    print(CUSTOM_APP_RUN_MESSAGE)
+    print(CUSTOM_APP_RUN_MESSAGE)  # noqa:T001

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -15,10 +15,11 @@ class TemplateAppsTestCase(BaseTestCase):
         super().setUp()
         self.start_path = os.getcwd()
 
-        # Initialise just so that pylint picks up these variables are present (reinitialised in set_template())
+        # Initialise so these variables are assigned on the instance
         self.template_data_path = None
         self.template_twine = None
         self.template_path = None
+        self.app_test_path = None
         self.teardown_templates = []
 
         def set_template(template):


### PR DESCRIPTION
Alters the AppFrom manager to clean up the "app" module import, avoid potential issues with cleaning up `sys.path` incorrectly and warn if it encounters an already-imported app context.