### PR TITLE
Fix: Use socket handler for remote logging

### DIFF
--- a/octue/logging_handlers.py
+++ b/octue/logging_handlers.py
@@ -21,14 +21,12 @@ def get_remote_handler(logger_uri, log_level):
     """Get a log handler for streaming logs to a remote URI accessed via HTTP or HTTPS."""
     parsed_uri = urlparse(logger_uri)
 
-    if parsed_uri.scheme == "https":
-        secure = True
-    elif parsed_uri.scheme == "http":
-        secure = False
-    else:
-        raise ValueError(f"Only HTTP or HTTPS currently supported for remote logger URI. Received {logger_uri!r}.")
+    if parsed_uri.scheme not in {"ws", "wss"}:
+        raise ValueError(
+            f"Only WS and WSS protocols currently supported for remote logger URI. Received {logger_uri!r}."
+        )
 
-    handler = logging.handlers.HTTPHandler(host=parsed_uri.netloc, url=parsed_uri.path, method="POST", secure=secure)
+    handler = logging.handlers.SocketHandler(host=parsed_uri.hostname, port=parsed_uri.port)
     handler.setLevel(log_level)
     handler.setFormatter(logging.Formatter(LOG_FORMAT))
     return handler

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -81,11 +81,13 @@ class Runner:
         analysis_logger.addHandler(handler)
         analysis_logger.setLevel(self._log_level)
 
-        if type(analysis_logger.handlers[0]).__name__ == "HTTPHandler":
+        if type(analysis_logger.handlers[0]).__name__ == "SocketHandler":
             local_logger = logging.getLogger(__name__)
             local_logger.addHandler(get_default_handler(log_level=self._log_level))
             local_logger.setLevel(self._log_level)
-            local_logger.info(f"Logs streaming to {analysis_logger.handlers[0].host + analysis_logger.handlers[0].url}")
+            local_logger.info(
+                f"Logs streaming to {analysis_logger.handlers[0].host + ':' + str(analysis_logger.handlers[0].port)}"
+            )
 
         return analysis_logger
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,7 @@ class RunnerTestCase(BaseTestCase):
             CliRunner().invoke(
                 octue_cli,
                 [
-                    "--logger-uri=https://0.0.0.1:3000/log",
+                    "--logger-uri=wss://0.0.0.1:3000",
                     "run",
                     f"--app-dir={TESTS_DIR}",
                     f"--twine={self.TWINE_FILE_PATH}",

--- a/tests/test_logging_handlers.py
+++ b/tests/test_logging_handlers.py
@@ -6,31 +6,29 @@ from octue.logging_handlers import get_remote_handler
 
 
 class TestGetRemoteHandler(BaseTestCase):
-    def test_get_remote_handler_parses_urls_properly(self):
+    def test_get_remote_handler_parses_ws_properly(self):
         """Assert that the remote log handler parses URIs properly."""
-        handler = get_remote_handler(logger_uri="http://0.0.0.1:3000/log", log_level="DEBUG")
-        assert handler.host == "0.0.0.1:3000"
-        assert handler.url == "/log"
-        assert handler.secure is False
+        handler = get_remote_handler(logger_uri="ws://0.0.0.1:3000", log_level="DEBUG")
+        assert handler.host == "0.0.0.1"
+        assert handler.port == 3000
 
-    def test_https_is_supported(self):
+    def test_wss_is_supported(self):
         """Test that HTTPS is supported by the remote log handler."""
-        handler = get_remote_handler(logger_uri="https://0.0.0.1:3000/log", log_level="DEBUG")
-        assert handler.host == "0.0.0.1:3000"
-        assert handler.url == "/log"
-        assert handler.secure is True
+        handler = get_remote_handler(logger_uri="wss://0.0.0.1:3000/log", log_level="DEBUG")
+        assert handler.host == "0.0.0.1"
+        assert handler.port == 3000
 
-    def test_non_http_or_https_protocol_raises_error(self):
+    def test_non_ws_or_wss_protocol_raises_error(self):
         """Ensure an error is raised if a protocol other than HTTP or HTTPS is used for the logger URI."""
         with self.assertRaises(ValueError):
-            get_remote_handler(logger_uri="ftp://0.0.0.1:3000/log", log_level="DEBUG")
+            get_remote_handler(logger_uri="https://0.0.0.1:3000/log", log_level="DEBUG")
 
     def test_remote_logger_emits_messages(self):
         """Test that the remote log handler emits messages."""
         logger = logging.getLogger("test-logger")
-        logger.addHandler(get_remote_handler(logger_uri="https://0.0.0.0:80/log", log_level="DEBUG"))
+        logger.addHandler(get_remote_handler(logger_uri="wss://0.0.0.0:80", log_level="DEBUG"))
         logger.setLevel("DEBUG")
 
-        with mock.patch("logging.handlers.HTTPHandler.emit") as mock_emit:
+        with mock.patch("logging.handlers.SocketHandler.emit") as mock_emit:
             logger.debug("Hello")
             mock_emit.assert_called()


### PR DESCRIPTION
## Summary
Use `SocketHandler` instead of `HTTPHandler` for remote logging.

## Links
* #35 