### PR TITLE
Feature: Add hashes of input and configuration data to Analysis instances

### DIFF
--- a/docs/source/analysis_objects.rst
+++ b/docs/source/analysis_objects.rst
@@ -23,7 +23,7 @@ Additionally, all input and configuration attributes are hashed using a
 your app can always be verified. These hashes exist on the following attributes:
 
 -   ``input_values_hash``
--   ``configuration_values_hash``
+-   ``input_manifest_hash``
 -   ``configuration_values_hash``
 -   ``configuration_manifest_hash``
 

--- a/docs/source/analysis_objects.rst
+++ b/docs/source/analysis_objects.rst
@@ -1,0 +1,44 @@
+.. _analysis_objects:
+
+================
+Analysis objects
+================
+
+An ``Analysis`` object is the sole argument to the ``app`` function in your ``app.py`` module. Its attributes include
+every strand that can be possibly added to a ``Twine``, although only the strands specified in your ``twine.py`` file
+will not be ``None``. The attributes are:
+
+-   ``input_values``
+-   ``input_manifest``
+-   ``configuration_values``
+-   ``configuration_manifest``
+-   ``output_values``
+-   ``output_manifest``
+-   ``credentials``
+-   ``children``
+-   ``monitors``
+
+Additionally, all input and configuration attributes are hashed using a
+`BLAKE3 hash <https://github.com/BLAKE3-team/BLAKE3>`_ so the inputs and configuration that produced a given output in
+your app can always be verified. These hashes exist on the following attributes:
+
+-   ``input_values_hash``
+-   ``configuration_values_hash``
+-   ``configuration_values_hash``
+-   ``configuration_manifest_hash``
+
+If an input or configuration attribute is ``None``, so will its hash attribute be. For ``Manifest``s, some metadata
+about the ``Datafile``s and ``Dataset``s within them, and about the ``Manifest`` itself, is included when calculating
+the hash:
+
+- For a ``Datafile``, the content of its on-disk file is hashed, along with the following metadata:
+
+    - ``name``
+    - ``cluster``
+    - ``sequence``
+    - ``posix_timestamp``
+    - ``tags``
+
+- For a ``Dataset``, the hashes of its ``Datafile``s are included, along with its ``tags``.
+
+- For a ``Manifest``, the hashes of its ``Dataset``s are included, along with its ``keys``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Not all of Octue's API functionality is implemented in the SDK yet, we're active
    :hidden:
 
    installation
+   analysis_objects
    license
    version_history
    bibliography

--- a/octue/mixins/__init__.py
+++ b/octue/mixins/__init__.py
@@ -1,4 +1,5 @@
 from .base import MixinBase
+from .hashable import Hashable
 from .identifiable import Identifiable
 from .loggable import Loggable
 from .pathable import Pathable
@@ -6,4 +7,4 @@ from .serialisable import Serialisable
 from .taggable import Taggable
 
 
-__all__ = "Identifiable", "Loggable", "MixinBase", "Pathable", "Serialisable", "Taggable"
+__all__ = "Hashable", "Identifiable", "Loggable", "MixinBase", "Pathable", "Serialisable", "Taggable"

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -22,10 +22,10 @@ class Hashable:
         """ Use the Hashable class to hash an arbitrary object that isn't an attribute of a class instance. """
 
         class Holder(cls):
-            _ATTRIBUTES_TO_HASH = ("object",)
+            _ATTRIBUTES_TO_HASH = ("object_",)
 
         holder = Holder()
-        holder.object = object_
+        holder.object_ = object_
         return holder.hash_value
 
     @property

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -36,7 +36,7 @@ class Hashable:
     def _calculate_blake3_hash(self, blake3_hash=None):
         blake3_hash = blake3_hash or blake3()
 
-        for attribute_name in self.ATTRIBUTES_TO_HASH:
+        for attribute_name in sorted(self.ATTRIBUTES_TO_HASH):
 
             attribute = getattr(self, attribute_name)
 

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -17,7 +17,7 @@ class Hashable:
     ATTRIBUTES_TO_HASH = None
 
     @property
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=1)
     def blake3_hash(self):
         if not self.ATTRIBUTES_TO_HASH:
             return None

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -38,7 +38,8 @@ class Hashable:
         return self._calculate_hash()
 
     def _calculate_hash(self, hash_=None):
-        """ Calculate the BLAKE3 hash of the sorted attributes in self.ATTRIBUTES_TO_HASH. """
+        """ Calculate the BLAKE3 hash of the sorted attributes in self._ATTRIBUTES_TO_HASH. If hash_ is not None and is
+        a BLAKE3 hasher object, its in-progress hash will be updated, rather than starting from scratch. """
         hash_ = hash_ or blake3()
 
         for attribute_name in sorted(self._ATTRIBUTES_TO_HASH):
@@ -59,7 +60,7 @@ class Hashable:
 
     @staticmethod
     def _prepare_iterable_for_hashing(attribute_name, attribute):
-        """ Prepare an iterable attribute for hashing, using the items` own BLAKE3 hashes if available. """
+        """ Prepare an iterable attribute for hashing, using the items' own BLAKE3 hashes if available. """
         items = tuple(attribute)
 
         if any(hasattr(item, "hash_value") for item in items):

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -3,6 +3,15 @@ import functools
 from blake3 import blake3
 
 
+_HASH_FUNCTIONS = {
+    str: lambda attribute: attribute,
+    int: str,
+    float: str,
+    type(None): lambda attribute: "None",
+    dict: lambda attribute: str(sorted(attribute.items())),
+}
+
+
 class Hashable:
 
     ATTRIBUTES_TO_HASH = None
@@ -19,40 +28,35 @@ class Hashable:
 
             attribute = getattr(self, attribute_name)
 
-            if isinstance(attribute, str):
-                items_to_hash = attribute
+            try:
+                items_to_hash = _HASH_FUNCTIONS[type(attribute)](attribute)
 
-            elif isinstance(attribute, int) or isinstance(attribute, float):
-                items_to_hash = str(attribute)
-
-            elif attribute is None:
-                items_to_hash = "None"
-
-            elif isinstance(attribute, dict):
-                items_to_hash = str(sorted(attribute.items()))
-
-            elif isinstance(attribute, collections.abc.Iterable):
-
-                items = tuple(attribute)
-
-                if any(hasattr(item, "blake3_hash") for item in items):
-                    if all(hasattr(item, "blake3_hash") for item in items):
-                        items_to_hash = str(sorted(subitem.blake3_hash for subitem in items))
-                    else:
-                        raise ValueError(f"Mixed types in attribute {attribute_name!r}: {attribute!r}")
-
+            except KeyError:
+                if isinstance(attribute, collections.abc.Iterable):
+                    items_to_hash = self._hash_iterable(attribute_name, attribute)
                 else:
-                    try:
-                        items_to_hash = str(sorted(items))
-                    except TypeError:
-                        raise TypeError(
-                            f"Attribute needs to be sorted for consistent hash output, but cannot be: "
-                            f"{attribute_name!r}: {attribute!r}"
-                        )
-
-            else:
-                raise TypeError(f"Attribute {attribute_name!r}: {attribute!r} cannot be hashed.")
+                    raise TypeError(f"Attribute <{attribute_name!r}: {attribute!r}> cannot be hashed.")
 
             blake3_hash.update(items_to_hash.encode())
 
         return blake3_hash.hexdigest()
+
+    @staticmethod
+    def _hash_iterable(attribute_name, attribute):
+        items = tuple(attribute)
+
+        if any(hasattr(item, "blake3_hash") for item in items):
+
+            if not all(hasattr(item, "blake3_hash") for item in items):
+                raise ValueError(f"Mixed types in attribute <{attribute_name!r}: {attribute!r}>")
+
+            return str(sorted(subitem.blake3_hash for subitem in items))
+
+        try:
+            return str(sorted(items))
+
+        except TypeError:
+            raise TypeError(
+                f"Attribute needs to be sorted for consistent hash output, but cannot be: "
+                f"<{attribute_name!r}: {attribute!r}>"
+            )

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -16,6 +16,15 @@ class Hashable:
 
     ATTRIBUTES_TO_HASH = None
 
+    @classmethod
+    def hash_non_class_object(cls, object_):
+        class Holder(cls):
+            ATTRIBUTES_TO_HASH = ("object",)
+
+        holder = Holder()
+        holder.object = object_
+        return holder.blake3_hash
+
     @property
     @functools.lru_cache(maxsize=1)
     def blake3_hash(self):

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -1,0 +1,48 @@
+import collections
+import functools
+from blake3 import blake3
+
+
+class Hashable:
+
+    ATTRIBUTES_TO_HASH = None
+
+    @property
+    @functools.lru_cache(maxsize=None)
+    def blake3_hash(self):
+        return self._calculate_blake3_hash()
+
+    def _calculate_blake3_hash(self):
+        blake3_hash = blake3()
+
+        for attribute_name in self.ATTRIBUTES_TO_HASH:
+
+            attribute = getattr(self, attribute_name)
+
+            if isinstance(attribute, dict):
+                items_to_hash = str(sorted(attribute.items()))
+
+            elif isinstance(attribute, collections.Iterable):
+
+                items = tuple(attribute)
+
+                if any(hasattr(item, "blake3_hash") for item in items):
+                    if all(hasattr(item, "blake3_hash") for item in items):
+                        items_to_hash = str(sorted(subitem.blake3_hash for subitem in items))
+                    else:
+                        raise ValueError(f"Mixed types in attribute: {attribute!r}")
+
+                else:
+                    try:
+                        items_to_hash = str(sorted(items))
+                    except TypeError:
+                        raise TypeError(
+                            f"Attribute needs to be sorted for consistent hash output, but cannot be: {attribute!r}"
+                        )
+
+            else:
+                raise TypeError(f"Attribute {attribute!r} cannot be hashed.")
+
+            blake3_hash.update(items_to_hash.encode())
+
+        return blake3_hash.hexdigest()

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -19,6 +19,9 @@ class Hashable:
     @property
     @functools.lru_cache(maxsize=None)
     def blake3_hash(self):
+        if not self.ATTRIBUTES_TO_HASH:
+            return None
+
         return self._calculate_blake3_hash()
 
     def _calculate_blake3_hash(self, blake3_hash=None):

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -14,15 +14,15 @@ _HASH_PREPARATION_FUNCTIONS = {
 
 class Hashable:
 
-    ATTRIBUTES_TO_HASH = None
-    HASH_TYPE = "BLAKE3"
+    _ATTRIBUTES_TO_HASH = None
+    _HASH_TYPE = "BLAKE3"
 
     @classmethod
     def hash_non_class_object(cls, object_):
         """ Use the Hashable class to hash an arbitrary object that isn't an attribute of a class instance. """
 
         class Holder(cls):
-            ATTRIBUTES_TO_HASH = ("object",)
+            _ATTRIBUTES_TO_HASH = ("object",)
 
         holder = Holder()
         holder.object = object_
@@ -32,7 +32,7 @@ class Hashable:
     @functools.lru_cache(maxsize=1)
     def hash_value(self):
         """ Get the hash of the instance. """
-        if not self.ATTRIBUTES_TO_HASH:
+        if not self._ATTRIBUTES_TO_HASH:
             return None
 
         return self._calculate_hash()
@@ -41,7 +41,7 @@ class Hashable:
         """ Calculate the BLAKE3 hash of the sorted attributes in self.ATTRIBUTES_TO_HASH. """
         hash_ = hash_ or blake3()
 
-        for attribute_name in sorted(self.ATTRIBUTES_TO_HASH):
+        for attribute_name in sorted(self._ATTRIBUTES_TO_HASH):
             attribute = getattr(self, attribute_name)
 
             try:

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -3,7 +3,7 @@ import functools
 from blake3 import blake3
 
 
-_HASH_FUNCTIONS = {
+_HASH_PREPARATION_FUNCTIONS = {
     str: lambda attribute: attribute,
     int: str,
     float: str,
@@ -18,6 +18,8 @@ class Hashable:
 
     @classmethod
     def hash_non_class_object(cls, object_):
+        """ Use the Hashable class to hash an arbitrary object that isn't an attribute of a class instance. """
+
         class Holder(cls):
             ATTRIBUTES_TO_HASH = ("object",)
 
@@ -28,24 +30,25 @@ class Hashable:
     @property
     @functools.lru_cache(maxsize=1)
     def blake3_hash(self):
+        """ Get the BLAKE3 hash of the instance. """
         if not self.ATTRIBUTES_TO_HASH:
             return None
 
         return self._calculate_blake3_hash()
 
     def _calculate_blake3_hash(self, blake3_hash=None):
+        """ Calculate the BLAKE3 hash of the sorted attributes in self.ATTRIBUTES_TO_HASH. """
         blake3_hash = blake3_hash or blake3()
 
         for attribute_name in sorted(self.ATTRIBUTES_TO_HASH):
-
             attribute = getattr(self, attribute_name)
 
             try:
-                items_to_hash = _HASH_FUNCTIONS[type(attribute)](attribute)
+                items_to_hash = _HASH_PREPARATION_FUNCTIONS[type(attribute)](attribute)
 
             except KeyError:
                 if isinstance(attribute, collections.abc.Iterable):
-                    items_to_hash = self._hash_iterable(attribute_name, attribute)
+                    items_to_hash = self._prepare_iterable_for_hashing(attribute_name, attribute)
                 else:
                     raise TypeError(f"Attribute <{attribute_name!r}: {attribute!r}> cannot be hashed.")
 
@@ -54,7 +57,8 @@ class Hashable:
         return blake3_hash.hexdigest()
 
     @staticmethod
-    def _hash_iterable(attribute_name, attribute):
+    def _prepare_iterable_for_hashing(attribute_name, attribute):
+        """ Prepare an iterable attribute for hashing, using the items` own BLAKE3 hashes if available. """
         items = tuple(attribute)
 
         if any(hasattr(item, "blake3_hash") for item in items):

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -66,13 +66,13 @@ class Hashable:
             if not all(hasattr(item, "blake3_hash") for item in items):
                 raise ValueError(f"Mixed types in attribute <{attribute_name!r}: {attribute!r}>")
 
-            return str(sorted(subitem.blake3_hash for subitem in items))
+            return str(sorted(item.blake3_hash for item in items))
 
         try:
             return str(sorted(items))
 
         except TypeError:
             raise TypeError(
-                f"Attribute needs to be sorted for consistent hash output, but cannot be: "
-                f"<{attribute_name!r}: {attribute!r}>"
+                f"Attribute <{attribute_name!r}: {attribute!r}> needs to be sorted for consistent hash output, but this"
+                f"failed."
             )

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -10,14 +10,14 @@ class Serialisable:
 
     """
 
+    _SERIALISE_FIELDS = None
+    _EXCLUDE_SERIALISE_FIELDS = ("logger",)
+
     def __init__(self, *args, **kwargs):
         """ Constructor for serialisable mixin
         """
         # Ensure it passes construction arguments up the chain
         super().__init__(*args, **kwargs)
-
-    _serialise_fields = None
-    _exclude_serialise_fields = ("logger",)
 
     def to_file(self, file_name, **kwargs):
         """ Write to a JSON file
@@ -55,10 +55,10 @@ class Serialisable:
         self.logger.debug("Serialising %s %s", self.__class__.__name__, self.id)
 
         # Get all non-private and non-protected attributes except those excluded specifically
-        attrs_to_serialise = self._serialise_fields or (
+        attrs_to_serialise = self._SERIALISE_FIELDS or (
             k for k in self.__dir__() if ((k[:1] != "_") and (type(getattr(self, k, "")).__name__ != "method"))
         )
-        attrs_to_serialise = (attr for attr in attrs_to_serialise if attr not in self._exclude_serialise_fields)
+        attrs_to_serialise = (attr for attr in attrs_to_serialise if attr not in self._EXCLUDE_SERIALISE_FIELDS)
         self_as_primitive = {attr: getattr(self, attr, None) for attr in attrs_to_serialise}
 
         # TODO this conversion backward-and-forward is very inefficient but allows us to use the same encoder for

--- a/octue/mixins/taggable.py
+++ b/octue/mixins/taggable.py
@@ -40,6 +40,9 @@ class TagGroup:
 
         self._tags = self._clean(tags)
 
+    def __iter__(self):
+        yield from self._tags
+
     @staticmethod
     def _clean(tags):
         """ Private method to clean up an iterable of tags into a list of cleaned tags

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -1,6 +1,6 @@
-import hashlib
 import json
 import logging
+from blake3 import blake3
 
 from octue.definitions import OUTPUT_STRANDS
 from octue.mixins import Identifiable, Loggable, Serialisable, Taggable
@@ -15,14 +15,14 @@ module_logger = logging.getLogger(__name__)
 
 def hash_json(json_object):
     """ Hash a JSON-compatible object. """
-    return hashlib.blake2b(json.dumps(json_object).encode()).hexdigest()
+    return blake3(json.dumps(json_object).encode()).hexdigest()
 
 
 HASH_FUNCTIONS = {
     "configuration_values": hash_json,
-    "configuration_manifest": lambda manifest: manifest.blake2b_hash,
+    "configuration_manifest": lambda manifest: manifest.blake3_hash,
     "input_values": hash_json,
-    "input_manifest": lambda manifest: manifest.blake2b_hash,
+    "input_manifest": lambda manifest: manifest.blake3_hash,
 }
 
 # Map strand names to class which we expect Twined to instantiate for us

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -14,7 +14,7 @@ module_logger = logging.getLogger(__name__)
 
 
 def hash_json(json_object):
-    return hashlib.sha256(json.dumps(json_object).encode()).hexdigest()
+    return hashlib.blake2b(json.dumps(json_object).encode()).hexdigest()
 
 
 HASH_FUNCTIONS = {

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -19,9 +19,9 @@ def hash_json(json_object):
 
 HASH_FUNCTIONS = {
     "configuration_values": hash_json,
-    "configuration_manifest": lambda manifest: manifest.sha_256,
+    "configuration_manifest": lambda manifest: manifest.blake2b_hash,
     "input_values": lambda input_values: hash_json,
-    "input_manifest": lambda manifest: manifest.sha_256,
+    "input_manifest": lambda manifest: manifest.blake2b_hash,
 }
 
 # Map strand names to class which we expect Twined to instantiate for us

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -14,9 +14,9 @@ module_logger = logging.getLogger(__name__)
 
 HASH_FUNCTIONS = {
     "configuration_values": Hashable.hash_non_class_object,
-    "configuration_manifest": lambda manifest: manifest.blake3_hash,
+    "configuration_manifest": lambda manifest: manifest.hash_value,
     "input_values": Hashable.hash_non_class_object,
-    "input_manifest": lambda manifest: manifest.blake3_hash,
+    "input_manifest": lambda manifest: manifest.hash_value,
 }
 
 # Map strand names to class which we expect Twined to instantiate for us

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -1,9 +1,8 @@
 import json
 import logging
-from blake3 import blake3
 
 from octue.definitions import OUTPUT_STRANDS
-from octue.mixins import Identifiable, Loggable, Serialisable, Taggable
+from octue.mixins import Hashable, Identifiable, Loggable, Serialisable, Taggable
 from octue.resources.manifest import Manifest
 from octue.utils.encoders import OctueJSONEncoder
 from octue.utils.folders import get_file_name_from_strand
@@ -13,15 +12,10 @@ from twined import ALL_STRANDS, Twine
 module_logger = logging.getLogger(__name__)
 
 
-def hash_json(json_object):
-    """ Hash a JSON-compatible object. """
-    return blake3(json.dumps(json_object).encode()).hexdigest()
-
-
 HASH_FUNCTIONS = {
-    "configuration_values": hash_json,
+    "configuration_values": Hashable.hash_non_class_object,
     "configuration_manifest": lambda manifest: manifest.blake3_hash,
-    "input_values": hash_json,
+    "input_values": Hashable.hash_non_class_object,
     "input_manifest": lambda manifest: manifest.blake3_hash,
 }
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -14,13 +14,14 @@ module_logger = logging.getLogger(__name__)
 
 
 def hash_json(json_object):
+    """ Hash a JSON-compatible object. """
     return hashlib.blake2b(json.dumps(json_object).encode()).hexdigest()
 
 
 HASH_FUNCTIONS = {
     "configuration_values": hash_json,
     "configuration_manifest": lambda manifest: manifest.blake2b_hash,
-    "input_values": lambda input_values: hash_json,
+    "input_values": hash_json,
     "input_manifest": lambda manifest: manifest.blake2b_hash,
 }
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -12,7 +12,7 @@ from twined import ALL_STRANDS, Twine
 module_logger = logging.getLogger(__name__)
 
 
-HASH_FUNCTIONS = {
+_HASH_FUNCTIONS = {
     "configuration_values": Hashable.hash_non_class_object,
     "configuration_manifest": lambda manifest: manifest.hash_value,
     "input_values": Hashable.hash_non_class_object,
@@ -71,11 +71,11 @@ class Analysis(Identifiable, Loggable, Serialisable, Taggable):
             setattr(self, f"{strand_name}", strand_data)
 
         for strand_name, strand_data in strand_kwargs:
-            if strand_name in HASH_FUNCTIONS:
+            if strand_name in _HASH_FUNCTIONS:
                 strand_hash_name = f"{strand_name}_hash"
 
                 if strand_data is not None:
-                    setattr(self, strand_hash_name, HASH_FUNCTIONS[strand_name](strand_data))
+                    setattr(self, strand_hash_name, _HASH_FUNCTIONS[strand_name](strand_data))
                 else:
                     setattr(self, strand_hash_name, None)
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -113,15 +113,15 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     def size_bytes(self):
         return os.path.getsize(self.absolute_path)
 
-    def _calculate_blake3_hash(self):
-        """ Calculate the BLAKE3 hash string of the file. """
-        blake3_hash = blake3()
+    def _calculate_hash(self):
+        """ Calculate the hash of the file. """
+        hash = blake3()
         with open(self.absolute_path, "rb") as f:
-            # Read and update hash string value in blocks of 4K
+            # Read and update hash value in blocks of 4K
             for byte_block in iter(lambda: f.read(4096), b""):
-                blake3_hash.update(byte_block)
+                hash.update(byte_block)
 
-        return super()._calculate_blake3_hash(blake3_hash)
+        return super()._calculate_hash(hash)
 
     def check(self, size_bytes=None, sha=None, last_modified=None, extension=None):
         """ Check file presence and integrity

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -81,7 +81,6 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
         super().__init__(id=id, logger=logger, tags=tags, path=path, path_from=path_from, base_from=base_from)
 
         self.cluster = cluster
-
         self.sequence = sequence
         self.posix_timestamp = posix_timestamp or time.time()
 
@@ -123,6 +122,17 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
             for byte_block in iter(lambda: f.read(4096), b""):
                 blake2b_hash.update(byte_block)
 
+        blake2b_hash.update(
+            "".join(
+                (
+                    self.name,
+                    str(self.cluster),
+                    str(self.sequence),
+                    str(self.posix_timestamp),
+                    str(sorted(self.tags._tags)),
+                )
+            ).encode()
+        )
         return blake2b_hash.hexdigest()
 
     def check(self, size_bytes=None, sha=None, last_modified=None, extension=None):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -59,9 +59,8 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     :type posix_timestamp: number
     """
 
-    ATTRIBUTES_TO_HASH = "name", "cluster", "sequence", "posix_timestamp", "tags"
-
-    _exclude_serialise_fields = ("logger", "open")
+    _ATTRIBUTES_TO_HASH = "name", "cluster", "sequence", "posix_timestamp", "tags"
+    _EXCLUDE_SERIALISE_FIELDS = ("logger", "open")
 
     def __init__(
         self,

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -1,3 +1,4 @@
+import functools
 import hashlib
 import logging
 import os
@@ -112,7 +113,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
     def size_bytes(self):
         return os.path.getsize(self.absolute_path)
 
-    @property
+    @functools.cached_property
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the file. """
         blake2b_hash = hashlib.blake2b()

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -101,8 +101,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
         return os.path.splitext(path)[-1].strip(".")
 
     def _get_sha_256(self):
-        """ Calculate the SHA256 hash string of the file
-        """
+        """ Calculate the SHA256 hash string of the file. """
         sha256_hash = hashlib.sha256()
         with open(self.absolute_path, "rb") as f:
             # Read and update hash string value in blocks of 4K

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -1,8 +1,8 @@
 import functools
-import hashlib
 import logging
 import os
 import time
+from blake3 import blake3
 
 from octue.exceptions import FileNotFoundException, InvalidInputException
 from octue.mixins import Identifiable, Loggable, Pathable, Serialisable, Taggable
@@ -114,15 +114,15 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
 
     @property
     @functools.lru_cache(maxsize=None)
-    def blake2b_hash(self):
-        """ Calculate the BLAKE2b hash string of the file. """
-        blake2b_hash = hashlib.blake2b()
+    def blake3_hash(self):
+        """ Calculate the BLAKE3 hash string of the file. """
+        blake3_hash = blake3()
         with open(self.absolute_path, "rb") as f:
             # Read and update hash string value in blocks of 4K
             for byte_block in iter(lambda: f.read(4096), b""):
-                blake2b_hash.update(byte_block)
+                blake3_hash.update(byte_block)
 
-        blake2b_hash.update(
+        blake3_hash.update(
             "".join(
                 (
                     self.name,
@@ -133,7 +133,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
                 )
             ).encode()
         )
-        return blake2b_hash.hexdigest()
+        return blake3_hash.hexdigest()
 
     def check(self, size_bytes=None, sha=None, last_modified=None, extension=None):
         """ Check file presence and integrity

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -113,7 +113,8 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
     def size_bytes(self):
         return os.path.getsize(self.absolute_path)
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the file. """
         blake2b_hash = hashlib.blake2b()

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -100,16 +100,6 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
         path = path or self.path
         return os.path.splitext(path)[-1].strip(".")
 
-    def _get_sha_256(self):
-        """ Calculate the SHA256 hash string of the file. """
-        sha256_hash = hashlib.sha256()
-        with open(self.absolute_path, "rb") as f:
-            # Read and update hash string value in blocks of 4K
-            for byte_block in iter(lambda: f.read(4096), b""):
-                sha256_hash.update(byte_block)
-
-        return sha256_hash.hexdigest()
-
     @property
     def name(self):
         return str(os.path.split(self.path)[-1])
@@ -123,8 +113,15 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable):
         return os.path.getsize(self.absolute_path)
 
     @property
-    def sha_256(self):
-        return self._get_sha_256()
+    def blake2b_hash(self):
+        """ Calculate the BLAKE2b hash string of the file. """
+        blake2b_hash = hashlib.blake2b()
+        with open(self.absolute_path, "rb") as f:
+            # Read and update hash string value in blocks of 4K
+            for byte_block in iter(lambda: f.read(4096), b""):
+                blake2b_hash.update(byte_block)
+
+        return blake2b_hash.hexdigest()
 
     def check(self, size_bytes=None, sha=None, last_modified=None, extension=None):
         """ Check file presence and integrity

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -171,4 +171,6 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
     @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the dataset. """
-        return hashlib.blake2b("".join(sorted(file.blake2b_hash for file in self.files)).encode()).hexdigest()
+        blake2b_hash = hashlib.blake2b("".join(sorted(file.blake2b_hash for file in self.files)).encode())
+        blake2b_hash.update(str(sorted(self.tags._tags)).encode())
+        return blake2b_hash.hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -167,7 +167,8 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
 
         return results[0]
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the dataset. """
         return hashlib.blake2b("".join(file.blake2b_hash for file in self.files).encode()).hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -16,7 +16,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
     list of output files (results) and their properties that will be sent back to the octue system.
     """
 
-    ATTRIBUTES_TO_HASH = "files", "name", "tags"
+    _ATTRIBUTES_TO_HASH = "files", "name", "tags"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, tags=None, **kwargs):
         """ Construct a Dataset

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,21 +1,21 @@
-import functools
 import logging
-from blake3 import blake3
 
 from octue.exceptions import BrokenSequenceException, InvalidInputException, UnexpectedNumberOfResultsException
-from octue.mixins import Identifiable, Loggable, Pathable, Serialisable, Taggable
+from octue.mixins import Hashable, Identifiable, Loggable, Pathable, Serialisable, Taggable
 from octue.resources.datafile import Datafile
 
 
 module_logger = logging.getLogger(__name__)
 
 
-class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
+class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable):
     """ A representation of a dataset, containing files, tags, etc
 
     This is used to read a list of files (and their associated properties) into octue analysis, or to compile a
     list of output files (results) and their properties that will be sent back to the octue system.
     """
+
+    ATTRIBUTES_TO_HASH = "files", "tags"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, tags=None, **kwargs):
         """ Construct a Dataset
@@ -166,11 +166,3 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
             raise UnexpectedNumberOfResultsException("No files found with this tag")
 
         return results[0]
-
-    @property
-    @functools.lru_cache(maxsize=None)
-    def blake3_hash(self):
-        """ Calculate the BLAKE3 hash string of the dataset. """
-        blake3_hash = blake3("".join(sorted(file.blake3_hash for file in self.files)).encode())
-        blake3_hash.update(str(sorted(self.tags._tags)).encode())
-        return blake3_hash.hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 
 from octue.exceptions import BrokenSequenceException, InvalidInputException, UnexpectedNumberOfResultsException
@@ -164,3 +165,8 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
             raise UnexpectedNumberOfResultsException("No files found with this tag")
 
         return results[0]
+
+    @property
+    def sha_256(self):
+        """ Calculate the SHA256 hash string of the dataset. """
+        return hashlib.sha256("".join(file.sha_256 for file in self.files).encode()).hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -171,4 +171,4 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
     @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the dataset. """
-        return hashlib.blake2b("".join(file.blake2b_hash for file in self.files).encode()).hexdigest()
+        return hashlib.blake2b("".join(sorted(file.blake2b_hash for file in self.files)).encode()).hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from octue.exceptions import BrokenSequenceException, InvalidInputException, UnexpectedNumberOfResultsException
 from octue.mixins import Hashable, Identifiable, Loggable, Pathable, Serialisable, Taggable
@@ -15,7 +16,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
     list of output files (results) and their properties that will be sent back to the octue system.
     """
 
-    ATTRIBUTES_TO_HASH = "files", "tags"
+    ATTRIBUTES_TO_HASH = "files", "name", "tags"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, tags=None, **kwargs):
         """ Construct a Dataset
@@ -35,6 +36,10 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
                 self.files.append(Datafile(**fi, path_from=self, base_from=self))
 
         self.__dict__.update(**kwargs)
+
+    @property
+    def name(self):
+        return str(os.path.split(self.path)[-1])
 
     def append(self, *args, **kwargs):
         """ Add a data/results file to the manifest

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -167,6 +167,6 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
         return results[0]
 
     @property
-    def sha_256(self):
+    def blake2b_hash(self):
         """ Calculate the SHA256 hash string of the dataset. """
-        return hashlib.sha256("".join(file.sha_256 for file in self.files).encode()).hexdigest()
+        return hashlib.blake2b("".join(file.blake2b_hash for file in self.files).encode()).hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,3 +1,4 @@
+import functools
 import hashlib
 import logging
 
@@ -166,7 +167,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
 
         return results[0]
 
-    @property
+    @functools.cached_property
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the dataset. """
         return hashlib.blake2b("".join(file.blake2b_hash for file in self.files).encode()).hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,6 +1,6 @@
 import functools
-import hashlib
 import logging
+from blake3 import blake3
 
 from octue.exceptions import BrokenSequenceException, InvalidInputException, UnexpectedNumberOfResultsException
 from octue.mixins import Identifiable, Loggable, Pathable, Serialisable, Taggable
@@ -169,8 +169,8 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
 
     @property
     @functools.lru_cache(maxsize=None)
-    def blake2b_hash(self):
-        """ Calculate the BLAKE2b hash string of the dataset. """
-        blake2b_hash = hashlib.blake2b("".join(sorted(file.blake2b_hash for file in self.files)).encode())
-        blake2b_hash.update(str(sorted(self.tags._tags)).encode())
-        return blake2b_hash.hexdigest()
+    def blake3_hash(self):
+        """ Calculate the BLAKE3 hash string of the dataset. """
+        blake3_hash = blake3("".join(sorted(file.blake3_hash for file in self.files)).encode())
+        blake3_hash.update(str(sorted(self.tags._tags)).encode())
+        return blake3_hash.hexdigest()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -168,5 +168,5 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable):
 
     @property
     def blake2b_hash(self):
-        """ Calculate the SHA256 hash string of the dataset. """
+        """ Calculate the BLAKE2b hash string of the dataset. """
         return hashlib.blake2b("".join(file.blake2b_hash for file in self.files).encode()).hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 
 from octue.exceptions import InvalidInputException, InvalidManifestException
@@ -79,3 +80,8 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
             self.datasets.append(Dataset(logger=self.logger, path_from=self, path=dataset_spec["key"]))
 
         return self
+
+    @property
+    def sha_256(self):
+        """ Calculate the SHA256 hash string of the manifest. """
+        return hashlib.sha256("".join(dataset.sha_256 for dataset in self.datasets).encode()).hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -12,7 +12,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
     """ A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
     (or leaving), a data service for an analysis at the configuration, input or output stage. """
 
-    ATTRIBUTES_TO_HASH = "datasets", "keys"
+    _ATTRIBUTES_TO_HASH = "datasets", "keys"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, **kwargs):
         """ Construct a Manifest

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -82,6 +82,6 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
         return self
 
     @property
-    def sha_256(self):
+    def blake2b_hash(self):
         """ Calculate the SHA256 hash string of the manifest. """
-        return hashlib.sha256("".join(dataset.sha_256 for dataset in self.datasets).encode()).hexdigest()
+        return hashlib.blake2b("".join(dataset.blake2b_hash for dataset in self.datasets).encode()).hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -80,7 +80,8 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
 
         return self
 
-    @functools.cached_property
+    @property
+    @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the manifest. """
         return hashlib.blake2b("".join(dataset.blake2b_hash for dataset in self.datasets).encode()).hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,3 +1,4 @@
+import functools
 import hashlib
 import logging
 
@@ -79,7 +80,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
 
         return self
 
-    @property
+    @functools.cached_property
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the manifest. """
         return hashlib.blake2b("".join(dataset.blake2b_hash for dataset in self.datasets).encode()).hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,6 +1,6 @@
 import functools
-import hashlib
 import logging
+from blake3 import blake3
 
 from octue.exceptions import InvalidInputException, InvalidManifestException
 from octue.mixins import Identifiable, Loggable, Pathable, Serialisable
@@ -82,8 +82,8 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
 
     @property
     @functools.lru_cache(maxsize=None)
-    def blake2b_hash(self):
-        """ Calculate the BLAKE2b hash string of the manifest. """
-        blake2b_hash = hashlib.blake2b("".join(sorted(dataset.blake2b_hash for dataset in self.datasets)).encode())
-        blake2b_hash.update(str(sorted(self.keys.items())).encode())
-        return blake2b_hash.hexdigest()
+    def blake3_hash(self):
+        """ Calculate the BLAKE3 hash string of the manifest. """
+        blake3_hash = blake3("".join(sorted(dataset.blake3_hash for dataset in self.datasets)).encode())
+        blake3_hash.update(str(sorted(self.keys.items())).encode())
+        return blake3_hash.hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -10,10 +10,8 @@ module_logger = logging.getLogger(__name__)
 
 
 class Manifest(Pathable, Serialisable, Loggable, Identifiable):
-    """ A representation of a manifest, which can contain multiple datasets
-    This is used to manage all files coming into (or leaving), a data service for an analysis at the
-    configuration, input or output stage.
-    """
+    """ A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
+    (or leaving), a data service for an analysis at the configuration, input or output stage. """
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, **kwargs):
         """ Construct a Manifest
@@ -44,11 +42,11 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
 
         # Instantiate the datasets if not already done
         self.datasets = []
-        for key, ds in zip(key_list, datasets):
-            if isinstance(ds, Dataset):
-                self.datasets.append(ds)
+        for key, dataset in zip(key_list, datasets):
+            if isinstance(dataset, Dataset):
+                self.datasets.append(dataset)
             else:
-                self.datasets.append(Dataset(**ds, path=key, path_from=self))
+                self.datasets.append(Dataset(**dataset, path=key, path_from=self))
 
         # Instantiate the rest of everything!
         self.__dict__.update(**kwargs)
@@ -83,5 +81,5 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
 
     @property
     def blake2b_hash(self):
-        """ Calculate the SHA256 hash string of the manifest. """
+        """ Calculate the BLAKE2b hash string of the manifest. """
         return hashlib.blake2b("".join(dataset.blake2b_hash for dataset in self.datasets).encode()).hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,18 +1,18 @@
-import functools
 import logging
-from blake3 import blake3
 
 from octue.exceptions import InvalidInputException, InvalidManifestException
-from octue.mixins import Identifiable, Loggable, Pathable, Serialisable
+from octue.mixins import Hashable, Identifiable, Loggable, Pathable, Serialisable
 from .dataset import Dataset
 
 
 module_logger = logging.getLogger(__name__)
 
 
-class Manifest(Pathable, Serialisable, Loggable, Identifiable):
+class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
     """ A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
     (or leaving), a data service for an analysis at the configuration, input or output stage. """
+
+    ATTRIBUTES_TO_HASH = "datasets", "keys"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, **kwargs):
         """ Construct a Manifest
@@ -79,11 +79,3 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
             self.datasets.append(Dataset(logger=self.logger, path_from=self, path=dataset_spec["key"]))
 
         return self
-
-    @property
-    @functools.lru_cache(maxsize=None)
-    def blake3_hash(self):
-        """ Calculate the BLAKE3 hash string of the manifest. """
-        blake3_hash = blake3("".join(sorted(dataset.blake3_hash for dataset in self.datasets)).encode())
-        blake3_hash.update(str(sorted(self.keys.items())).encode())
-        return blake3_hash.hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -84,4 +84,6 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
     @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the manifest. """
-        return hashlib.blake2b("".join(sorted(dataset.blake2b_hash for dataset in self.datasets)).encode()).hexdigest()
+        blake2b_hash = hashlib.blake2b("".join(sorted(dataset.blake2b_hash for dataset in self.datasets)).encode())
+        blake2b_hash.update(str(sorted(self.keys.items())).encode())
+        return blake2b_hash.hexdigest()

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -84,4 +84,4 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable):
     @functools.lru_cache(maxsize=None)
     def blake2b_hash(self):
         """ Calculate the BLAKE2b hash string of the manifest. """
-        return hashlib.blake2b("".join(dataset.blake2b_hash for dataset in self.datasets).encode()).hexdigest()
+        return hashlib.blake2b("".join(sorted(dataset.blake2b_hash for dataset in self.datasets)).encode()).hexdigest()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ setup(
     name="octue",
     version="0.1.6",
     py_modules=["cli"],
-    install_requires=["click>=7.1.2", "twined==0.0.13"],  # Dev note: you also need to bump twined in tox.ini
+    install_requires=[
+        "blake3>=0.1.8",
+        "click>=7.1.2",
+        "twined==0.0.13",
+    ],  # Dev note: you also need to bump twined in tox.ini
     url="https://www.github.com/octue/octue-sdk-python",
     license="MIT",
     author="Thomas Clark (github: thclark)",

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,7 +5,7 @@ import uuid
 from tempfile import TemporaryDirectory, gettempdir
 
 from octue.mixins import MixinBase, Pathable
-from octue.resources import Datafile, Dataset
+from octue.resources import Datafile, Dataset, Manifest
 
 
 class MyPathable(Pathable, MixinBase):
@@ -18,7 +18,6 @@ class BaseTestCase(unittest.TestCase):
     """
 
     def setUp(self):
-
         # Set up paths to the test data directory and to the app templates directory
         root_dir = os.path.dirname(os.path.abspath(__file__))
         self.data_path = os.path.join(root_dir, "data")
@@ -37,6 +36,7 @@ class BaseTestCase(unittest.TestCase):
             subprocess.call(args, cwd=tmp_dir_name)
 
     def create_valid_dataset(self):
+        """ Creat a valid dataset with two valid datafiles (they're the same file in this case). """
         path_from = MyPathable(path=os.path.join(self.data_path, "basic_files", "configuration", "test-dataset"))
         path = os.path.join("path-within-dataset", "a_test_file.csv")
 
@@ -46,3 +46,9 @@ class BaseTestCase(unittest.TestCase):
         ]
 
         return Dataset(files=files)
+
+    def create_valid_manifest(self):
+        """ Creat a valid manifest with two valid datasets (they're the same dataset in this case). """
+        datasets = [self.create_valid_dataset(), self.create_valid_dataset()]
+        manifest = Manifest(datasets=datasets, keys={"my_dataset": 0, "another_dataset": 1})
+        return manifest

--- a/tests/base.py
+++ b/tests/base.py
@@ -36,7 +36,7 @@ class BaseTestCase(unittest.TestCase):
             subprocess.call(args, cwd=tmp_dir_name)
 
     def create_valid_dataset(self):
-        """ Creat a valid dataset with two valid datafiles (they're the same file in this case). """
+        """ Create a valid dataset with two valid datafiles (they're the same file in this case). """
         path_from = MyPathable(path=os.path.join(self.data_path, "basic_files", "configuration", "test-dataset"))
         path = os.path.join("path-within-dataset", "a_test_file.csv")
 
@@ -48,7 +48,7 @@ class BaseTestCase(unittest.TestCase):
         return Dataset(files=files)
 
     def create_valid_manifest(self):
-        """ Creat a valid manifest with two valid datasets (they're the same dataset in this case). """
+        """ Create a valid manifest with two valid datasets (they're the same dataset in this case). """
         datasets = [self.create_valid_dataset(), self.create_valid_dataset()]
         manifest = Manifest(datasets=datasets, keys={"my_dataset": 0, "another_dataset": 1})
         return manifest

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,6 +4,13 @@ import unittest
 import uuid
 from tempfile import TemporaryDirectory, gettempdir
 
+from octue.mixins import MixinBase, Pathable
+from octue.resources import Datafile, Dataset
+
+
+class MyPathable(Pathable, MixinBase):
+    pass
+
 
 class BaseTestCase(unittest.TestCase):
     """ Base test case for twined:
@@ -28,3 +35,14 @@ class BaseTestCase(unittest.TestCase):
 
         with TemporaryDirectory(dir=tmp_dir_name):
             subprocess.call(args, cwd=tmp_dir_name)
+
+    def create_valid_dataset(self):
+        path_from = MyPathable(path=os.path.join(self.data_path, "basic_files", "configuration", "test-dataset"))
+        path = os.path.join("path-within-dataset", "a_test_file.csv")
+
+        files = [
+            Datafile(path_from=path_from, base_from=path_from, path=path, skip_checks=False),
+            Datafile(path_from=path_from, base_from=path_from, path=path, skip_checks=False),
+        ]
+
+        return Dataset(files=files)

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -1,0 +1,45 @@
+from octue.mixins import Hashable
+from ..base import BaseTestCase
+
+
+class EmptyClass:
+    pass
+
+
+class TypeWithBLAKE3Hash:
+    blake3_hash = None
+
+
+class TypeWithIterable(Hashable):
+    ATTRIBUTES_TO_HASH = ("my_iterable",)
+
+
+class HashableTestCase(BaseTestCase):
+    def test_no_attributes_to_hash_results_in_no_hash(self):
+        """ Assert classes with Hashable mixed in but no attributes to hash give None for their hash. """
+        self.assertIsNone(EmptyClass().blake3_hash)
+
+    def test_non_hashable_type_results_in_type_error(self):
+        class MyClass(Hashable):
+            ATTRIBUTES_TO_HASH = ("a_class",)
+
+        my_class = MyClass()
+        my_class.a_class = EmptyClass()
+
+        with self.assertRaises(TypeError):
+            my_class.blake3_hash
+
+    def test_iterable_attribute_with_mixed_types_raises_value_error(self):
+
+        my_class = TypeWithIterable()
+        my_class.my_iterable = [1, 2, TypeWithBLAKE3Hash()]
+
+        with self.assertRaises(ValueError):
+            my_class.blake3_hash
+
+    def test_unsortable_iterable_attribute_raises_type_error(self):
+        my_class = TypeWithIterable()
+        my_class.my_iterable = [TypeWithBLAKE3Hash(), TypeWithBLAKE3Hash()]
+
+        with self.assertRaises(TypeError):
+            my_class.blake3_hash

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -11,7 +11,7 @@ class TypeWithHash:
 
 
 class TypeWithIterable(Hashable):
-    ATTRIBUTES_TO_HASH = ("my_iterable",)
+    _ATTRIBUTES_TO_HASH = ("my_iterable",)
 
 
 class HashableTestCase(BaseTestCase):
@@ -23,7 +23,7 @@ class HashableTestCase(BaseTestCase):
         """ Ensure trying to hash unhashable attributes results in a TypeError. """
 
         class MyClass(Hashable):
-            ATTRIBUTES_TO_HASH = ("a_class",)
+            _ATTRIBUTES_TO_HASH = ("a_class",)
 
         my_class = MyClass()
         my_class.a_class = EmptyClass()

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -17,7 +17,7 @@ class TypeWithIterable(Hashable):
 class HashableTestCase(BaseTestCase):
     def test_no_attributes_to_hash_results_in_no_hash(self):
         """ Assert classes with Hashable mixed in but no attributes to hash give None for their hash. """
-        self.assertIsNone(EmptyClass().blake3_hash)
+        self.assertIsNone(TypeWithBLAKE3Hash().blake3_hash)
 
     def test_non_hashable_type_results_in_type_error(self):
         class MyClass(Hashable):
@@ -39,7 +39,7 @@ class HashableTestCase(BaseTestCase):
 
     def test_unsortable_iterable_attribute_raises_type_error(self):
         my_class = TypeWithIterable()
-        my_class.my_iterable = [TypeWithBLAKE3Hash(), TypeWithBLAKE3Hash()]
+        my_class.my_iterable = [EmptyClass(), EmptyClass()]
 
         with self.assertRaises(TypeError):
             my_class.blake3_hash

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -20,6 +20,8 @@ class HashableTestCase(BaseTestCase):
         self.assertIsNone(TypeWithBLAKE3Hash().blake3_hash)
 
     def test_non_hashable_type_results_in_type_error(self):
+        """ Ensure trying to hash unhashable attributes results in a TypeError. """
+
         class MyClass(Hashable):
             ATTRIBUTES_TO_HASH = ("a_class",)
 
@@ -30,7 +32,8 @@ class HashableTestCase(BaseTestCase):
             my_class.blake3_hash
 
     def test_iterable_attribute_with_mixed_types_raises_value_error(self):
-
+        """ Ensure trying to hash iterable attributes containing a mix between types with a 'blake3_hash' attribute and
+        types that don't results in a TypeError. """
         my_class = TypeWithIterable()
         my_class.my_iterable = [1, 2, TypeWithBLAKE3Hash()]
 
@@ -38,6 +41,7 @@ class HashableTestCase(BaseTestCase):
             my_class.blake3_hash
 
     def test_unsortable_iterable_attribute_raises_type_error(self):
+        """ Ensure trying to hash unsortable iterable attributes results in a TypeError. """
         my_class = TypeWithIterable()
         my_class.my_iterable = [EmptyClass(), EmptyClass()]
 

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -6,8 +6,8 @@ class EmptyClass:
     pass
 
 
-class TypeWithBLAKE3Hash:
-    blake3_hash = None
+class TypeWithHash:
+    hash_value = None
 
 
 class TypeWithIterable(Hashable):
@@ -17,7 +17,7 @@ class TypeWithIterable(Hashable):
 class HashableTestCase(BaseTestCase):
     def test_no_attributes_to_hash_results_in_no_hash(self):
         """ Assert classes with Hashable mixed in but no attributes to hash give None for their hash. """
-        self.assertIsNone(TypeWithBLAKE3Hash().blake3_hash)
+        self.assertIsNone(TypeWithHash().hash_value)
 
     def test_non_hashable_type_results_in_type_error(self):
         """ Ensure trying to hash unhashable attributes results in a TypeError. """
@@ -29,16 +29,16 @@ class HashableTestCase(BaseTestCase):
         my_class.a_class = EmptyClass()
 
         with self.assertRaises(TypeError):
-            my_class.blake3_hash
+            my_class.hash_value
 
     def test_iterable_attribute_with_mixed_types_raises_value_error(self):
-        """ Ensure trying to hash iterable attributes containing a mix between types with a 'blake3_hash' attribute and
+        """ Ensure trying to hash iterable attributes containing a mix between types with a 'hash_value' attribute and
         types that don't results in a TypeError. """
         my_class = TypeWithIterable()
-        my_class.my_iterable = [1, 2, TypeWithBLAKE3Hash()]
+        my_class.my_iterable = [1, 2, TypeWithHash()]
 
         with self.assertRaises(ValueError):
-            my_class.blake3_hash
+            my_class.hash_value
 
     def test_unsortable_iterable_attribute_raises_type_error(self):
         """ Ensure trying to hash unsortable iterable attributes results in a TypeError. """
@@ -46,4 +46,4 @@ class HashableTestCase(BaseTestCase):
         my_class.my_iterable = [EmptyClass(), EmptyClass()]
 
         with self.assertRaises(TypeError):
-            my_class.blake3_hash
+            my_class.hash_value

--- a/tests/mixins/test_serialisable.py
+++ b/tests/mixins/test_serialisable.py
@@ -17,7 +17,7 @@ class Inherit(Serialisable):
 
 
 class InheritWithFieldsToSerialise(Inherit):
-    _serialise_fields = ("field_to_serialise",)
+    _SERIALISE_FIELDS = ("field_to_serialise",)
 
 
 class SerialisableTestCase(BaseTestCase):

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -8,7 +8,7 @@ class TestHashJson(BaseTestCase):
         """ Ensure JSON-compliant python objects can be hashed. """
         hash_ = hash_json({"hello": 5})
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 128)
+        self.assertTrue(len(hash_) == 64)
 
 
 class AnalysisTestCase(BaseTestCase):
@@ -54,4 +54,4 @@ class AnalysisTestCase(BaseTestCase):
         for strand_name in HASH_FUNCTIONS:
             hash_ = getattr(analysis, f"{strand_name}_hash")
             self.assertTrue(isinstance(hash_, str))
-            self.assertTrue(len(hash_) == 128)
+            self.assertTrue(len(hash_) == 64)

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -25,3 +25,10 @@ class AnalysisTestCase(BaseTestCase):
 
         with self.assertRaises(AttributeError):
             analysis.furry_purry_cat
+
+    def test_analysis_hash_attributes_are_none_when_no_relevant_strands(self):
+        """ Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are in the
+        Twine. """
+        analysis = Analysis(twine="{}")
+        for strand_name in "configuration_values", "configuration_manifest", "input_values", "input_manifest":
+            self.assertIsNone(getattr(analysis, f"{strand_name}_hash"))

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,4 +1,4 @@
-from octue.resources import Analysis
+from octue.resources.analysis import HASH_FUNCTIONS, Analysis
 from twined import Twine
 from ..base import BaseTestCase
 
@@ -27,8 +27,23 @@ class AnalysisTestCase(BaseTestCase):
             analysis.furry_purry_cat
 
     def test_analysis_hash_attributes_are_none_when_no_relevant_strands(self):
-        """ Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are in the
-        Twine. """
+        """ Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are provided
+        """
         analysis = Analysis(twine="{}")
-        for strand_name in "configuration_values", "configuration_manifest", "input_values", "input_manifest":
+        for strand_name in HASH_FUNCTIONS:
             self.assertIsNone(getattr(analysis, f"{strand_name}_hash"))
+
+    def test_analysis_hash_attributes_are_populated_when_relevant_strands_are_present(self):
+        """ Ensures that the hash attributes of Analysis instances are valid if the relevant strands are provided. """
+        analysis = Analysis(
+            twine="{}",
+            configuration_values={"resistance_setting": 7},
+            configuration_manifest=self.create_valid_manifest(),
+            input_values={"quality_factor": 5},
+            input_manifest=self.create_valid_manifest(),
+        )
+
+        for strand_name in HASH_FUNCTIONS:
+            hash_ = getattr(analysis, f"{strand_name}_hash")
+            self.assertTrue(isinstance(hash_, str))
+            self.assertTrue(len(hash_) == 128)

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,6 +1,14 @@
-from octue.resources.analysis import HASH_FUNCTIONS, Analysis
+from octue.resources.analysis import HASH_FUNCTIONS, Analysis, hash_json
 from twined import Twine
 from ..base import BaseTestCase
+
+
+class TestHashJson(BaseTestCase):
+    def test_hash_json(self):
+        """ Ensure JSON-compliant python objects can be hashed. """
+        hash_ = hash_json({"hello": 5})
+        self.assertTrue(isinstance(hash_, str))
+        self.assertTrue(len(hash_) == 128)
 
 
 class AnalysisTestCase(BaseTestCase):

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,4 +1,4 @@
-from octue.resources.analysis import HASH_FUNCTIONS, Analysis
+from octue.resources.analysis import _HASH_FUNCTIONS, Analysis
 from twined import Twine
 from ..base import BaseTestCase
 
@@ -30,7 +30,7 @@ class AnalysisTestCase(BaseTestCase):
         """ Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are provided
         """
         analysis = Analysis(twine="{}")
-        for strand_name in HASH_FUNCTIONS:
+        for strand_name in _HASH_FUNCTIONS:
             self.assertIsNone(getattr(analysis, f"{strand_name}_hash"))
 
     def test_analysis_hash_attributes_are_populated_when_relevant_strands_are_present(self):
@@ -43,7 +43,7 @@ class AnalysisTestCase(BaseTestCase):
             input_manifest=self.create_valid_manifest(),
         )
 
-        for strand_name in HASH_FUNCTIONS:
+        for strand_name in _HASH_FUNCTIONS:
             hash_ = getattr(analysis, f"{strand_name}_hash")
             self.assertTrue(isinstance(hash_, str))
             self.assertTrue(len(hash_) == 64)

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,14 +1,6 @@
-from octue.resources.analysis import HASH_FUNCTIONS, Analysis, hash_json
+from octue.resources.analysis import HASH_FUNCTIONS, Analysis
 from twined import Twine
 from ..base import BaseTestCase
-
-
-class TestHashJson(BaseTestCase):
-    def test_hash_json(self):
-        """ Ensure JSON-compliant python objects can be hashed. """
-        hash_ = hash_json({"hello": 5})
-        self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 64)
 
 
 class AnalysisTestCase(BaseTestCase):

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -93,18 +93,18 @@ class DatafileTestCase(BaseTestCase):
             "sequence",
             "size_bytes",
             "tags",
-            "blake3_hash",
+            "hash_value",
         ):
             self.assertIn(k, df_dict.keys())
 
-    def test_blake3_hash(self):
+    def test_hash_value(self):
         """ Test hashing a datafile gives a hash of length 128. """
-        hash_ = self.create_valid_datafile().blake3_hash
+        hash_ = self.create_valid_datafile().hash_value
         self.assertTrue(isinstance(hash_, str))
         self.assertTrue(len(hash_) == 64)
 
-    def test_blake3_hashes_for_the_same_datafile_are_the_same(self):
+    def test_hashes_for_the_same_datafile_are_the_same(self):
         """ Ensure the hashes for two datafiles that are exactly the same are the same."""
         first_file = self.create_valid_datafile()
         second_file = copy.deepcopy(first_file)
-        self.assertEqual(first_file.blake3_hash, second_file.blake3_hash)
+        self.assertEqual(first_file.hash_value, second_file.hash_value)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -97,6 +97,7 @@ class DatafileTestCase(BaseTestCase):
             self.assertIn(k, df_dict.keys())
 
     def test_hash(self):
-        """ Ensure a Datafile can be hashed."""
+        """ Test hashing a datafile gives a hash of length 64. """
         df = self.create_valid_datafile()
         self.assertTrue(isinstance(df.sha_256, str))
+        self.assertTrue(len(df.sha_256) == 64)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import uuid
 
@@ -96,8 +97,14 @@ class DatafileTestCase(BaseTestCase):
         ):
             self.assertIn(k, df_dict.keys())
 
-    def test_hash(self):
+    def test_blake3_hash(self):
         """ Test hashing a datafile gives a hash of length 128. """
         hash_ = self.create_valid_datafile().blake3_hash
         self.assertTrue(isinstance(hash_, str))
         self.assertTrue(len(hash_) == 64)
+
+    def test_blake3_hashes_for_the_same_datafile_are_the_same(self):
+        """ Ensure the hashes for two datafiles that are exactly the same are the same."""
+        first_file = self.create_valid_datafile()
+        second_file = copy.deepcopy(first_file)
+        self.assertEqual(first_file.blake3_hash, second_file.blake3_hash)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -97,7 +97,7 @@ class DatafileTestCase(BaseTestCase):
             self.assertIn(k, df_dict.keys())
 
     def test_hash(self):
-        """ Test hashing a datafile gives a hash of length 64. """
-        df = self.create_valid_datafile()
-        self.assertTrue(isinstance(df.sha_256, str))
-        self.assertTrue(len(df.sha_256) == 64)
+        """ Test hashing a datafile gives a hash of length 128. """
+        hash = self.create_valid_datafile().blake2b_hash
+        self.assertTrue(isinstance(hash, str))
+        self.assertTrue(len(hash) == 128)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -95,3 +95,8 @@ class DatafileTestCase(BaseTestCase):
             "sha_256",
         ):
             self.assertIn(k, df_dict.keys())
+
+    def test_hash(self):
+        """ Ensure a Datafile can be hashed."""
+        df = self.create_valid_datafile()
+        self.assertTrue(isinstance(df.sha_256, str))

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -92,7 +92,7 @@ class DatafileTestCase(BaseTestCase):
             "sequence",
             "size_bytes",
             "tags",
-            "sha_256",
+            "blake2b_hash",
         ):
             self.assertIn(k, df_dict.keys())
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -98,6 +98,6 @@ class DatafileTestCase(BaseTestCase):
 
     def test_hash(self):
         """ Test hashing a datafile gives a hash of length 128. """
-        hash = self.create_valid_datafile().blake2b_hash
-        self.assertTrue(isinstance(hash, str))
-        self.assertTrue(len(hash) == 128)
+        hash_ = self.create_valid_datafile().blake2b_hash
+        self.assertTrue(isinstance(hash_, str))
+        self.assertTrue(len(hash_) == 128)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -92,12 +92,12 @@ class DatafileTestCase(BaseTestCase):
             "sequence",
             "size_bytes",
             "tags",
-            "blake2b_hash",
+            "blake3_hash",
         ):
             self.assertIn(k, df_dict.keys())
 
     def test_hash(self):
         """ Test hashing a datafile gives a hash of length 128. """
-        hash_ = self.create_valid_datafile().blake2b_hash
+        hash_ = self.create_valid_datafile().blake3_hash
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 128)
+        self.assertTrue(len(hash_) == 64)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -233,6 +233,6 @@ class DatasetTestCase(BaseTestCase):
 
     def test_hash(self):
         """ Test hashing a dataset with multiple files gives a hash of length 128. """
-        hash = self.create_valid_dataset().blake2b_hash
-        self.assertTrue(isinstance(hash, str))
-        self.assertTrue(len(hash) == 128)
+        hash_ = self.create_valid_dataset().blake2b_hash
+        self.assertTrue(isinstance(hash_, str))
+        self.assertTrue(len(hash_) == 128)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -233,6 +233,6 @@ class DatasetTestCase(BaseTestCase):
 
     def test_hash(self):
         """ Test hashing a dataset with multiple files gives a hash of length 128. """
-        hash_ = self.create_valid_dataset().blake2b_hash
+        hash_ = self.create_valid_dataset().blake3_hash
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 128)
+        self.assertTrue(len(hash_) == 64)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -1,3 +1,5 @@
+import copy
+
 from octue import exceptions
 from octue.resources import Datafile, Dataset
 from ..base import BaseTestCase
@@ -231,8 +233,14 @@ class DatasetTestCase(BaseTestCase):
         files = resource.get_files("name__icontains", filter_value="second")
         self.assertEqual(0, len(files))
 
-    def test_hash(self):
+    def test_blake3_hash(self):
         """ Test hashing a dataset with multiple files gives a hash of length 128. """
         hash_ = self.create_valid_dataset().blake3_hash
         self.assertTrue(isinstance(hash_, str))
         self.assertTrue(len(hash_) == 64)
+
+    def test_blake3_hashes_for_the_same_dataset_are_the_same(self):
+        """ Ensure the hashes for two datasets that are exactly the same are the same."""
+        first_dataset = self.create_valid_dataset()
+        second_dataset = copy.deepcopy(first_dataset)
+        self.assertEqual(first_dataset.blake3_hash, second_dataset.blake3_hash)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -233,14 +233,14 @@ class DatasetTestCase(BaseTestCase):
         files = resource.get_files("name__icontains", filter_value="second")
         self.assertEqual(0, len(files))
 
-    def test_blake3_hash(self):
+    def test_hash_value(self):
         """ Test hashing a dataset with multiple files gives a hash of length 128. """
-        hash_ = self.create_valid_dataset().blake3_hash
+        hash_ = self.create_valid_dataset().hash_value
         self.assertTrue(isinstance(hash_, str))
         self.assertTrue(len(hash_) == 64)
 
-    def test_blake3_hashes_for_the_same_dataset_are_the_same(self):
+    def test_hashes_for_the_same_dataset_are_the_same(self):
         """ Ensure the hashes for two datasets that are exactly the same are the same."""
         first_dataset = self.create_valid_dataset()
         second_dataset = copy.deepcopy(first_dataset)
-        self.assertEqual(first_dataset.blake3_hash, second_dataset.blake3_hash)
+        self.assertEqual(first_dataset.hash_value, second_dataset.hash_value)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -1,25 +1,6 @@
-import os
-
 from octue import exceptions
-from octue.mixins import MixinBase, Pathable
 from octue.resources import Datafile, Dataset
 from ..base import BaseTestCase
-
-
-class MyPathable(Pathable, MixinBase):
-    pass
-
-
-def create_valid_dataset(data_path):
-    path_from = MyPathable(path=os.path.join(data_path, "basic_files", "configuration", "test-dataset"))
-    path = os.path.join("path-within-dataset", "a_test_file.csv")
-
-    files = [
-        Datafile(path_from=path_from, base_from=path_from, path=path, skip_checks=False),
-        Datafile(path_from=path_from, base_from=path_from, path=path, skip_checks=False),
-    ]
-
-    return Dataset(files=files)
 
 
 class DatasetTestCase(BaseTestCase):
@@ -252,6 +233,6 @@ class DatasetTestCase(BaseTestCase):
 
     def test_hash(self):
         """ Test hashing a dataset with multiple files gives a hash of length 128. """
-        hash = create_valid_dataset(self.data_path).blake2b_hash
+        hash = self.create_valid_dataset().blake2b_hash
         self.assertTrue(isinstance(hash, str))
         self.assertTrue(len(hash) == 128)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -251,4 +251,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(0, len(files))
 
     def test_hash(self):
-        self.assertTrue(isinstance(create_valid_dataset(self.data_path).sha_256, str))
+        """ Test hashing a dataset with multiple files gives a hash of length 64. """
+        hash = create_valid_dataset(self.data_path).sha_256
+        self.assertTrue(isinstance(hash, str))
+        self.assertTrue(len(hash) == 64)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -1,9 +1,28 @@
+import os
+
 from octue import exceptions
+from octue.mixins import MixinBase, Pathable
 from octue.resources import Datafile, Dataset
 from ..base import BaseTestCase
 
 
-class DatafileTestCase(BaseTestCase):
+class MyPathable(Pathable, MixinBase):
+    pass
+
+
+def create_valid_dataset(data_path):
+    path_from = MyPathable(path=os.path.join(data_path, "basic_files", "configuration", "test-dataset"))
+    path = os.path.join("path-within-dataset", "a_test_file.csv")
+
+    files = [
+        Datafile(path_from=path_from, base_from=path_from, path=path, skip_checks=False),
+        Datafile(path_from=path_from, base_from=path_from, path=path, skip_checks=False),
+    ]
+
+    return Dataset(files=files)
+
+
+class DatasetTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
         """ Ensures a Datafile instantiates using only a path and generates a uuid ID
         """
@@ -230,3 +249,6 @@ class DatafileTestCase(BaseTestCase):
         )
         files = resource.get_files("name__icontains", filter_value="second")
         self.assertEqual(0, len(files))
+
+    def test_hash(self):
+        self.assertTrue(isinstance(create_valid_dataset(self.data_path).sha_256, str))

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -251,7 +251,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(0, len(files))
 
     def test_hash(self):
-        """ Test hashing a dataset with multiple files gives a hash of length 64. """
-        hash = create_valid_dataset(self.data_path).sha_256
+        """ Test hashing a dataset with multiple files gives a hash of length 128. """
+        hash = create_valid_dataset(self.data_path).blake2b_hash
         self.assertTrue(isinstance(hash, str))
-        self.assertTrue(len(hash) == 64)
+        self.assertTrue(len(hash) == 128)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -3,15 +3,15 @@ from tests.base import BaseTestCase
 
 
 class TestManifest(BaseTestCase):
-    def test_blake3_hash(self):
+    def test_hash_value(self):
         """ Test hashing a manifest with multiple datasets gives a hash of length 128. """
         manifest = self.create_valid_manifest()
-        hash_ = manifest.blake3_hash
+        hash_ = manifest.hash_value
         self.assertTrue(isinstance(hash_, str))
         self.assertTrue(len(hash_) == 64)
 
-    def test_blake3_hashes_for_the_same_manifest_are_the_same(self):
+    def test_hashes_for_the_same_manifest_are_the_same(self):
         """ Ensure the hashes for two manifests that are exactly the same are the same."""
         first_file = self.create_valid_manifest()
         second_file = copy.deepcopy(first_file)
-        self.assertEqual(first_file.blake3_hash, second_file.blake3_hash)
+        self.assertEqual(first_file.hash_value, second_file.hash_value)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -1,0 +1,10 @@
+from tests.base import BaseTestCase
+
+
+class TestManifest(BaseTestCase):
+    def test_hash(self):
+        """ Test hashing a manifest with multiple datasets gives a hash of length 128. """
+        manifest = self.create_valid_manifest()
+        hash = manifest.blake2b_hash
+        self.assertTrue(isinstance(hash, str))
+        self.assertTrue(len(hash) == 128)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -5,6 +5,6 @@ class TestManifest(BaseTestCase):
     def test_hash(self):
         """ Test hashing a manifest with multiple datasets gives a hash of length 128. """
         manifest = self.create_valid_manifest()
-        hash_ = manifest.blake2b_hash
+        hash_ = manifest.blake3_hash
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 128)
+        self.assertTrue(len(hash_) == 64)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -5,6 +5,6 @@ class TestManifest(BaseTestCase):
     def test_hash(self):
         """ Test hashing a manifest with multiple datasets gives a hash of length 128. """
         manifest = self.create_valid_manifest()
-        hash = manifest.blake2b_hash
-        self.assertTrue(isinstance(hash, str))
-        self.assertTrue(len(hash) == 128)
+        hash_ = manifest.blake2b_hash
+        self.assertTrue(isinstance(hash_, str))
+        self.assertTrue(len(hash_) == 128)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -1,10 +1,17 @@
+import copy
 from tests.base import BaseTestCase
 
 
 class TestManifest(BaseTestCase):
-    def test_hash(self):
+    def test_blake3_hash(self):
         """ Test hashing a manifest with multiple datasets gives a hash of length 128. """
         manifest = self.create_valid_manifest()
         hash_ = manifest.blake3_hash
         self.assertTrue(isinstance(hash_, str))
         self.assertTrue(len(hash_) == 64)
+
+    def test_blake3_hashes_for_the_same_manifest_are_the_same(self):
+        """ Ensure the hashes for two manifests that are exactly the same are the same."""
+        first_file = self.create_valid_manifest()
+        second_file = copy.deepcopy(first_file)
+        self.assertEqual(first_file.blake3_hash, second_file.blake3_hash)


### PR DESCRIPTION
## Contents

### New Features

<!-- Write `Closes #xyz` to link issues that this PR completes,
           `WIP on #xyz` to link issues that this PR works toward. -->

- [x] Close #44 - add hashes of input data
- [x] Add `Hashable` mixin


### Breaking changes

- [x] Any `sha256` properties have been replaced with `blake3_hash` properties

### Minor fixes and improvements

- [x] Replace SHA256 hashing with [BLAKE3 hashing](https://github.com/BLAKE3-team/BLAKE3) - this is reportedly around 10 times as fast!

### Notes
I've made the hashes cached properties to avoid recomputing them every time they're accessed.

## Quality Checklist

- [x] New features are fully tested (No matter how much Coverage Karma you have)
- [x] **[v0.2 onward]** New features are included in the documentation

### Coverage Karma

- [x] If your PR decreases test coverage, do you feel you have built enough `Coverage Karma`* to justify it?
