### PR TITLE
Devops: Move release version GitHub check into python-ci workflow

### DIFF
--- a/.github/workflows/check-version-consistency.yml
+++ b/.github/workflows/check-version-consistency.yml
@@ -1,9 +1,0 @@
-name: check-version-consistency
-on: [push]
-jobs:
-  check-version-consistency:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: python .github/workflows/scripts/check-version-consistency.py

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,6 +9,14 @@ name: python-ci
 on: [push]
 
 jobs:
+
+  check-version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: python .github/workflows/scripts/check-version-consistency.py
+
   tests:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
<!-- PRs from release/x.y.z branches will be used to create Release Notes so make sure they contain everything -->
<!-- Please don't add features not discussed in an issue first -->

### Minor fixes and improvements
- [x] Neaten up #40/#42 by combining the two workflow files while still keeping separate checks on GitHub. This also makes the version check display less verbosely on GitHub