### PR TITLE
Feature: Add order_by method to filter containers

### DIFF
--- a/octue/mixins/filterable.py
+++ b/octue/mixins/filterable.py
@@ -60,7 +60,7 @@ class Filterable:
         try:
             attribute = getattr(self, attribute_name)
         except AttributeError:
-            raise exceptions.InvalidInputException(f"An attribute named {attribute_name!r} does not exist on {self!r}.")
+            raise AttributeError(f"An attribute named {attribute_name!r} does not exist on {self!r}.")
 
         filter_ = self._get_filter(attribute, filter_action)
         return filter_(attribute, filter_value)

--- a/octue/mixins/filterable.py
+++ b/octue/mixins/filterable.py
@@ -56,7 +56,12 @@ class Filterable:
     def satisfies(self, filter_name, filter_value):
         """ Check that the instance satisfies the given filter for the given filter value. """
         attribute_name, filter_action = self._split_filter_name(filter_name)
-        attribute = getattr(self, attribute_name)
+
+        try:
+            attribute = getattr(self, attribute_name)
+        except AttributeError:
+            raise exceptions.InvalidInputException(f"An attribute named {attribute_name!r} does not exist on {self!r}.")
+
         filter_ = self._get_filter(attribute, filter_action)
         return filter_(attribute, filter_value)
 

--- a/octue/resources/filter_containers.py
+++ b/octue/resources/filter_containers.py
@@ -1,5 +1,8 @@
+from octue import exceptions
+
+
 def _filter(instance, filter_name=None, filter_value=None):
-    """ Returns a new FilterSet containing only the Filterables to which the given filter criteria apply.
+    """ Returns a new instance containing only the Filterables to which the given filter criteria apply.
 
     Say we want to filter by files whose extension equals "csv". We want to be able to do...
 
@@ -19,9 +22,23 @@ def _filter(instance, filter_name=None, filter_value=None):
     return instance.__class__((item for item in instance if item.satisfies(filter_name, filter_value)))
 
 
+def _order_by(instance, attribute_name):
+    """ Order the instance by the given attribute_name, returning the instance's elements as a FilterList (not a
+    FilterSet.
+    """
+    try:
+        return FilterList(sorted(instance, key=lambda item: getattr(item, attribute_name)))
+    except AttributeError:
+        raise exceptions.InvalidInputException(
+            f"An attribute named {attribute_name!r} does not exist on one or more members of {instance!r}."
+        )
+
+
 class FilterSet(set):
     filter = _filter
+    order_by = _order_by
 
 
 class FilterList(list):
     filter = _filter
+    order_by = _order_by

--- a/octue/resources/filter_containers.py
+++ b/octue/resources/filter_containers.py
@@ -23,7 +23,7 @@ def _filter(instance, filter_name=None, filter_value=None):
 
 
 def _order_by(instance, attribute_name):
-    """ Order the instance by the given attribute_name, returning the instance's elements as a FilterList (not a
+    """ Order the instance by the given attribute_name, returning the instance's elements as a new FilterList (not a
     FilterSet.
     """
     try:

--- a/octue/resources/filter_containers.py
+++ b/octue/resources/filter_containers.py
@@ -22,12 +22,12 @@ def _filter(instance, filter_name=None, filter_value=None):
     return instance.__class__((item for item in instance if item.satisfies(filter_name, filter_value)))
 
 
-def _order_by(instance, attribute_name):
+def _order_by(instance, attribute_name, reverse=False):
     """ Order the instance by the given attribute_name, returning the instance's elements as a new FilterList (not a
     FilterSet.
     """
     try:
-        return FilterList(sorted(instance, key=lambda item: getattr(item, attribute_name)))
+        return FilterList(sorted(instance, key=lambda item: getattr(item, attribute_name), reverse=reverse))
     except AttributeError:
         raise exceptions.InvalidInputException(
             f"An attribute named {attribute_name!r} does not exist on one or more members of {instance!r}."

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -20,6 +20,11 @@ class TestFilterable(BaseTestCase):
         with self.assertRaises(exceptions.InvalidInputException):
             FilterableSubclass().satisfies(filter_name="invalid_filter_name", filter_value=None)
 
+    def test_error_raised_when_non_existent_attribute_name_received(self):
+        """ Ensure an error is raised when a non-existent attribute name is used in the filter name. """
+        with self.assertRaises(exceptions.InvalidInputException):
+            FilterableSubclass().satisfies(filter_name="boogaloo__is_a_dance", filter_value=True)
+
     def test_error_raised_when_valid_but_non_existent_filter_name_received(self):
         """ Ensure an error is raised when a valid but non-existent filter name is received. """
         with self.assertRaises(exceptions.InvalidInputException):

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -22,7 +22,7 @@ class TestFilterable(BaseTestCase):
 
     def test_error_raised_when_non_existent_attribute_name_received(self):
         """ Ensure an error is raised when a non-existent attribute name is used in the filter name. """
-        with self.assertRaises(exceptions.InvalidInputException):
+        with self.assertRaises(AttributeError):
             FilterableSubclass().satisfies(filter_name="boogaloo__is_a_dance", filter_value=True)
 
     def test_error_raised_when_valid_but_non_existent_filter_name_received(self):

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -33,6 +33,12 @@ class TestFilterSet(BaseTestCase):
         sorted_filter_set = FilterSet(cats).order_by("age")
         self.assertEqual(sorted_filter_set, FilterList(reversed(cats)))
 
+    def test_order_by_in_reverse(self):
+        """ Test ordering in reverse works correctly. """
+        cats = [Cat(age=5), Cat(age=3), Cat(age=4)]
+        sorted_filter_set = FilterSet(cats).order_by("age", reverse=True)
+        self.assertEqual(sorted_filter_set, FilterList([cats[0], cats[2], cats[1]]))
+
     def test_order_by_iterable(self):
         """ Test that ordering by list attributes orders by the size of the list. """
         cats = [Cat(previous_names=["Scatta", "Catta"]), Cat(previous_names=["Kitty"]), Cat(previous_names=[])]

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -15,22 +15,26 @@ class Cat(Filterable):
 
 
 class TestFilterSet(BaseTestCase):
-    def test_order_by_with_string_attribute(self):
-        """ Test ordering a FilterSet by a string attribute. """
-        cats = [Cat(name="Zorg"), Cat(name="James"), Cat(name="Princess Carolyne")]
-        filter_set = FilterSet(cats)
-        sorted_filter_set = filter_set.order_by("name")
-        self.assertEqual(sorted_filter_set, FilterList([cats[1], cats[2], cats[0]]))
-
-    def test_order_by_with_int_attribute(self):
-        """ Test ordering a FilterSet by an integer attribute. """
-        cats = [Cat(age=5), Cat(age=4), Cat(age=3)]
-        filter_set = FilterSet(cats)
-        sorted_filter_set = filter_set.order_by("age")
-        self.assertEqual(sorted_filter_set, FilterList([cats[2], cats[1], cats[0]]))
-
     def test_ordering_by_a_non_existent_attribute(self):
         """ Ensure an error is raised if ordering is attempted by a non-existent attribute. """
         filter_set = FilterSet([Cat(age=5), Cat(age=4), Cat(age=3)])
         with self.assertRaises(exceptions.InvalidInputException):
             filter_set.order_by("dog-likeness")
+
+    def test_order_by_with_string_attribute(self):
+        """ Test ordering a FilterSet by a string attribute returns an appropriately ordered FilterList. """
+        cats = [Cat(name="Zorg"), Cat(name="James"), Cat(name="Princess Carolyn")]
+        sorted_filter_set = FilterSet(cats).order_by("name")
+        self.assertEqual(sorted_filter_set, FilterList([cats[1], cats[2], cats[0]]))
+
+    def test_order_by_with_int_attribute(self):
+        """ Test ordering a FilterSet by an integer attribute returns an appropriately ordered FilterList. """
+        cats = [Cat(age=5), Cat(age=4), Cat(age=3)]
+        sorted_filter_set = FilterSet(cats).order_by("age")
+        self.assertEqual(sorted_filter_set, FilterList(reversed(cats)))
+
+    def test_order_by_iterable(self):
+        """ Test that ordering by list attributes orders by the size of the list. """
+        cats = [Cat(previous_names=["Scatta", "Catta"]), Cat(previous_names=["Kitty"]), Cat(previous_names=[])]
+        sorted_filter_set = FilterSet(cats).order_by("previous_names")
+        self.assertEqual(sorted_filter_set, FilterList(reversed(cats)))

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -6,12 +6,10 @@ from octue.resources.filter_containers import FilterList, FilterSet
 
 
 class Cat(Filterable):
-    def __init__(self, name=None, is_alive=None, previous_names=None, age=None, owner=None):
+    def __init__(self, name=None, previous_names=None, age=None):
         self.name = name
-        self.is_alive = is_alive
         self.previous_names = previous_names
         self.age = age
-        self.owner = owner
 
 
 class TestFilterSet(BaseTestCase):
@@ -33,7 +31,7 @@ class TestFilterSet(BaseTestCase):
         sorted_filter_set = FilterSet(cats).order_by("age")
         self.assertEqual(sorted_filter_set, FilterList(reversed(cats)))
 
-    def test_order_by_iterable(self):
+    def test_order_by_list_attribute(self):
         """ Test that ordering by list attributes orders by the size of the list. """
         cats = [Cat(previous_names=["Scatta", "Catta"]), Cat(previous_names=["Kitty"]), Cat(previous_names=[])]
         sorted_filter_set = FilterSet(cats).order_by("previous_names")

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -33,14 +33,14 @@ class TestFilterSet(BaseTestCase):
         sorted_filter_set = FilterSet(cats).order_by("age")
         self.assertEqual(sorted_filter_set, FilterList(reversed(cats)))
 
-    def test_order_by_in_reverse(self):
-        """ Test ordering in reverse works correctly. """
-        cats = [Cat(age=5), Cat(age=3), Cat(age=4)]
-        sorted_filter_set = FilterSet(cats).order_by("age", reverse=True)
-        self.assertEqual(sorted_filter_set, FilterList([cats[0], cats[2], cats[1]]))
-
     def test_order_by_iterable(self):
         """ Test that ordering by list attributes orders by the size of the list. """
         cats = [Cat(previous_names=["Scatta", "Catta"]), Cat(previous_names=["Kitty"]), Cat(previous_names=[])]
         sorted_filter_set = FilterSet(cats).order_by("previous_names")
         self.assertEqual(sorted_filter_set, FilterList(reversed(cats)))
+
+    def test_order_by_in_reverse(self):
+        """ Test ordering in reverse works correctly. """
+        cats = [Cat(age=5), Cat(age=3), Cat(age=4)]
+        sorted_filter_set = FilterSet(cats).order_by("age", reverse=True)
+        self.assertEqual(sorted_filter_set, FilterList([cats[0], cats[2], cats[1]]))

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -1,0 +1,36 @@
+from tests.base import BaseTestCase
+
+from octue import exceptions
+from octue.mixins import Filterable
+from octue.resources.filter_containers import FilterList, FilterSet
+
+
+class Cat(Filterable):
+    def __init__(self, name=None, is_alive=None, previous_names=None, age=None, owner=None):
+        self.name = name
+        self.is_alive = is_alive
+        self.previous_names = previous_names
+        self.age = age
+        self.owner = owner
+
+
+class TestFilterSet(BaseTestCase):
+    def test_order_by_with_string_attribute(self):
+        """ Test ordering a FilterSet by a string attribute. """
+        cats = [Cat(name="Zorg"), Cat(name="James"), Cat(name="Princess Carolyne")]
+        filter_set = FilterSet(cats)
+        sorted_filter_set = filter_set.order_by("name")
+        self.assertEqual(sorted_filter_set, FilterList([cats[1], cats[2], cats[0]]))
+
+    def test_order_by_with_int_attribute(self):
+        """ Test ordering a FilterSet by an integer attribute. """
+        cats = [Cat(age=5), Cat(age=4), Cat(age=3)]
+        filter_set = FilterSet(cats)
+        sorted_filter_set = filter_set.order_by("age")
+        self.assertEqual(sorted_filter_set, FilterList([cats[2], cats[1], cats[0]]))
+
+    def test_ordering_by_a_non_existent_attribute(self):
+        """ Ensure an error is raised if ordering is attempted by a non-existent attribute. """
+        filter_set = FilterSet([Cat(age=5), Cat(age=4), Cat(age=3)])
+        with self.assertRaises(exceptions.InvalidInputException):
+            filter_set.order_by("dog-likeness")


### PR DESCRIPTION
## Contents

### New Features

- [x] Close #8 - `order_by` filtering for `Dataset` files
- [x] WIP #6  - Queryset for dataset files, chainable filters

### Minor fixes and improvements

- [x] Raise a more helpful error message if trying to filter by a non-existent attribute of an item in a filter container


## Quality Checklist

- [x] New features are fully tested (No matter how much Coverage Karma you have)

## Comments
* I don't think there's any need for a `yield` method as you can already yield from both a set and a list and they also already exist in memory so there's no benefit to returning a generator from them. Let me know if I've got the wrong end of the stick here