### PR TITLE
Refactor: Rename TagGroup to TagSet

### DIFF
--- a/octue/mixins/filterable.py
+++ b/octue/mixins/filterable.py
@@ -29,7 +29,7 @@ TYPE_FILTERS = {
         **CONTAINS_FILTER_ACTIONS,
     },
     "NoneType": IS_FILTER_ACTIONS,
-    "TagGroup": {
+    "TagSet": {
         "starts_with": lambda item, filter_value: item.starts_with(filter_value),
         "ends_with": lambda item, filter_value: item.ends_with(filter_value),
         **EQUALS_FILTER_ACTION,

--- a/octue/mixins/taggable.py
+++ b/octue/mixins/taggable.py
@@ -1,4 +1,4 @@
-from octue.resources.tag import TagGroup
+from octue.resources.tag import TagSet
 
 
 class Taggable:
@@ -8,7 +8,7 @@ class Taggable:
         """ Constructor for Taggable mixins
         """
         super().__init__(*args, **kwargs)
-        self._tags = TagGroup(tags)
+        self._tags = TagSet(tags)
 
     def add_tags(self, *args):
         """ Adds one or more new tag strings to the object tags. New tags will be cleaned and validated. """
@@ -20,5 +20,5 @@ class Taggable:
 
     @tags.setter
     def tags(self, tags):
-        """ Overwrite any existing tag group and assign new tags. """
-        self._tags = TagGroup(tags)
+        """ Overwrite any existing tag set and assign new tags. """
+        self._tags = TagSet(tags)

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -27,8 +27,8 @@ class Tag(Filterable):
     @property
     @lru_cache(maxsize=1)
     def subtags(self):
-        """ Return the subtags of the tag as a new TagGroup (e.g. TagGroup({'a', 'b', 'c'}) for the Tag('a:b:c'). """
-        return TagGroup({Tag(subtag_name) for subtag_name in (self.name.split(":"))})
+        """ Return the subtags of the tag as a new TagSet (e.g. TagSet({'a', 'b', 'c'}) for the Tag('a:b:c'). """
+        return TagSet({Tag(subtag_name) for subtag_name in (self.name.split(":"))})
 
     def __eq__(self, other):
         if isinstance(other, str):
@@ -84,13 +84,13 @@ class Tag(Filterable):
         return cleaned_name
 
 
-class TagGroup:
-    """ Class to handle a group of tags as a string. """
+class TagSet:
+    """ Class to handle a set of tags as a string. """
 
     _FILTERSET_ATTRIBUTE = "tags"
 
     def __init__(self, tags=None, *args, **kwargs):
-        """ Construct a TagGroup. """
+        """ Construct a TagSet. """
         # TODO Call the superclass with *args anad **kwargs, then update everything to using ResourceBase
         tags = tags or FilterSet()
 
@@ -98,7 +98,7 @@ class TagGroup:
         if isinstance(tags, str):
             self.tags = FilterSet(Tag(tag) for tag in tags.strip().split())
 
-        elif isinstance(tags, TagGroup):
+        elif isinstance(tags, TagSet):
             self.tags = FilterSet(tags.tags)
 
         # Tags can be some other iterable than a list, but each tag must be a Tag or string.
@@ -115,20 +115,20 @@ class TagGroup:
         return self.serialise()
 
     def __eq__(self, other):
-        """ Does this TagGroup have the same tags as another TagGroup? """
-        if not isinstance(other, TagGroup):
+        """ Does this TagSet have the same tags as another TagSet? """
+        if not isinstance(other, TagSet):
             return False
         return self.tags == other.tags
 
     def __iter__(self):
-        """ Iterate over the tags in the TagGroup. """
+        """ Iterate over the tags in the TagSet. """
         yield from self.tags
 
     def __len__(self):
         return len(self.tags)
 
     def __repr__(self):
-        return f"<TagGroup({self.tags})>"
+        return f"<TagSet({self.tags})>"
 
     def add_tags(self, *args):
         """ Adds one or more new tag strings to the object tags. New tags will be cleaned and validated.
@@ -136,13 +136,13 @@ class TagGroup:
         self.tags |= {Tag(arg) for arg in args}
 
     def has_tag(self, tag):
-        """ Returns true if any of the tags exactly matches value, allowing test like `if 'a' in TagGroup('a b')`
+        """ Returns true if any of the tags exactly matches value, allowing test like `if 'a' in TagSet('a b')`
         """
         return tag in self or Tag(tag) in self
 
     def get_subtags(self):
-        """ Return a new TagGroup instance with all the subtags. """
-        return TagGroup(subtag for tag in self for subtag in tag.subtags)
+        """ Return a new TagSet instance with all the subtags. """
+        return TagSet(subtag for tag in self for subtag in tag.subtags)
 
     def starts_with(self, value):
         """ Implement a startswith method that returns true if any of the tags starts with value """

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -2,7 +2,7 @@ from tests.base import BaseTestCase
 
 from octue import exceptions
 from octue.mixins.filterable import Filterable
-from octue.resources.tag import TagGroup
+from octue.resources.tag import TagSet
 
 
 class FilterableSubclass(Filterable):
@@ -98,9 +98,9 @@ class TestFilterable(BaseTestCase):
             self.assertTrue(filterable_thing.satisfies("iterable__is_not", None))
             self.assertFalse(filterable_thing.satisfies("iterable__is_not", iterable))
 
-    def test_tag_group_filters(self):
-        """ Test the filters for TagGroup. """
-        filterable_thing = FilterableSubclass(iterable=TagGroup({"fred", "charlie"}))
+    def test_tag_set_filters(self):
+        """ Test the filters for TagSet. """
+        filterable_thing = FilterableSubclass(iterable=TagSet({"fred", "charlie"}))
         self.assertTrue(filterable_thing.satisfies("iterable__starts_with", "f"))
         self.assertFalse(filterable_thing.satisfies("iterable__starts_with", "e"))
         self.assertTrue(filterable_thing.satisfies("iterable__ends_with", "e"))

--- a/tests/mixins/test_taggable.py
+++ b/tests/mixins/test_taggable.py
@@ -1,6 +1,6 @@
 from octue import exceptions
 from octue.mixins import MixinBase, Taggable
-from octue.resources.tag import Tag, TagGroup
+from octue.resources.tag import Tag, TagSet
 from ..base import BaseTestCase
 
 
@@ -29,11 +29,11 @@ class TaggableTestCase(BaseTestCase):
         with self.assertRaises(exceptions.InvalidTagException):
             MyTaggable(tags=":a b c")
 
-    def test_instantiates_with_tag_group(self):
+    def test_instantiates_with_tag_set(self):
         """ Ensures datafile inherits correctly from the Taggable class and passes arguments through
         """
         taggable_1 = MyTaggable(tags="")
-        self.assertIsInstance(taggable_1.tags, TagGroup)
+        self.assertIsInstance(taggable_1.tags, TagSet)
         taggable_2 = MyTaggable(tags=taggable_1.tags)
         self.assertFalse(taggable_1 is taggable_2)
 

--- a/tests/resources/test_tag.py
+++ b/tests/resources/test_tag.py
@@ -1,13 +1,13 @@
 from tests.base import BaseTestCase
 
 from octue.resources.filter_containers import FilterSet
-from octue.resources.tag import Tag, TagGroup
+from octue.resources.tag import Tag, TagSet
 
 
 class TestTag(BaseTestCase):
     def test_subtags(self):
         """ Test that subtags are correctly parsed from tags. """
-        self.assertEqual(Tag("a:b:c").subtags, TagGroup({Tag("a"), Tag("b"), Tag("c")}))
+        self.assertEqual(Tag("a:b:c").subtags, TagSet({Tag("a"), Tag("b"), Tag("c")}))
 
     def test_tag_comparison(self):
         """ Test that tags can be alphabetically compared. """
@@ -57,134 +57,134 @@ class TestTag(BaseTestCase):
         self.assertFalse(Tag("hello:world").subtags.ends_with("e"))
 
 
-class TestTagGroup(BaseTestCase):
-    TAG_GROUP = TagGroup(tags="a b:c d:e:f")
+class TestTagSet(BaseTestCase):
+    TAG_SET = TagSet(tags="a b:c d:e:f")
 
     def test_instantiation_from_space_delimited_string(self):
-        """ Test that a TagGroup can be instantiated from a space-delimited string of tag names."""
-        tag_group = TagGroup(tags="a b:c d:e:f")
-        self.assertEqual(tag_group.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
+        """ Test that a TagSet can be instantiated from a space-delimited string of tag names."""
+        tag_set = TagSet(tags="a b:c d:e:f")
+        self.assertEqual(tag_set.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
 
     def test_instantiation_from_iterable_of_strings(self):
-        """ Test that a TagGroup can be instantiated from an iterable of strings."""
-        tag_group = TagGroup(tags=["a", "b:c", "d:e:f"])
-        self.assertEqual(tag_group.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
+        """ Test that a TagSet can be instantiated from an iterable of strings."""
+        tag_set = TagSet(tags=["a", "b:c", "d:e:f"])
+        self.assertEqual(tag_set.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
 
     def test_instantiation_from_iterable_of_tags(self):
-        """ Test that a TagGroup can be instantiated from an iterable of Tags."""
-        tag_group = TagGroup(tags=[Tag("a"), Tag("b:c"), Tag("d:e:f")])
-        self.assertEqual(tag_group.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
+        """ Test that a TagSet can be instantiated from an iterable of Tags."""
+        tag_set = TagSet(tags=[Tag("a"), Tag("b:c"), Tag("d:e:f")])
+        self.assertEqual(tag_set.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
 
     def test_instantiation_from_filter_set_of_strings(self):
-        """ Test that a TagGroup can be instantiated from a FilterSet of strings."""
-        tag_group = TagGroup(tags=FilterSet({"a", "b:c", "d:e:f"}))
-        self.assertEqual(tag_group.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
+        """ Test that a TagSet can be instantiated from a FilterSet of strings."""
+        tag_set = TagSet(tags=FilterSet({"a", "b:c", "d:e:f"}))
+        self.assertEqual(tag_set.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
 
     def test_instantiation_from_filter_set_of_tags(self):
-        """ Test that a TagGroup can be instantiated from a FilterSet of Tags."""
-        tag_group = TagGroup(tags=FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
-        self.assertEqual(tag_group.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
+        """ Test that a TagSet can be instantiated from a FilterSet of Tags."""
+        tag_set = TagSet(tags=FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
+        self.assertEqual(tag_set.tags, FilterSet({Tag("a"), Tag("b:c"), Tag("d:e:f")}))
 
-    def test_instantiation_from_tag_group(self):
-        """ Test that a TagGroup can be instantiated from another TagGroup. """
-        self.assertEqual(self.TAG_GROUP, TagGroup(self.TAG_GROUP))
+    def test_instantiation_from_tag_set(self):
+        """ Test that a TagSet can be instantiated from another TagSet. """
+        self.assertEqual(self.TAG_SET, TagSet(self.TAG_SET))
 
     def test_equality(self):
-        """ Ensure two TagGroups with the same tags compare equal. """
-        self.assertTrue(self.TAG_GROUP == TagGroup(tags="a b:c d:e:f"))
+        """ Ensure two TagSets with the same tags compare equal. """
+        self.assertTrue(self.TAG_SET == TagSet(tags="a b:c d:e:f"))
 
     def test_inequality(self):
-        """ Ensure two TagGroups with different tags compare unequal. """
-        self.assertTrue(self.TAG_GROUP != TagGroup(tags="a"))
+        """ Ensure two TagSets with different tags compare unequal. """
+        self.assertTrue(self.TAG_SET != TagSet(tags="a"))
 
-    def test_non_tag_groups_compare_unequal_to_tag_groups(self):
-        """ Ensure a TagGroup and a non-TagGroup compare unequal. """
-        self.assertFalse(self.TAG_GROUP == "a")
-        self.assertTrue(self.TAG_GROUP != "a")
+    def test_non_tag_sets_compare_unequal_to_tag_sets(self):
+        """ Ensure a TagSet and a non-TagSet compare unequal. """
+        self.assertFalse(self.TAG_SET == "a")
+        self.assertTrue(self.TAG_SET != "a")
 
     def test_iterating_over(self):
-        """ Ensure a TagGroup can be iterated over. """
-        self.assertEqual(set(self.TAG_GROUP), {Tag("a"), Tag("b:c"), Tag("d:e:f")})
+        """ Ensure a TagSet can be iterated over. """
+        self.assertEqual(set(self.TAG_SET), {Tag("a"), Tag("b:c"), Tag("d:e:f")})
 
     def test_has_tag(self):
-        """ Ensure we can check that a TagGroup has a certain tag. """
-        self.assertTrue(self.TAG_GROUP.has_tag("d:e:f"))
+        """ Ensure we can check that a TagSet has a certain tag. """
+        self.assertTrue(self.TAG_SET.has_tag("d:e:f"))
 
     def test_does_not_have_tag(self):
-        """ Ensure we can check that a TagGroup does not have a certain tag. """
-        self.assertFalse(self.TAG_GROUP.has_tag("hello"))
+        """ Ensure we can check that a TagSet does not have a certain tag. """
+        self.assertFalse(self.TAG_SET.has_tag("hello"))
 
     def test_has_tag_only_matches_full_tags(self):
         """ Test that the has_tag method only matches full tags (i.e. that it doesn't match subtags or parts of tags."""
         for tag in "a", "b:c", "d:e:f":
-            self.assertTrue(self.TAG_GROUP.has_tag(tag))
+            self.assertTrue(self.TAG_SET.has_tag(tag))
 
         for tag in "b", "c", "d", "e", "f":
-            self.assertFalse(self.TAG_GROUP.has_tag(tag))
+            self.assertFalse(self.TAG_SET.has_tag(tag))
 
     def test_get_subtags(self):
-        """ Test subtags can be accessed as a new TagGroup. """
-        self.assertEqual(TagGroup("meta:sys2:3456 blah").get_subtags(), TagGroup("meta sys2 3456 blah"))
+        """ Test subtags can be accessed as a new TagSet. """
+        self.assertEqual(TagSet("meta:sys2:3456 blah").get_subtags(), TagSet("meta sys2 3456 blah"))
 
     def test_starts_with(self):
         """ Ensure starts_with only checks the starts of tags, and doesn't check the starts of subtags. """
         for tag in "a", "b", "d":
-            self.assertTrue(self.TAG_GROUP.starts_with(tag))
+            self.assertTrue(self.TAG_SET.starts_with(tag))
 
         for tag in "c", "e", "f":
-            self.assertFalse(self.TAG_GROUP.starts_with(tag))
+            self.assertFalse(self.TAG_SET.starts_with(tag))
 
     def test_ends_swith(self):
         """ Ensure ends_with doesn't check ends of subtags. """
         for tag in "a", "c", "f":
-            self.assertTrue(self.TAG_GROUP.ends_with(tag))
+            self.assertTrue(self.TAG_SET.ends_with(tag))
 
         for tag in "b", "d", "e":
-            self.assertFalse(self.TAG_GROUP.ends_with(tag))
+            self.assertFalse(self.TAG_SET.ends_with(tag))
 
     def test_contains_searches_for_tags_and_subtags(self):
         """ Ensure tags and subtags can be searched for. """
         for tag in "a", "b", "d":
-            self.assertTrue(self.TAG_GROUP.any_tag_contains(tag))
+            self.assertTrue(self.TAG_SET.any_tag_contains(tag))
 
         for subtag in "c", "e", "f":
-            self.assertTrue(self.TAG_GROUP.any_tag_contains(subtag))
+            self.assertTrue(self.TAG_SET.any_tag_contains(subtag))
 
     def test_filter(self):
-        """ Test that tag groups can be filtered. """
-        tag_group = TagGroup(tags="tag1 tag2 meta:sys1:1234 meta:sys2:3456 meta:sys2:55")
+        """ Test that tag sets can be filtered. """
+        tag_set = TagSet(tags="tag1 tag2 meta:sys1:1234 meta:sys2:3456 meta:sys2:55")
         self.assertEqual(
-            tag_group.tags.filter("name__starts_with", "meta"),
+            tag_set.tags.filter("name__starts_with", "meta"),
             FilterSet({Tag("meta:sys1:1234"), Tag("meta:sys2:3456"), Tag("meta:sys2:55")}),
         )
 
     def test_filter_chaining(self):
         """ Test that filters can be chained. """
-        tag_group = TagGroup(tags="tag1 tag2 meta:sys1:1234 meta:sys2:3456 meta:sys2:55")
+        tag_set = TagSet(tags="tag1 tag2 meta:sys1:1234 meta:sys2:3456 meta:sys2:55")
 
-        filtered_tags_1 = tag_group.tags.filter("name__starts_with", "meta")
-        self.assertEqual(filtered_tags_1, TagGroup("meta:sys1:1234 meta:sys2:3456 meta:sys2:55").tags)
+        filtered_tags_1 = tag_set.tags.filter("name__starts_with", "meta")
+        self.assertEqual(filtered_tags_1, TagSet("meta:sys1:1234 meta:sys2:3456 meta:sys2:55").tags)
 
         filtered_tags_2 = filtered_tags_1.filter("name__contains", "sys2")
-        self.assertEqual(filtered_tags_2, TagGroup("meta:sys2:3456 meta:sys2:55").tags)
+        self.assertEqual(filtered_tags_2, TagSet("meta:sys2:3456 meta:sys2:55").tags)
 
         filtered_tags_3 = filtered_tags_1.filter("name__equals", "meta:sys2:55")
-        self.assertEqual(filtered_tags_3, TagGroup("meta:sys2:55").tags)
+        self.assertEqual(filtered_tags_3, TagSet("meta:sys2:55").tags)
 
     def test_serialise(self):
-        """ Ensure that TagGroups are serialised to the string form of a list. """
-        self.assertEqual(self.TAG_GROUP.serialise(), "['a', 'b:c', 'd:e:f']")
+        """ Ensure that TagSets are serialised to the string form of a list. """
+        self.assertEqual(self.TAG_SET.serialise(), "['a', 'b:c', 'd:e:f']")
 
     def test_serialise_orders_tags(self):
-        """ Ensure that TagGroups are serialised to the string form of a list. """
-        tag_group = TagGroup("z hello a c:no")
-        self.assertEqual(tag_group.serialise(), "['a', 'c:no', 'hello', 'z']")
+        """ Ensure that TagSets are serialised to the string form of a list. """
+        tag_set = TagSet("z hello a c:no")
+        self.assertEqual(tag_set.serialise(), "['a', 'c:no', 'hello', 'z']")
 
     def test_str_is_equivalent_to_serialise(self):
-        """ Test that calling `str` on a TagGroup is equivalent to using the `serialise` method. """
-        tag_group = TagGroup("z hello a c:no")
-        self.assertEqual(str(tag_group), tag_group.serialise())
+        """ Test that calling `str` on a TagSet is equivalent to using the `serialise` method. """
+        tag_set = TagSet("z hello a c:no")
+        self.assertEqual(str(tag_set), tag_set.serialise())
 
     def test_repr(self):
-        """ Test the representation of a TagGroup appears as expected. """
-        self.assertEqual(repr(self.TAG_GROUP), f"<TagGroup({repr(self.TAG_GROUP.tags)})>")
+        """ Test the representation of a TagSet appears as expected. """
+        self.assertEqual(repr(self.TAG_SET), f"<TagSet({repr(self.TAG_SET.tags)})>")


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Rename `TagGroup` to `TagSet` to reflect that it is a set and not a group

## Quality Checklist

- [x] New features are fully tested (No matter how much Coverage Karma you have)