### PR TITLE
Fix sphinx documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,11 @@ repos:
     rev: 0.0.1
     hooks:
       - id: build-docs
+        language_version: python3
         additional_dependencies:
+          - 'Sphinx>=2,<3'
+          - 'sphinx-rtd-theme==0.5.0'
+          - 'sphinx-tabs==1.2.1'
           - 'scipy~=1.5.2'
           - 'jsonschema~=3.2.0'
 

--- a/README.md
+++ b/README.md
@@ -9,19 +9,10 @@
 
 Utilities for running python based data services, digital twins and applications with the Octue toolkit and [twined](https://twined.readthedocs.io/en/latest/?badge=latest) SDK for python based apps running within octue.
 
-[See documentation.](https://octue-python-sdk.readthedocs.io/en/latest/)
-
 
 ## Developer notes
 
-**Documentation for use of the library is [here](https://{{library_name}}.readthedocs.io). You don't need to pay attention to the following unless you plan to develop {{library_name}} itself.**
-
-### Getting started
-
-1. Click 'use this template' to the top right, and away you go.
-2. Search for `{{` in your new repository. Do search and replace for the various terms - it's obvious what they are, like replace `{{github_username}}` with your github username!
-3. Set up the license you need in `LICENSE`.
-4. If you need to deploy to pypi, you have to do the first deploy manually - travis can't do that for you. [See the packaging instructions](https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi).
+**Documentation for use of the library is [here](https://octue-python-sdk.readthedocs.io). You don't need to pay attention to the following unless you plan to develop `octue-sdk-python` itself.**
 
 ### Pre-Commit
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/octue.svg)](https://badge.fury.io/py/octue)
 [![codecov](https://codecov.io/gh/octue/octue-sdk-python/branch/main/graph/badge.svg?token=4KdR7fmwcT)](https://codecov.io/gh/octue/octue-sdk-python)
-[![Documentation Status](https://readthedocs.org/projects/octue/badge/?version=latest)](https://octue.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/octue/badge/?version=latest)](https://octue-python-sdk.readthedocs.io/en/latest/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![black-girls-code](https://img.shields.io/badge/black%20girls-code-f64279.svg)](https://www.blackgirlscode.com/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI version](https://badge.fury.io/py/octue.svg)](https://badge.fury.io/py/octue)
 [![codecov](https://codecov.io/gh/octue/octue-sdk-python/branch/main/graph/badge.svg?token=4KdR7fmwcT)](https://codecov.io/gh/octue/octue-sdk-python)
-[![Documentation Status](https://readthedocs.org/projects/octue/badge/?version=latest)](https://octue-python-sdk.readthedocs.io/en/latest/)
+[![Documentation Status](https://readthedocs.org/projects/octue-python-sdk/badge/?version=latest)](https://octue-python-sdk.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![black-girls-code](https://img.shields.io/badge/black%20girls-code-f64279.svg)](https://www.blackgirlscode.com/)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 # octue-sdk-python <span><img src="http://slurmed.com/fanart/javier/213_purple-fruit-snake.gif" alt="Purple Fruit Snake" width="100"/></span>
 
-Utilities for running python based data services, digital twins and applications with the Octue toolkit and [twined](https://www.twined.readthedocs.io) SDK for python based apps running within octue.
+Utilities for running python based data services, digital twins and applications with the Octue toolkit and [twined](https://twined.readthedocs.io/en/latest/?badge=latest) SDK for python based apps running within octue.
 
-[See documentation.](https://octue.readthedocs.io/en/latest)
+[See documentation.](https://octue-python-sdk.readthedocs.io/en/latest/)
 
 
 ## Developer notes

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 
 # Required by the python script for building documentation
-Sphinx==1.8.3
-sphinx-rtd-theme==0.4.2
-sphinx-tabs==1.1.10
+Sphinx>=2,<3
+sphinx-rtd-theme==0.5.0
+sphinx-tabs==1.2.1
 breathe==4.11.1
 exhale==0.2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,3 @@
 Sphinx>=2,<3
 sphinx-rtd-theme==0.5.0
 sphinx-tabs==1.2.1
-breathe==4.11.1
-exhale==0.2.1


### PR DESCRIPTION
## Contents

### Fixes
* Fix links to documentation in README
* Remove generic content from README

### Other fixes outside of the code
The main fixes to get the docs working were carried out in the admin interface of ReadTheDocs:
* Untick "Install project" in the advanced settings
* Set the default branch to `main` rather than `master` (since we've renamed our base branch)

I also stopped the building of epub and pdf docs as we're not using them.

### Issues
- [x] Close #70 