### PR TITLE
Fix: Send output of CLI tests to temporary directory

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from unittest import mock
 from click.testing import CliRunner
 from tests import TESTS_DIR
@@ -27,45 +28,51 @@ class RunnerTestCase(BaseTestCase):
 
     def test_run_command_can_be_added(self):
         """Test that an arbitrary run command can be used in the run command of the CLI."""
-        result = CliRunner().invoke(
-            octue_cli,
-            [
-                "run",
-                f"--app-dir={TESTS_DIR}",
-                f"--twine={self.TWINE_FILE_PATH}",
-                f'--config-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "configuration")}',
-                f'--input-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "input")}',
-            ],
-        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = CliRunner().invoke(
+                octue_cli,
+                [
+                    "run",
+                    f"--app-dir={TESTS_DIR}",
+                    f"--twine={self.TWINE_FILE_PATH}",
+                    f'--config-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "configuration")}',
+                    f'--input-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "input")}',
+                    f"--output-dir={temporary_directory}",
+                ],
+            )
 
         assert CUSTOM_APP_RUN_MESSAGE in result.output
 
     def test_run_command_works_with_data_dir(self):
         """Test that the run command of the CLI works with the --data-dir option."""
-        result = CliRunner().invoke(
-            octue_cli,
-            [
-                "run",
-                f"--app-dir={TESTS_DIR}",
-                f"--twine={self.TWINE_FILE_PATH}",
-                f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
-            ],
-        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = CliRunner().invoke(
+                octue_cli,
+                [
+                    "run",
+                    f"--app-dir={TESTS_DIR}",
+                    f"--twine={self.TWINE_FILE_PATH}",
+                    f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
+                    f"--output-dir={temporary_directory}",
+                ],
+            )
 
         assert CUSTOM_APP_RUN_MESSAGE in result.output
 
     def test_remote_logger_uri_can_be_set(self):
         """Test that remote logger URI can be set via the CLI and that this is logged locally."""
-        with mock.patch("logging.StreamHandler.emit") as mock_local_logger_emit:
-            CliRunner().invoke(
-                octue_cli,
-                [
-                    "--logger-uri=wss://0.0.0.1:3000",
-                    "run",
-                    f"--app-dir={TESTS_DIR}",
-                    f"--twine={self.TWINE_FILE_PATH}",
-                    f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
-                ],
-            )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with mock.patch("logging.StreamHandler.emit") as mock_local_logger_emit:
+                CliRunner().invoke(
+                    octue_cli,
+                    [
+                        "--logger-uri=wss://0.0.0.1:3000",
+                        "run",
+                        f"--app-dir={TESTS_DIR}",
+                        f"--twine={self.TWINE_FILE_PATH}",
+                        f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
+                        f"--output-dir={temporary_directory}",
+                    ],
+                )
 
             mock_local_logger_emit.assert_called()


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Close #32 - stop CLI tests leaving output files in working area.


## Quality Checklist

- [x] New features are fully tested (No matter how much Coverage Karma you have)