### PR TITLE
Feature: Add option to handle developer logs separately

### DIFF
--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -1,6 +1,9 @@
+import logging
+
 from .cli import octue_cli
 from .logging_handlers import LOG_FORMAT
 from .runner import Runner
 
 
 __all__ = "LOG_FORMAT", "octue_cli", "Runner"
+package_logger = logging.getLogger(__name__)

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -37,6 +37,7 @@ global_cli_context = {}
 )
 @click.option(
     "--show-twined-logs",
+    is_flag=True,
     default=False,
     show_default=True,
     help="Show logs from the whole package in addition to logs just from your app.",

--- a/octue/logging_handlers.py
+++ b/octue/logging_handlers.py
@@ -4,7 +4,8 @@ from urllib.parse import urlparse
 
 
 # Logging format for analysis runs. All handlers should use this logging format, to make logs consistently parseable
-LOG_FORMAT = "%(name)s %(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"
+LOGGING_METADATA = " | ".join(("%(name)s", "%(levelname)s", "%(asctime)s", "%(module)s", "%(process)d", "%(thread)d"))
+LOG_FORMAT = "[" + LOGGING_METADATA + "]" + " %(message)s"
 
 
 def get_default_handler(log_level):

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -75,6 +75,10 @@ class Runner:
 
         if show_twined_logs:
             apply_log_handler(logger=package_logger, handler=self.handler, log_level=self._log_level)
+            package_logger.info(
+                "Showing package logs as well as analysis logs (the package logs are recommended for software "
+                "engineers but may still be useful to app development by scientists."
+            )
 
     @staticmethod
     def _update_manifest_path(manifest, pathname):

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 
-from octue.logging_handlers import get_default_handler
+from octue.logging_handlers import apply_log_handler
 from octue.resources.analysis import CLASS_MAP, Analysis
 from octue.utils import gen_uuid
 from twined import Twine
@@ -74,30 +74,7 @@ class Runner:
         self.handler = handler
 
         if show_twined_logs:
-            self._apply_log_handler(logger=package_logger, handler=self.handler)
-
-    def _apply_log_handler(self, logger, handler=None):
-        """ Create a logger specific to the analysis
-
-        :parameter analysis_id: The id of the analysis to get the log for. Should be unique to the analysis
-        :type analysis_id: str
-
-        :parameter handler: The handler to use. If None, default console handler will be attached.
-
-        :return: logger named in the pattern `analysis-{analysis_id}`
-        :rtype logging.Logger
-        """
-        handler = handler or get_default_handler(log_level=self._log_level)
-        logger.addHandler(handler)
-        logger.setLevel(self._log_level)
-        logger.info("Using local logger.")
-
-        # Log locally that a remote logger will be used from now on.
-        if type(logger.handlers[0]).__name__ == "SocketHandler":
-            local_logger = logging.getLogger(__name__)
-            local_logger.addHandler(get_default_handler(log_level=self._log_level))
-            local_logger.setLevel(self._log_level)
-            local_logger.info(f"Logs streaming to {logger.handlers[0].host + ':' + str(logger.handlers[0].port)}")
+            apply_log_handler(logger=package_logger, handler=self.handler, log_level=self._log_level)
 
     @staticmethod
     def _update_manifest_path(manifest, pathname):
@@ -193,7 +170,7 @@ class Runner:
 
         analysis_id = str(analysis_id) if analysis_id else gen_uuid()
         analysis_logger = logging.getLogger(f"analysis-{analysis_id}")
-        self._apply_log_handler(logger=analysis_logger, handler=self.handler)
+        apply_log_handler(logger=analysis_logger, handler=self.handler, log_level=self._log_level)
 
         analysis = Analysis(
             id=analysis_id,


### PR DESCRIPTION
### Minor fixes and improvements
* Add a package-level logger
* Add `--show-twined-logs` option to CLI so developers can also see logs from the SDK
* Move `handler` argument from `Runner.run` to `Runner` constructor
* Make log format more human readable


## Quality Checklist

- [x] New features are fully tested (No matter how much Coverage Karma you have)
