### PR TITLE
Devops: Use latest versions of flake8, isort, and black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,19 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.7.0
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         args: ['--line-length', '120']
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.4
     hooks:
       - id: flake8
         language_version: python3

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -54,7 +54,7 @@ global_cli_context = {}
 )
 @click.version_option(version=pkg_resources.get_distribution("octue").version)
 def octue_cli(id, skip_checks, logger_uri, log_level, show_twined_logs, force_reset):
-    """ Octue CLI, enabling a data service / digital twin to be run like a command line application.
+    """Octue CLI, enabling a data service / digital twin to be run like a command line application.
 
     When acting in CLI mode, results are read from and written to disk (see
     https://octue-python-sdk.readthedocs.io/en/latest/ for how to run your application directly without the CLI).
@@ -211,7 +211,10 @@ def start(app_dir, data_dir, config_dir, service_id, twine, timeout):
     )
 
     run_function = functools.partial(
-        runner.run, app_src=app_dir, children=children, skip_checks=global_cli_context["skip_checks"],
+        runner.run,
+        app_src=app_dir,
+        children=children,
+        skip_checks=global_cli_context["skip_checks"],
     )
 
     backend_configuration_values = runner.configuration["configuration_values"]["backend"]

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -1,82 +1,70 @@
 class OctueSDKException(Exception):
-    """ All exceptions from this library inherit from here
-    """
+    """All exceptions from this library inherit from here"""
 
 
 class InvalidInputException(OctueSDKException, ValueError):
-    """Raise when an object is instantiated or a function called with invalid inputs
-    """
+    """Raise when an object is instantiated or a function called with invalid inputs"""
 
 
 class FileNotFoundException(InvalidInputException, FileNotFoundError):
-    """ Raise when a required folder (e.g. <data_dir>/input) cannot be found
-    """
+    """Raise when a required folder (e.g. <data_dir>/input) cannot be found"""
 
 
 class ProtectedAttributeException(OctueSDKException, KeyError):
-    """ Raise when a user attempts to set an attribute whose value should be protected
-    """
+    """Raise when a user attempts to set an attribute whose value should be protected"""
 
 
 class FolderNotFoundException(InvalidInputException):
-    """ Raise when a multi manifest can not be refined to a single manifest in a search
-    """
+    """Raise when a multi manifest can not be refined to a single manifest in a search"""
 
 
 class ManifestNotFoundException(InvalidInputException):
-    """ Raise when a multi manifest can not be refined to a single manifest in a search
-    """
+    """Raise when a multi manifest can not be refined to a single manifest in a search"""
 
 
 class InvalidManifestException(InvalidInputException):
-    """Raise when a manifest loaded from JSON does not pass validation
-    """
+    """Raise when a manifest loaded from JSON does not pass validation"""
 
 
 class InvalidManifestTypeException(InvalidManifestException):
-    """Raised when user attempts to create a manifest of a type other than 'input', 'output' or 'build'
-    """
+    """Raised when user attempts to create a manifest of a type other than 'input', 'output' or 'build'"""
 
 
 class InvalidOctueFileTypeException(OctueSDKException):
-    """Raised when you attempt to register a file type in the results manifest that Octue doesn't know about
-    """
+    """Raised when you attempt to register a file type in the results manifest that Octue doesn't know about"""
 
 
 class InvalidFilePointerException(OctueSDKException):
-    """Raised when you attempt to create a Datafile with an object that is not file-like.
-    """
+    """Raised when you attempt to create a Datafile with an object that is not file-like."""
 
 
 class NotImplementedYetException(OctueSDKException):
-    """Raised when you attempt to use a function whose high-level API is in place, but which is not implemented yet
-    """
+    """Raised when you attempt to use a function whose high-level API is in place, but which is not implemented yet"""
 
 
 class UnexpectedNumberOfResultsException(OctueSDKException):
-    """ Raise when searching for a single data file (or a particular number of data files) and the number of results
+    """Raise when searching for a single data file (or a particular number of data files) and the number of results
     exceeds that expected
     """
 
 
 class BrokenSequenceException(OctueSDKException):
-    """ Raise when filtering for a sequence of files whose numbering does not start at 0, or does not monotonically
+    """Raise when filtering for a sequence of files whose numbering does not start at 0, or does not monotonically
     increase
     """
 
 
 class InvalidTagException(OctueSDKException, ValueError):
-    """ Raise when a tag applied to a data file or dataset
-    """
+    """Raise when a tag applied to a data file or dataset"""
 
 
 class ServiceNotFound(OctueSDKException):
-    """ Raise when a Service of the given ID has not been found on the Google Pub/Sub server (i.e. if there is no topic
+    """Raise when a Service of the given ID has not been found on the Google Pub/Sub server (i.e. if there is no topic
     associated with the Service ID).
     """
 
 
 class BackendNotFound(OctueSDKException):
-    """ Raise when details of a backend that doesn't exist in `octue.resources.service_backends` are given for use as a
+    """Raise when details of a backend that doesn't exist in `octue.resources.service_backends` are given for use as a
     Service backend.
     """

--- a/octue/logging_handlers.py
+++ b/octue/logging_handlers.py
@@ -9,7 +9,7 @@ LOG_FORMAT = "[" + LOGGING_METADATA + "]" + " %(message)s"
 
 
 def apply_log_handler(logger, handler=None, log_level=logging.INFO):
-    """ Create a logger specific to the analysis
+    """Create a logger specific to the analysis
 
     :parameter analysis_id: The id of the analysis to get the log for. Should be unique to the analysis
     :type analysis_id: str

--- a/octue/mixins/base.py
+++ b/octue/mixins/base.py
@@ -1,5 +1,5 @@
 class MixinBase:
-    """ Allows you to use any combination of mixin classes which pass unused *args and **kwargs up to their superclass,
+    """Allows you to use any combination of mixin classes which pass unused *args and **kwargs up to their superclass,
     without encountering:
     ```
     Error
@@ -15,8 +15,7 @@ class MixinBase:
     """
 
     def __init__(self, *args, **kwargs):
-        """ Constructor for ResourceBase
-        """
+        """Constructor for ResourceBase"""
         if (len(args) > 0) or (len(kwargs.keys()) > 0):
             raise TypeError("object.__init__() takes no parameters")
         super().__init__()

--- a/octue/mixins/filterable.py
+++ b/octue/mixins/filterable.py
@@ -88,7 +88,7 @@ class Filterable:
         return filter_(attribute, filter_value)
 
     def _split_filter_name(self, filter_name):
-        """ Split the filter name into the attribute name and filter action, raising an error if it the attribute name
+        """Split the filter name into the attribute name and filter action, raising an error if it the attribute name
         and filter action aren't delimited by a double underscore i.e. "__".
         """
         try:
@@ -102,7 +102,7 @@ class Filterable:
         return attribute_name, filter_action
 
     def _get_filter(self, attribute, filter_action):
-        """ Get the filter for the attribute and filter action, raising an error if there is no filter action of that
+        """Get the filter for the attribute and filter action, raising an error if there is no filter action of that
         name.
         """
         try:
@@ -116,7 +116,7 @@ class Filterable:
             )
 
     def _get_filter_actions_for_attribute(self, attribute):
-        """ Get the possible filters for the given attribute based on its type or interface, raising an error if the
+        """Get the possible filters for the given attribute based on its type or interface, raising an error if the
         attribute's type isn't supported (i.e. if there aren't any filters defined for it)."""
         try:
             return TYPE_FILTERS[type(attribute).__name__]

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -38,8 +38,8 @@ class Hashable:
         return self._calculate_hash()
 
     def _calculate_hash(self, hash_=None):
-        """ Calculate the BLAKE3 hash of the sorted attributes in self._ATTRIBUTES_TO_HASH. If hash_ is not None and is
-        a BLAKE3 hasher object, its in-progress hash will be updated, rather than starting from scratch. """
+        """Calculate the BLAKE3 hash of the sorted attributes in self._ATTRIBUTES_TO_HASH. If hash_ is not None and is
+        a BLAKE3 hasher object, its in-progress hash will be updated, rather than starting from scratch."""
         hash_ = hash_ or blake3()
 
         for attribute_name in sorted(self._ATTRIBUTES_TO_HASH):

--- a/octue/mixins/identifiable.py
+++ b/octue/mixins/identifiable.py
@@ -5,7 +5,7 @@ from octue.utils import gen_uuid
 
 
 class Identifiable:
-    """ Mixin to allow instantiation of a class with a given uuid, or generate one on instantiation
+    """Mixin to allow instantiation of a class with a given uuid, or generate one on instantiation
 
     Prevents setting an id after an object is instantiated.
 
@@ -22,8 +22,7 @@ class Identifiable:
     """
 
     def __init__(self, *args, id=None, **kwargs):
-        """ Constructor for Identifiable class
-        """
+        """Constructor for Identifiable class"""
         super().__init__(*args, **kwargs)
 
         # Store a boolean record of whether this object was created with a previously-existing uuid or was created new.

--- a/octue/mixins/loggable.py
+++ b/octue/mixins/loggable.py
@@ -2,7 +2,7 @@ import logging
 
 
 class Loggable:
-    """ Mixin to allow instantiation of a class with a logger, or by default use the module logger from that class
+    """Mixin to allow instantiation of a class with a logger, or by default use the module logger from that class
 
     The attached logger is a class variable, so all Resources of the same type inheriting from Loggable will share the
     same logger instance; this can be confusing if you overload __init_logger__ in multiple different ways.
@@ -22,8 +22,7 @@ class Loggable:
         self.__init_logger__(logger)
 
     def __init_logger__(self, logger=None):
-        """ Overload this in a subclass to initialise your own logger using class attributes
-        """
+        """Overload this in a subclass to initialise your own logger using class attributes"""
         self._logger = logger or logging.getLogger(self.__class__.__module__)
 
     @property

--- a/octue/mixins/pathable.py
+++ b/octue/mixins/pathable.py
@@ -4,15 +4,14 @@ from octue.exceptions import InvalidInputException
 
 
 class Pathable:
-    """ Mixin class to enable resources to get their path location from an owner.
+    """Mixin class to enable resources to get their path location from an owner.
 
     For example, datasets can get their path from the Manifest they belong to.
 
     """
 
     def __init__(self, *args, path=None, path_from=None, base_from=None, **kwargs):
-        """ Constructor for pathable mixin
-        """
+        """Constructor for pathable mixin"""
         super().__init__(*args, **kwargs)
 
         if (path_from is not None) and not isinstance(path_from, Pathable):
@@ -32,7 +31,7 @@ class Pathable:
 
     @property
     def _base_path(self):
-        """ Gets the absolute path of the base_from object, from which any relative paths are constructed
+        """Gets the absolute path of the base_from object, from which any relative paths are constructed
         :return:
         :rtype:
         """
@@ -43,7 +42,7 @@ class Pathable:
 
     @property
     def _path_prefix(self):
-        """ Gets the path prefix (this is the absolute_path of the owner path_from object).
+        """Gets the path prefix (this is the absolute_path of the owner path_from object).
         Defaults to the current working directory
         """
         if self._path_from is not None:
@@ -56,25 +55,22 @@ class Pathable:
 
     @property
     def absolute_path(self):
-        """ The absolute path of this resource
-        """
+        """The absolute path of this resource"""
         return os.path.normpath(os.path.join(self._path_prefix, self._path))
 
     @property
     def relative_path(self):
-        """ The path of this resource relative to its base path
-        """
+        """The path of this resource relative to its base path"""
         return os.path.relpath(self.absolute_path, self._base_path)
 
     @property
     def path(self):
-        """ The path of this resource
-        """
+        """The path of this resource"""
         return self._path
 
     @path.setter
     def path(self, value):
-        """ Set the path of this resource.
+        """Set the path of this resource.
 
         :param value: Path of the resource. If the resource was instantiated with a `path_from` object, this path must
         be relative. Otherwise, absolute paths are acceptable.

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -4,7 +4,7 @@ from octue.utils.encoders import OctueJSONEncoder
 
 
 class Serialisable:
-    """ Mixin class to make resources serialisable to JSON.
+    """Mixin class to make resources serialisable to JSON.
 
     Objects must have a `.logger` and a `.id` property
 
@@ -14,13 +14,12 @@ class Serialisable:
     _EXCLUDE_SERIALISE_FIELDS = ("logger",)
 
     def __init__(self, *args, **kwargs):
-        """ Constructor for serialisable mixin
-        """
+        """Constructor for serialisable mixin"""
         # Ensure it passes construction arguments up the chain
         super().__init__(*args, **kwargs)
 
     def to_file(self, file_name, **kwargs):
-        """ Write to a JSON file
+        """Write to a JSON file
 
         :parameter file_name:  file to write to, including relative or absolute path and .json extension
         :type file_name: path-like
@@ -30,7 +29,7 @@ class Serialisable:
             fp.write(self.serialise(**kwargs, to_string=True))
 
     def serialise(self, to_string=False, **kwargs):
-        """ Serialise into a primitive dict or JSON string
+        """Serialise into a primitive dict or JSON string
 
         Serialises all non-private and non-protected attributes except for 'logger', unless the subclass has a
         `_serialise_fields` tuple of the attribute names to serialise. For example:

--- a/octue/mixins/taggable.py
+++ b/octue/mixins/taggable.py
@@ -5,8 +5,7 @@ class Taggable:
     """ A mixin class allowing objects to be tagged. """
 
     def __init__(self, *args, tags=None, **kwargs):
-        """ Constructor for Taggable mixins
-        """
+        """Constructor for Taggable mixins"""
         super().__init__(*args, **kwargs)
         self._tags = TagSet(tags)
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -24,7 +24,7 @@ CLASS_MAP = {"configuration_manifest": Manifest, "input_manifest": Manifest, "ou
 
 
 class Analysis(Identifiable, Loggable, Serialisable, Taggable):
-    """ Analysis class, holding references to all input and output data
+    """Analysis class, holding references to all input and output data
 
     ## The Analysis Instance
 
@@ -55,8 +55,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Taggable):
     """
 
     def __init__(self, twine, skip_checks=False, **kwargs):
-        """ Constructor of Analysis instance
-        """
+        """Constructor of Analysis instance"""
 
         # Instantiate the twine (if not already) and attach it to self
         if not isinstance(twine, Twine):
@@ -83,7 +82,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Taggable):
         super().__init__(**kwargs)
 
     def finalise(self, output_dir=None):
-        """ Validates and serialises output_values and output_manifest, optionally writing them to files
+        """Validates and serialises output_values and output_manifest, optionally writing them to files
 
         If output_dir is given, then the serialised outputs are also written to files in the output directory
 

--- a/octue/resources/child.py
+++ b/octue/resources/child.py
@@ -6,7 +6,7 @@ BACKEND_TO_SERVICE_MAPPING = {service_backends.GCPPubSubBackend: Service}
 
 
 class Child:
-    """ A class representing a child service that can be asked questions. It is a convenience wrapper for `Service` that
+    """A class representing a child service that can be asked questions. It is a convenience wrapper for `Service` that
     makes the asking of questions more intuitive for Scientists and allows easier selection of backends.
     """
 
@@ -18,7 +18,7 @@ class Child:
         self._service = BACKEND_TO_SERVICE_MAPPING[type(backend)](backend=backend)
 
     def ask(self, input_values, input_manifest=None, timeout=20):
-        """ Ask the child a question (i.e. send it some input value and/or a manifest and wait for it to run an analysis
+        """Ask the child a question (i.e. send it some input value and/or a manifest and wait for it to run an analysis
         on them and return the output values). The input values given must adhere to the Twine file of the child.
         """
         subscription = self._service.ask(self.id, input_values, input_manifest)

--- a/octue/resources/communication/credentials.py
+++ b/octue/resources/communication/credentials.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class GCPCredentialsManager:
-    """ A credentials manager for Google Cloud Platform (GCP) that takes a JSON string from an environment variable and
+    """A credentials manager for Google Cloud Platform (GCP) that takes a JSON string from an environment variable and
     writes it to a file in a temporary directory.
     """
 
@@ -21,8 +21,8 @@ class GCPCredentialsManager:
             raise EnvironmentError(f"There is no environment variable called {self.environment_variable_name}.")
 
     def get_credentials(self):
-        """ Get the Google OAUTH2 service account credentials for which the environment variable value is either the
-        filename containing them or a JSON string version of them. """
+        """Get the Google OAUTH2 service account credentials for which the environment variable value is either the
+        filename containing them or a JSON string version of them."""
 
         # Check that the environment variable refers to a valid *and* real path.
         if os.path.exists(self.environment_variable_value):

--- a/octue/resources/communication/google_pub_sub/service.py
+++ b/octue/resources/communication/google_pub_sub/service.py
@@ -25,7 +25,7 @@ BATCH_SETTINGS = pubsub_v1.types.BatchSettings(max_bytes=10 * 1000 * 1000, max_l
 
 
 class Service(CoolNameable):
-    """ A Twined service that can be used in two modes:
+    """A Twined service that can be used in two modes:
     * As a server accepting questions (input values and manifests), running them through its app, and responding to the
     requesting service with the results of the analysis.
     * As a requester of answers from another Service in the above mode.
@@ -51,7 +51,7 @@ class Service(CoolNameable):
         return f"<{type(self).__name__}({self.name!r})>"
 
     def serve(self, timeout=None):
-        """ Start the Service as a server, waiting to accept questions from any other Service using Google Pub/Sub on
+        """Start the Service as a server, waiting to accept questions from any other Service using Google Pub/Sub on
         the same Google Cloud Platform project. Questions are responded to asynchronously."""
         topic = Topic(name=self.id, namespace=OCTUE_NAMESPACE, service=self)
         topic.create(allow_existing=True)
@@ -69,7 +69,7 @@ class Service(CoolNameable):
                 future.cancel()
 
     def answer(self, question):
-        """ Acknowledge and answer a question (i.e. receive the question (input values and/or manifest), run the
+        """Acknowledge and answer a question (i.e. receive the question (input values and/or manifest), run the
         Service's app to analyse it, and return the output values to the asker). Answers are published to a topic whose
         name is generated from the UUID sent with the question, and are in the format specified in the Service's Twine
         file.
@@ -98,7 +98,7 @@ class Service(CoolNameable):
         logger.info("%r responded on topic %r.", self, topic.path)
 
     def ask(self, service_id, input_values, input_manifest=None):
-        """ Ask a serving Service a question (i.e. send it input values for it to run its app on). The input values must
+        """Ask a serving Service a question (i.e. send it input values for it to run its app on). The input values must
         be in the format specified by the serving Service's Twine file. A single-use topic and subscription are created
         before sending the question to the serving Service - the topic is the expected publishing place for the answer
         from the serving Service when it comes, and the subscription is set up to subscribe to this.
@@ -114,7 +114,10 @@ class Service(CoolNameable):
         response_topic.create(allow_existing=False)
 
         response_subscription = Subscription(
-            name=response_topic_and_subscription_name, topic=response_topic, namespace=OCTUE_NAMESPACE, service=self,
+            name=response_topic_and_subscription_name,
+            topic=response_topic,
+            namespace=OCTUE_NAMESPACE,
+            service=self,
         )
         response_subscription.create(allow_existing=False)
 
@@ -132,11 +135,12 @@ class Service(CoolNameable):
         return response_subscription
 
     def wait_for_answer(self, subscription, timeout=20):
-        """ Wait for an answer to a question on the given subscription, deleting the subscription and its topic once
+        """Wait for an answer to a question on the given subscription, deleting the subscription and its topic once
         the answer is received.
         """
         answer = self.subscriber.pull(
-            request={"subscription": subscription.path, "max_messages": 1}, retry=retry.Retry(deadline=timeout),
+            request={"subscription": subscription.path, "max_messages": 1},
+            retry=retry.Retry(deadline=timeout),
         ).received_messages[0]
 
         self.subscriber.acknowledge(request={"subscription": subscription.path, "ack_ids": [answer.ack_id]})

--- a/octue/resources/communication/google_pub_sub/subscription.py
+++ b/octue/resources/communication/google_pub_sub/subscription.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class Subscription:
-    """ A candidate subscription to use with Google Pub/Sub. The subscription represented by an instance of this class
+    """A candidate subscription to use with Google Pub/Sub. The subscription represented by an instance of this class
     does not necessarily already exist on the Google Pub/Sub servers.
     """
 

--- a/octue/resources/communication/google_pub_sub/topic.py
+++ b/octue/resources/communication/google_pub_sub/topic.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class Topic:
-    """ A candidate topic to use with Google Pub/Sub. The topic represented by an instance of this class does not
+    """A candidate topic to use with Google Pub/Sub. The topic represented by an instance of this class does not
     necessarily already exist on the Google Pub/Sub servers.
     """
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -12,7 +12,7 @@ module_logger = logging.getLogger(__name__)
 
 
 class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable, Filterable):
-    """ Class for representing data files on the Octue system
+    """Class for representing data files on the Octue system
 
     Files in a manifest look like this:
 
@@ -76,8 +76,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
         skip_checks=True,
         **kwargs,
     ):
-        """ Construct a datafile
-        """
+        """Construct a datafile"""
         super().__init__(id=id, logger=logger, tags=tags, path=path, path_from=path_from, base_from=base_from)
 
         self.cluster = cluster
@@ -95,8 +94,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
             self.check(**kwargs)
 
     def _get_extension_from_path(self, path=None):
-        """ Gets extension of a file, either from a provided file path or from self.path field
-        """
+        """Gets extension of a file, either from a provided file path or from self.path field"""
         path = path or self.path
         return os.path.splitext(path)[-1].strip(".")
 
@@ -127,8 +125,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
         return super()._calculate_hash(hash)
 
     def check(self, size_bytes=None, sha=None, last_modified=None, extension=None):
-        """ Check file presence and integrity
-        """
+        """Check file presence and integrity"""
         # TODO Check consistency of size_bytes input against self.size_bytes property for a file if we have one
         # TODO Check consistency of sha against file contents if we have a file
         # TODO Check consistency of last_modified date
@@ -142,13 +139,12 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
             raise FileNotFoundException(f"No file found at {self.absolute_path}")
 
     def exists(self):
-        """ Returns true if the datafile exists on the current system, false otherwise
-        """
+        """Returns true if the datafile exists on the current system, false otherwise"""
         return isfile(self.absolute_path)
 
     @property
     def open(self):
-        """ Context manager to handle the opening and closing of a Datafile.
+        """Context manager to handle the opening and closing of a Datafile.
 
         If opened in write mode, the manager will attempt to determine if the folder path exists and, if not, will
         create the folder structure required to write the file.

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -12,7 +12,7 @@ module_logger = logging.getLogger(__name__)
 
 
 class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable):
-    """ A representation of a dataset, containing files, tags, etc
+    """A representation of a dataset, containing files, tags, etc
 
     This is used to read a list of files (and their associated properties) into octue analysis, or to compile a
     list of output files (results) and their properties that will be sent back to the octue system.
@@ -22,8 +22,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
     _ATTRIBUTES_TO_HASH = "files", "name", "tags"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, tags=None, **kwargs):
-        """ Construct a Dataset
-        """
+        """Construct a Dataset"""
         super().__init__(id=id, logger=logger, tags=tags, path=path, path_from=path_from, base_from=base_from)
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined
@@ -51,7 +50,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         return len(self.files)
 
     def add(self, *args, **kwargs):
-        """ Add a data/results file to the manifest
+        """Add a data/results file to the manifest
 
         Usage:
             my_file = octue.DataFile(...)
@@ -96,7 +95,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         return self.files.filter(filter_name=field_lookup, filter_value=filter_value)
 
     def get_file_sequence(self, filter_name, filter_value=None, strict=True):
-        """ Get an ordered sequence of files matching a criterion
+        """Get an ordered sequence of files matching a criterion
 
         Accepts the same search arguments as `get_files`.
 
@@ -128,7 +127,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         return results
 
     def get_file_by_tag(self, tag_string):
-        """ Gets a data file from a manifest by searching for files with the provided tag(s)
+        """Gets a data file from a manifest by searching for files with the provided tag(s)
 
         Gets exclusively one file; if no file or more than one file is found this results in an error.
 

--- a/octue/resources/filter_containers.py
+++ b/octue/resources/filter_containers.py
@@ -2,7 +2,7 @@ from octue import exceptions
 
 
 def _filter(instance, filter_name=None, filter_value=None):
-    """ Returns a new instance containing only the Filterables to which the given filter criteria apply.
+    """Returns a new instance containing only the Filterables to which the given filter criteria apply.
 
     Say we want to filter by files whose extension equals "csv". We want to be able to do...
 
@@ -23,7 +23,7 @@ def _filter(instance, filter_name=None, filter_value=None):
 
 
 def _order_by(instance, attribute_name, reverse=False):
-    """ Order the instance by the given attribute_name, returning the instance's elements as a new FilterList (not a
+    """Order the instance by the given attribute_name, returning the instance's elements as a new FilterList (not a
     FilterSet.
     """
     try:

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -10,14 +10,13 @@ module_logger = logging.getLogger(__name__)
 
 
 class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
-    """ A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
-    (or leaving), a data service for an analysis at the configuration, input or output stage. """
+    """A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
+    (or leaving), a data service for an analysis at the configuration, input or output stage."""
 
     _ATTRIBUTES_TO_HASH = "datasets", "keys"
 
     def __init__(self, id=None, logger=None, path=None, path_from=None, base_from=None, **kwargs):
-        """ Construct a Manifest
-        """
+        """Construct a Manifest"""
         super().__init__(id=id, logger=logger, path=path, path_from=path_from, base_from=base_from)
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined
@@ -54,7 +53,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         self.__dict__.update(**kwargs)
 
     def get_dataset(self, key):
-        """ Gets a dataset by its key name (as defined in the twine)
+        """Gets a dataset by its key name (as defined in the twine)
         :return: Dataset selected by its key
         :rtype: Dataset
         """
@@ -67,8 +66,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         return self.datasets[idx]
 
     def prepare(self, data):
-        """ Prepare new manifest from a manifest_spec
-        """
+        """Prepare new manifest from a manifest_spec"""
         if len(self.datasets) > 0:
             raise InvalidInputException("You cannot `prepare()` a manifest already instantiated with datasets")
 

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -10,7 +10,7 @@ TAG_PATTERN = re.compile(r"^$|^[a-z0-9][a-z0-9:\-]*(?<![:-])$")
 
 
 class Tag(Filterable):
-    """ A tag starts and ends with a character in [a-z] or [0-9]. It can contain the colon discriminator or hyphens.
+    """A tag starts and ends with a character in [a-z] or [0-9]. It can contain the colon discriminator or hyphens.
     Empty strings are also valid. More valid examples:
        system:32
        angry-marmaduke
@@ -138,8 +138,7 @@ class TagSet:
         return f"<TagSet({self.tags})>"
 
     def add_tags(self, *args):
-        """ Adds one or more new tag strings to the object tags. New tags will be cleaned and validated.
-        """
+        """Adds one or more new tag strings to the object tags. New tags will be cleaned and validated."""
         self.tags |= {Tag(arg) for arg in args}
 
     def get_subtags(self):

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -15,7 +15,7 @@ module_logger = logging.getLogger(__name__)
 
 
 class Runner:
-    """ Runs analyses in the app framework
+    """Runs analyses in the app framework
 
     The Runner class provides a set of configuration parameters for use by your application, together with a range of
     methods for managing input and output file parsing as well as controlling logging.
@@ -66,14 +66,17 @@ class Runner:
 
         # Validate and initialise configuration data
         self.configuration = self.twine.validate(
-            configuration_values=configuration_values, configuration_manifest=configuration_manifest, cls=CLASS_MAP,
+            configuration_values=configuration_values,
+            configuration_manifest=configuration_manifest,
+            cls=CLASS_MAP,
         )
         package_logger.debug("Configuration validated.")
 
         # Set path for configuration manifest.
         # TODO this is hacky, we need to rearchitect the twined validation so we can do this kind of thing in there
         self.configuration["configuration_manifest"] = self._update_manifest_path(
-            self.configuration.get("configuration_manifest", None), configuration_manifest,
+            self.configuration.get("configuration_manifest", None),
+            configuration_manifest,
         )
 
         # Store the log level (same log level used for all analyses)
@@ -89,7 +92,7 @@ class Runner:
 
     @staticmethod
     def _update_manifest_path(manifest, pathname):
-        """ A Quick hack to stitch the new Pathable functionality in the 0.1.4 release into the CLI and runner.
+        """A Quick hack to stitch the new Pathable functionality in the 0.1.4 release into the CLI and runner.
 
         The way we define a manifest path can be more robustly implemented as we migrate functionality into the twined
         library
@@ -119,7 +122,7 @@ class Runner:
         output_manifest_path=None,
         skip_checks=False,
     ):
-        """ Run an analysis
+        """Run an analysis
 
         :parameter app_src: Either: an instance of the AppFrom manager class which has a run() method, or
         a function which accepts a single parameter (the instantiated analysis), or a string pointing
@@ -174,13 +177,17 @@ class Runner:
             }
 
         # TODO this is hacky, we need to rearchitect the twined validation so we can do this kind of thing in there
-        inputs["input_manifest"] = self._update_manifest_path(inputs.get("input_manifest", None), input_manifest,)
+        inputs["input_manifest"] = self._update_manifest_path(
+            inputs.get("input_manifest", None),
+            input_manifest,
+        )
 
         outputs_and_monitors = self.twine.prepare("monitors", "output_values", "output_manifest", cls=CLASS_MAP)
 
         # TODO this is hacky, we need to rearchitect the twined validation so we can do this kind of thing in there
         outputs_and_monitors["output_manifest"] = self._update_manifest_path(
-            outputs_and_monitors.get("output_manifest", None), output_manifest_path,
+            outputs_and_monitors.get("output_manifest", None),
+            output_manifest_path,
         )
 
         analysis_id = str(analysis_id) if analysis_id else gen_uuid()
@@ -214,15 +221,14 @@ class Runner:
 
 
 def unwrap(fcn):
-    """ Recurse through wrapping to get the raw function without decorators.
-    """
+    """Recurse through wrapping to get the raw function without decorators."""
     if hasattr(fcn, "__wrapped__"):
         return unwrap(fcn.__wrapped__)
     return fcn
 
 
 class AppFrom:
-    """ Context manager that imports module 'app' from user's code base at a location app_path.
+    """Context manager that imports module 'app' from user's code base at a location app_path.
 
      The manager will issue a warning if an existing module called "app" is already loaded.
 
@@ -269,6 +275,5 @@ class AppFrom:
 
     @property
     def run(self):
-        """ Returns the unwrapped run function from app.py in the application's root directory
-        """
+        """Returns the unwrapped run function from app.py in the application's root directory"""
         return unwrap(self.app_module.run)

--- a/octue/templates/template-child-services/parent_service/app.py
+++ b/octue/templates/template-child-services/parent_service/app.py
@@ -1,5 +1,5 @@
 def run(analysis, *args, **kwargs):
-    """ Your main entrypoint to run the application
+    """Your main entrypoint to run the application
 
     This is the function that gets run each time somebody requests an analysis from the digital twin / data service.
     You should write your own code and call it from here.

--- a/octue/templates/template-python-fractal/app.py
+++ b/octue/templates/template-python-fractal/app.py
@@ -2,7 +2,7 @@ from fractal import fractal
 
 
 def run(analysis, *args, **kwargs):
-    """ Your main entrypoint to run the application
+    """Your main entrypoint to run the application
 
     This is the function that gets run each time somebody requests an analysis from the digital twin / data service.
     You should write your own code and call it from here.

--- a/octue/templates/template-python-fractal/fractal/fractal.py
+++ b/octue/templates/template-python-fractal/fractal/fractal.py
@@ -6,8 +6,7 @@ from .mandelbrot import mandelbrot
 
 
 def fractal(analysis):
-    """ Compute the heightmap of a fractal and output a data file containing visualisation data
-    """
+    """Compute the heightmap of a fractal and output a data file containing visualisation data"""
 
     # Call the 'mandel' function to compute the fractal. Here, we just treat 'mandel' as a legacy function, passing in
     # what we need from the analysis object and getting results back

--- a/octue/templates/template-python-fractal/setup.py
+++ b/octue/templates/template-python-fractal/setup.py
@@ -9,5 +9,7 @@ def git_version():
 # This file makes your module installable as a library. It's not essential for running apps with twined.
 
 setup(
-    name="template-python-fractal", version=git_version(), py_modules=["app"],
+    name="template-python-fractal",
+    version=git_version(),
+    py_modules=["app"],
 )

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -4,7 +4,7 @@ from octue.resources import Datafile
 
 
 def run(analysis, *args, **kwargs):
-    """ An app to read a time series of files from a dataset, clean them and write a new, cleaned, dataset.
+    """An app to read a time series of files from a dataset, clean them and write a new, cleaned, dataset.
 
     See the "fractal" template for an introduction to the analysis object and the purpose of this 'run' function.
 

--- a/octue/templates/template-using-manifests/cleaner/clean.py
+++ b/octue/templates/template-using-manifests/cleaner/clean.py
@@ -4,7 +4,7 @@ from stringcase import snakecase
 
 
 def clean(data, date):
-    """ Clean up data from meteorological mast anemometers and wind vanes...
+    """Clean up data from meteorological mast anemometers and wind vanes...
 
     ... or rename the function and do pretty much whatever you want with the data!
 

--- a/octue/templates/template-using-manifests/cleaner/read_csv_files.py
+++ b/octue/templates/template-using-manifests/cleaner/read_csv_files.py
@@ -2,7 +2,7 @@ import pandas
 
 
 def read_csv_files(files):
-    """ Read a sequence of CSV files file containing meteorological mast anemometer and wind vane data
+    """Read a sequence of CSV files file containing meteorological mast anemometer and wind vane data
 
     You don't really need to care about this, because your files are unlikely to be in the same form as our
     example csv files. But for the sake of a complete example, we show you how we'd read these in here.

--- a/octue/templates/template-using-manifests/cleaner/read_dat_file.py
+++ b/octue/templates/template-using-manifests/cleaner/read_dat_file.py
@@ -2,7 +2,7 @@ from dateparser import parse
 
 
 def read_dat_file(file):
-    """ Read a dat file containing meteorological mast metadata
+    """Read a dat file containing meteorological mast metadata
 
     You don't really need to care about this, because your files are unlikely to be in the same form as our
     example dat files. You'll need to build your own file readers and test them (or use open-source libraries to do

--- a/octue/templates/template-using-manifests/setup.py
+++ b/octue/templates/template-using-manifests/setup.py
@@ -9,5 +9,7 @@ def git_version():
 # This file makes your module installable as a library. It's not essential for running apps with twined.
 
 setup(
-    name="template-using-manifests", version=git_version(), py_modules=["app"],
+    name="template-using-manifests",
+    version=git_version(),
+    py_modules=["app"],
 )

--- a/octue/templates/templates.py
+++ b/octue/templates/templates.py
@@ -12,7 +12,7 @@ PACKAGED_TEMPLATES = tuple(name for name in resource_listdir("octue", "templates
 
 
 def copy_template(template_name, destination_dir="."):
-    """ Copies one of the application templates from the octue/templates to a destination directory (current dir by default)
+    """Copies one of the application templates from the octue/templates to a destination directory (current dir by default)
 
     :parameter template_name: The name of the template to copy, must be one of AVAILABLE_TEMPLATES.
     :type template_name: str

--- a/octue/utils/decoders.py
+++ b/octue/utils/decoders.py
@@ -4,8 +4,7 @@ from octue.resources import Datafile, Dataset, Manifest
 
 
 def default_object_hook(obj):
-    """ A hook to convert default json objects into their Datafile, Dataset or Manifest class as appropriate
-    """
+    """A hook to convert default json objects into their Datafile, Dataset or Manifest class as appropriate"""
 
     # object hooks are called whenever a json object is created. When nested, this is done from innermost (deepest
     # nesting) out so it's safe to work at multiple levels here
@@ -22,8 +21,7 @@ def default_object_hook(obj):
 
 
 class OctueJSONDecoder(JSONDecoder):
-    """ A JSON Decoder to convert default json objects into their Datafile, Dataset or Manifest classes as appropriate
-    """
+    """A JSON Decoder to convert default json objects into their Datafile, Dataset or Manifest classes as appropriate"""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/octue/utils/encoders.py
+++ b/octue/utils/encoders.py
@@ -2,8 +2,7 @@ from twined.utils import TwinedEncoder
 
 
 class OctueJSONEncoder(TwinedEncoder):
-    """ A JSON Encoder which allows objects having a `serialise()` method to control their own conversion to primitives
-    """
+    """A JSON Encoder which allows objects having a `serialise()` method to control their own conversion to primitives"""
 
     def default(self, obj):
 

--- a/octue/utils/folders.py
+++ b/octue/utils/folders.py
@@ -4,7 +4,7 @@ from octue.definitions import OUTPUT_STRANDS, STRAND_FILENAME_MAP
 
 
 def get_file_name_from_strand(strand, path):
-    """ Where values or manifest are contained in a local file, assemble that filename.
+    """Where values or manifest are contained in a local file, assemble that filename.
 
     For output directories, the directory will be made if it doesn't exist. This is not true for input directories
     for which validation of their presence is handled elsewhere.

--- a/octue/utils/isfile.py
+++ b/octue/utils/isfile.py
@@ -2,7 +2,7 @@ import os
 
 
 def isfile(*args):
-    """ Returns true if input path is the name of a valid, existing, file.
+    """Returns true if input path is the name of a valid, existing, file.
 
     Joins multiple inputs, making it slightly more useful than os.path.isfile()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,8 +14,8 @@ class MyPathable(Pathable, MixinBase):
 
 
 class BaseTestCase(unittest.TestCase):
-    """ Base test case for twined:
-        - sets a path to the test data directory
+    """Base test case for twined:
+    - sets a path to the test data directory
     """
 
     def setUp(self):
@@ -26,7 +26,7 @@ class BaseTestCase(unittest.TestCase):
         super().setUp()
 
     def callCli(self, args):
-        """ Utility to call the octue CLI (eg for a templated example) in a separate subprocess
+        """Utility to call the octue CLI (eg for a templated example) in a separate subprocess
         Enables testing that multiple processes aren't using the same memory space, or for running multiple apps in
         parallel to ensure they don't conflict
         """

--- a/tests/mixins/test_base.py
+++ b/tests/mixins/test_base.py
@@ -4,13 +4,11 @@ from ..base import BaseTestCase
 
 class MixinBaseTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
-        """ Ensures the class instantiates without arguments
-        """
+        """Ensures the class instantiates without arguments"""
         MixinBase()
 
     def test_raises_exception_if_passed_args(self):
-        """ Ensures that the base mixin won't silently fail if passed arguments it's not supposed to have
-        """
+        """Ensures that the base mixin won't silently fail if passed arguments it's not supposed to have"""
         with self.assertRaises(TypeError):
             MixinBase("an_argument")
 

--- a/tests/mixins/test_cool_nameable.py
+++ b/tests/mixins/test_cool_nameable.py
@@ -1,6 +1,5 @@
-from tests.base import BaseTestCase
-
 from octue.mixins import CoolNameable
+from tests.base import BaseTestCase
 
 
 class NamedThing(CoolNameable):

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -1,8 +1,7 @@
-from tests.base import BaseTestCase
-
 from octue import exceptions
 from octue.mixins.filterable import Filterable
 from octue.resources.tag import TagSet
+from tests.base import BaseTestCase
 
 
 class FilterableSubclass(Filterable):
@@ -31,7 +30,7 @@ class TestFilterable(BaseTestCase):
             FilterableSubclass().satisfies(filter_name="age__is_secret", filter_value=True)
 
     def test_error_raised_when_attribute_type_has_no_filters_defined(self):
-        """ Ensure an error is raised when a filter for an attribute whose type doesn't have any filters defined is
+        """Ensure an error is raised when a filter for an attribute whose type doesn't have any filters defined is
         received.
         """
         with self.assertRaises(exceptions.InvalidInputException):

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -32,8 +32,8 @@ class HashableTestCase(BaseTestCase):
             my_class.hash_value
 
     def test_iterable_attribute_with_mixed_types_raises_value_error(self):
-        """ Ensure trying to hash iterable attributes containing a mix between types with a 'hash_value' attribute and
-        types that don't results in a TypeError. """
+        """Ensure trying to hash iterable attributes containing a mix between types with a 'hash_value' attribute and
+        types that don't results in a TypeError."""
         my_class = TypeWithIterable()
         my_class.my_iterable = [1, 2, TypeWithHash()]
 

--- a/tests/mixins/test_identifiable.py
+++ b/tests/mixins/test_identifiable.py
@@ -7,44 +7,38 @@ from ..base import BaseTestCase
 
 class IdentifiableTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
-        """ Ensures the class instantiates without arguments
-        """
+        """Ensures the class instantiates without arguments"""
         resource = Identifiable()
         self.assertIsInstance(resource.id, str)
         self.assertEqual(len(resource.id), 36)
 
     def test_instantiates_with_str_uuid(self):
-        """ Ensures class instantiates with a string uuid
-        """
+        """Ensures class instantiates with a string uuid"""
         resource = Identifiable(id=str(uuid.uuid4()))
         self.assertIsInstance(resource.id, str)
         self.assertEqual(len(resource.id), 36)
 
     def test_instantiates_with_uuid(self):
-        """ Ensures class instantiates with a UUID()
-        """
+        """Ensures class instantiates with a UUID()"""
         resource = Identifiable(id=uuid.uuid4())
         self.assertIsInstance(resource.id, str)
         self.assertEqual(len(resource.id), 36)
 
     def test_repr(self):
-        """ Ensures the class instantiates without arguments
-        """
+        """Ensures the class instantiates without arguments"""
         id = "07d38e81-6b00-4079-901b-e250ea3c7773"
         resource = Identifiable(id=id)
         self.assertEqual(resource.__repr__(), f"Identifiable {id}")
 
     def test_raises_error_with_non_uuid(self):
-        """ Ensures that if a string is passed not matching the UUID pattern, that an exception is raised
-        """
+        """Ensures that if a string is passed not matching the UUID pattern, that an exception is raised"""
         with self.assertRaises(exceptions.InvalidInputException) as e:
             Identifiable(id="notauuid-6b00-4079-901b-e250ea3c7773")
 
         self.assertIn("is not a valid uuid string or instance of class UUID", e.exception.args[0])
 
     def test_raises_error_with_non_str_or_uuid(self):
-        """ Ensures that if an id is passed, it must be of type str or UUID
-        """
+        """Ensures that if an id is passed, it must be of type str or UUID"""
 
         class NotStrOrUUID:
             pass
@@ -55,7 +49,7 @@ class IdentifiableTestCase(BaseTestCase):
         self.assertIn("must be a valid uuid string, an instance of class UUID or None", e.exception.args[0])
 
     def test_get_str_from_ID(self):
-        """ Ensures that calling str() on an object inheriting from Identifiable will use the class name and ID
+        """Ensures that calling str() on an object inheriting from Identifiable will use the class name and ID
         'ClassName <uuid>'
         """
 
@@ -66,7 +60,7 @@ class IdentifiableTestCase(BaseTestCase):
         self.assertEqual(str(resource), "Inherit 07d38e81-6b00-4079-901b-e250ea3c7773")
 
     def test_set_id_on_instantiated_object(self):
-        """ Ensures that setting id on an instantiated object will raise an error message, with a customised classname
+        """Ensures that setting id on an instantiated object will raise an error message, with a customised classname
         for inheritance
         """
 

--- a/tests/mixins/test_loggable.py
+++ b/tests/mixins/test_loggable.py
@@ -5,22 +5,20 @@ from ..base import BaseTestCase
 
 
 class InheritLoggable(Loggable):
-    """ Class used purely for testing to check the logger is instantiated
-    """
+    """Class used purely for testing to check the logger is instantiated"""
 
     pass
 
 
 class LoggableTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
-        """ Ensures the class instantiates without arguments
-        """
+        """Ensures the class instantiates without arguments"""
         resource = Loggable()
         self.assertIsInstance(resource.logger, logging.Logger)
         self.assertEqual(resource.logger.name, "octue.mixins.loggable")
 
     def test_inherits_correct_module_name(self):
-        """ Ensures default logger is the one attached to the file where the derived class was declared,
+        """Ensures default logger is the one attached to the file where the derived class was declared,
         not where the Loggable class was declared
         """
         resource = InheritLoggable()
@@ -28,8 +26,7 @@ class LoggableTestCase(BaseTestCase):
         self.assertEqual(resource.logger.name, __name__)
 
     def test_assigns_if_logger_passed(self):
-        """ Ensures non-default logger is attached correctly
-        """
+        """Ensures non-default logger is attached correctly"""
         custom_logger = logging.getLogger("custom_logger")
         resource = InheritLoggable(logger=custom_logger)
         self.assertIsInstance(resource.logger, logging.Logger)

--- a/tests/mixins/test_pathable.py
+++ b/tests/mixins/test_pathable.py
@@ -11,23 +11,21 @@ class MyPathable(Pathable, MixinBase):
 
 class PathableTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
-        """ Ensures the class instantiates without arguments, with default paths at the current working directory
-        """
+        """Ensures the class instantiates without arguments, with default paths at the current working directory"""
         resource = MyPathable()
         self.assertEqual(os.getcwd(), resource.absolute_path)
         self.assertEqual(".", resource.relative_path)
         self.assertEqual(".", resource.path)
 
     def test_paths_chain(self):
-        """ Ensures that pathable resources daisychain their paths
-        """
+        """Ensures that pathable resources daisychain their paths"""
         owner = MyPathable()
         owned = MyPathable(path_from=owner, path="owned")
         owned_owned = MyPathable(path_from=owned, path="owned_owned")
         self.assertEqual(os.path.join(os.getcwd(), "owned", "owned_owned"), owned_owned.absolute_path)
 
     def test_paths_chain_dynamic(self):
-        """ Ensures that daisychaining updates if path in the chain changes
+        """Ensures that daisychaining updates if path in the chain changes
 
         This enables us to initialise (for example) datasets from manifests, where all the paths are given relative to
         the dataset, then alter the path further up the tree to where a directory actually is on the system.
@@ -39,8 +37,7 @@ class PathableTestCase(BaseTestCase):
         self.assertEqual(os.path.join(os.getcwd(), "dynamic", "owned"), owned.absolute_path)
 
     def test_paths_chain_with_missing_values(self):
-        """ Ensures that pathable resources chain even if a part of the chain doesn't have a path
-        """
+        """Ensures that pathable resources chain even if a part of the chain doesn't have a path"""
 
         # Owner is in the current working directory
         owner = MyPathable(path="owner")
@@ -49,15 +46,13 @@ class PathableTestCase(BaseTestCase):
         self.assertEqual(os.path.join(os.getcwd(), "owner", "owned_owned"), owned_owned.absolute_path)
 
     def test_paths_relative(self):
-        """ Ensures that pathable resources have a relative path (by default relative to current working directory)
-        """
+        """Ensures that pathable resources have a relative path (by default relative to current working directory)"""
         owner = MyPathable(path="owner")
         owned = MyPathable(path_from=owner, path="owned")
         self.assertEqual(os.path.join("owner", "owned"), owned.relative_path)
 
     def test_paths_relative_to_base(self):
-        """ Ensures that pathable resources have a relative path that is relative to base_path if given
-        """
+        """Ensures that pathable resources have a relative path that is relative to base_path if given"""
         # Check it works for a single depth
         owner1 = MyPathable(path="owner")
         owned1 = MyPathable(path_from=owner1, path="owned", base_from=owner1)
@@ -70,8 +65,7 @@ class PathableTestCase(BaseTestCase):
         self.assertEqual(os.path.join("owned", "owned_owned"), owned_owned2.relative_path)
 
     def test_invalid_base_and_path_from(self):
-        """ Ensures that exceptions are correctly raised when the *_from objects are not Pathables
-        """
+        """Ensures that exceptions are correctly raised when the *_from objects are not Pathables"""
 
         class NotPathable:
             pass
@@ -83,14 +77,12 @@ class PathableTestCase(BaseTestCase):
             MyPathable(path="owner", base_from=NotPathable())
 
     def test_valid_absolute_path_without_from_path(self):
-        """ Ensures that an absolute path can be set if no from_path object is present
-        """
+        """Ensures that an absolute path can be set if no from_path object is present"""
         owner1 = MyPathable(path="/owner")
         self.assertEqual("/owner", owner1.absolute_path)
 
     def test_invalid_absolute_path_with_from_path(self):
-        """ Ensures that pathable resources have a relative path that is relative to base_path if given
-        """
+        """Ensures that pathable resources have a relative path that is relative to base_path if given"""
         # Check it works for a single depth
         owner1 = MyPathable(path="owner")
         with self.assertRaises(InvalidInputException):

--- a/tests/mixins/test_serialisable.py
+++ b/tests/mixins/test_serialisable.py
@@ -22,13 +22,11 @@ class InheritWithFieldsToSerialise(Inherit):
 
 class SerialisableTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
-        """ Ensures the class instantiates without arguments
-        """
+        """Ensures the class instantiates without arguments"""
         Serialisable()
 
     def test_raises_attribute_error_with_missing_logger(self):
-        """ Ensures class instantiates with a string uuid
-        """
+        """Ensures class instantiates with a string uuid"""
         resource = Serialisable()
         with self.assertRaises(AttributeError) as error:
             resource.serialise()
@@ -36,8 +34,7 @@ class SerialisableTestCase(BaseTestCase):
         self.assertIn("'Serialisable' object has no attribute 'logger'", error.exception.args[0])
 
     def test_returns_primitive_without_logger_or_protected_fields(self):
-        """ Ensures class instantiates with a UUID()
-        """
+        """Ensures class instantiates with a UUID()"""
         resource = Inherit()
         serialised = resource.serialise()
         self.assertTrue("id" in serialised.keys())
@@ -46,8 +43,7 @@ class SerialisableTestCase(BaseTestCase):
         self.assertFalse("_field_not_to_serialise" in serialised.keys())
 
     def test_serialise_only_attrs(self):
-        """ Restricts the id field, which would normally be serialised
-        """
+        """Restricts the id field, which would normally be serialised"""
         resource = InheritWithFieldsToSerialise()
         serialised = resource.serialise()
         self.assertFalse("id" in serialised.keys())
@@ -56,15 +52,13 @@ class SerialisableTestCase(BaseTestCase):
         self.assertFalse("_field_not_to_serialise" in serialised.keys())
 
     def test_serialise_to_string(self):
-        """ Restricts the id field, which would normally be serialised
-        """
+        """Restricts the id field, which would normally be serialised"""
         resource = InheritWithFieldsToSerialise()
         serialised = resource.serialise(to_string=True)
         self.assertIsInstance(serialised, str)
 
     def test_serialise_to_file(self):
-        """ Restricts the id field, which would normally be serialised
-        """
+        """Restricts the id field, which would normally be serialised"""
 
         with TemporaryDirectory() as dir_name:
             file_name = os.path.join(dir_name, "test_serialise_to_file.json")

--- a/tests/mixins/test_taggable.py
+++ b/tests/mixins/test_taggable.py
@@ -10,13 +10,11 @@ class MyTaggable(Taggable, MixinBase):
 
 class TaggableTestCase(BaseTestCase):
     def test_instantiates(self):
-        """ Ensures the class instantiates without arguments
-        """
+        """Ensures the class instantiates without arguments"""
         Taggable()
 
     def test_instantiates_with_tags(self):
-        """ Ensures datafile inherits correctly from the Taggable class and passes arguments through
-        """
+        """Ensures datafile inherits correctly from the Taggable class and passes arguments through"""
         taggable = MyTaggable(tags="")
         self.assertEqual(len(taggable.tags), 0)
 
@@ -30,16 +28,14 @@ class TaggableTestCase(BaseTestCase):
             MyTaggable(tags=":a b c")
 
     def test_instantiates_with_tag_set(self):
-        """ Ensures datafile inherits correctly from the Taggable class and passes arguments through
-        """
+        """Ensures datafile inherits correctly from the Taggable class and passes arguments through"""
         taggable_1 = MyTaggable(tags="")
         self.assertIsInstance(taggable_1.tags, TagSet)
         taggable_2 = MyTaggable(tags=taggable_1.tags)
         self.assertFalse(taggable_1 is taggable_2)
 
     def test_fails_to_instantiates_with_non_iterable(self):
-        """ Ensures datafile inherits correctly from the Taggable class and passes arguments through
-        """
+        """Ensures datafile inherits correctly from the Taggable class and passes arguments through"""
 
         class NoIter:
             pass
@@ -52,15 +48,13 @@ class TaggableTestCase(BaseTestCase):
         )
 
     def test_reset_tags(self):
-        """ Ensures datafile inherits correctly from the Taggable class and passes arguments through
-        """
+        """Ensures datafile inherits correctly from the Taggable class and passes arguments through"""
         taggable = MyTaggable(tags="a b")
         taggable.tags = "b c"
         self.assertEqual(set(taggable.tags), {Tag("b"), Tag("c")})
 
     def test_valid_tags(self):
-        """ Ensures valid tags do not raise an error
-        """
+        """Ensures valid tags do not raise an error"""
         taggable = MyTaggable()
         taggable.add_tags("a-valid-tag")
         taggable.add_tags("a:tag")
@@ -83,8 +77,7 @@ class TaggableTestCase(BaseTestCase):
         )
 
     def test_invalid_tags(self):
-        """ Ensures invalid tags raise an error
-        """
+        """Ensures invalid tags raise an error"""
         taggable = MyTaggable()
 
         for tag in "-bah", "humbug:", "SHOUTY", r"back\slashy", {"not-a": "string"}:
@@ -92,8 +85,7 @@ class TaggableTestCase(BaseTestCase):
                 taggable.add_tags(tag)
 
     def test_mixture_valid_invalid(self):
-        """ Ensures that adding a variety of tags, some of which are invalid, doesn't partially add them to the object
-        """
+        """Ensures that adding a variety of tags, some of which are invalid, doesn't partially add them to the object"""
         taggable = MyTaggable()
         taggable.add_tags("first-valid-should-be-added")
         try:

--- a/tests/resources/communication/google_pub_sub/test_service.py
+++ b/tests/resources/communication/google_pub_sub/test_service.py
@@ -1,12 +1,12 @@
 import concurrent.futures
 import time
 import uuid
-from tests.base import BaseTestCase
 
 from octue import exceptions
 from octue.resources.communication.google_pub_sub.service import Service
 from octue.resources.communication.service_backends import GCPPubSubBackend
 from octue.resources.manifest import Manifest
+from tests.base import BaseTestCase
 
 
 SERVER_WAIT_TIME = 5
@@ -28,8 +28,8 @@ class MockAnalysisWithOutputManifest:
 
 
 class TestService(BaseTestCase):
-    """ Some of these tests require a connection to either a real Google Pub/Sub instance on Google Cloud Platform
-    (GCP), or a local emulator. """
+    """Some of these tests require a connection to either a real Google Pub/Sub instance on Google Cloud Platform
+    (GCP), or a local emulator."""
 
     BACKEND = GCPPubSubBackend(project_name="octue-amy", credentials_environment_variable="GCP_SERVICE_ACCOUNT")
 
@@ -56,8 +56,8 @@ class TestService(BaseTestCase):
             self.assertTrue(time.perf_counter() - start_time < 20)
 
     def test_ask_on_non_existent_service_results_in_error(self):
-        """ Test that trying to ask a question to a non-existent service (i.e. one without a topic in Google Pub/Sub)
-        results in an error. """
+        """Test that trying to ask a question to a non-existent service (i.e. one without a topic in Google Pub/Sub)
+        results in an error."""
         with self.assertRaises(exceptions.ServiceNotFound):
             Service(backend=self.BACKEND, id=str(uuid.uuid4())).ask(service_id=1234, input_values=[1, 2, 3, 4])
 
@@ -85,7 +85,7 @@ class TestService(BaseTestCase):
             )
 
     def test_ask_with_input_manifest(self):
-        """ Test that a service can ask a question including an input_manifest to another service that is serving and
+        """Test that a service can ask a question including an input_manifest to another service that is serving and
         receive an answer.
         """
         asking_service = Service(backend=self.BACKEND, id=str(uuid.uuid4()))

--- a/tests/resources/communication/test_credentials.py
+++ b/tests/resources/communication/test_credentials.py
@@ -1,7 +1,7 @@
 import google.oauth2.service_account
-from tests.base import BaseTestCase
 
 from octue.resources.communication.credentials import GCPCredentialsManager
+from tests.base import BaseTestCase
 
 
 class TestGCPCredentialsManager(BaseTestCase):

--- a/tests/resources/communication/test_service_backends.py
+++ b/tests/resources/communication/test_service_backends.py
@@ -1,7 +1,6 @@
-from tests.base import BaseTestCase
-
 from octue.exceptions import BackendNotFound
 from octue.resources.communication.service_backends import get_backend
+from tests.base import BaseTestCase
 
 
 class TestServiceBackends(BaseTestCase):

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -5,20 +5,18 @@ from ..base import BaseTestCase
 
 class AnalysisTestCase(BaseTestCase):
     def test_instantiate_analysis(self):
-        """ Ensures that the base analysis class can be instantiated
-        """
+        """Ensures that the base analysis class can be instantiated"""
         # from octue import runner  # <-- instantiated in the library, not here
         analysis = Analysis(twine="{}")
         self.assertEqual(analysis.__class__.__name__, "Analysis")
 
     def test_instantiate_analysis_with_twine(self):
-        """ Ensures that the base analysis class can be instantiated
-        """
+        """Ensures that the base analysis class can be instantiated"""
         analysis = Analysis(twine=Twine(source="{}"))
         self.assertEqual(analysis.__class__.__name__, "Analysis")
 
     def test_non_existent_attributes_cannot_be_retrieved(self):
-        """ Ensure attributes that don't exist on Analysis aren't retrieved as None and instead raise an error. See
+        """Ensure attributes that don't exist on Analysis aren't retrieved as None and instead raise an error. See
         https://github.com/octue/octue-sdk-python/issues/45 for reasoning behind adding this.
         """
         analysis = Analysis(twine=Twine(source="{}"))
@@ -27,8 +25,7 @@ class AnalysisTestCase(BaseTestCase):
             analysis.furry_purry_cat
 
     def test_analysis_hash_attributes_are_none_when_no_relevant_strands(self):
-        """ Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are provided
-        """
+        """Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are provided"""
         analysis = Analysis(twine="{}")
         for strand_name in _HASH_FUNCTIONS:
             self.assertIsNone(getattr(analysis, f"{strand_name}_hash"))

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -22,8 +22,7 @@ class DatafileTestCase(BaseTestCase):
         return Datafile(path_from=self.path_from, base_from=self.path_from, path=self.path, skip_checks=False)
 
     def test_instantiates(self):
-        """ Ensures a Datafile instantiates using only a path and generates a uuid ID
-        """
+        """Ensures a Datafile instantiates using only a path and generates a uuid ID"""
         df = Datafile(path="a_path")
         self.assertTrue(isinstance(df.id, str))
         self.assertEqual(type(uuid.UUID(df.id)), uuid.UUID)
@@ -31,8 +30,7 @@ class DatafileTestCase(BaseTestCase):
         self.assertEqual(0, df.cluster)
 
     def test_path_argument_required(self):
-        """ Ensures instantiation without a path will fail
-        """
+        """Ensures instantiation without a path will fail"""
         with self.assertRaises(exceptions.InvalidInputException) as error:
             Datafile()
 
@@ -51,8 +49,7 @@ class DatafileTestCase(BaseTestCase):
         self.assertIn("Extension provided (notcsv) does not match file extension", error.exception.args[0])
 
     def test_file_attributes_accessible(self):
-        """ Ensures that its possible to set the sequence, cluster and timestamp
-        """
+        """Ensures that its possible to set the sequence, cluster and timestamp"""
         df = self.create_valid_datafile()
         self.assertIsInstance(df.size_bytes, int)
         self.assertGreaterEqual(df.last_modified, 1598200190.5771205)
@@ -63,8 +60,7 @@ class DatafileTestCase(BaseTestCase):
         df.posix_timestamp = 0
 
     def test_cannot_set_calculated_file_attributes(self):
-        """ Ensures that calculated attributes cannot be set
-        """
+        """Ensures that calculated attributes cannot be set"""
         df = self.create_valid_datafile()
 
         with self.assertRaises(AttributeError):
@@ -78,8 +74,7 @@ class DatafileTestCase(BaseTestCase):
         self.assertEqual(repr(self.create_valid_datafile()), "<Datafile('a_test_file.csv')>")
 
     def test_serialisable(self):
-        """ Ensures a datafile can serialise to json format
-        """
+        """Ensures a datafile can serialise to json format"""
         df = self.create_valid_datafile()
         df_dict = df.serialise()
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -1,21 +1,19 @@
 import copy
 import warnings
-from tests.base import BaseTestCase
 
 from octue import exceptions
 from octue.resources import Datafile, Dataset
 from octue.resources.filter_containers import FilterSet
+from tests.base import BaseTestCase
 
 
 class DatasetTestCase(BaseTestCase):
     def test_instantiates_with_no_args(self):
-        """ Ensures a Datafile instantiates using only a path and generates a uuid ID
-        """
+        """Ensures a Datafile instantiates using only a path and generates a uuid ID"""
         Dataset()
 
     def test_instantiates_with_kwargs(self):
-        """ Ensures that keyword arguments can be used to construct the dataset initially
-        """
+        """Ensures that keyword arguments can be used to construct the dataset initially"""
         files = [Datafile(path="path-within-dataset/a_test_file.csv")]
         resource = Dataset(files=files, tags="one two")
         self.assertEqual(len(resource.files), 1)
@@ -43,30 +41,26 @@ class DatasetTestCase(BaseTestCase):
             self.assertEqual(len(resource.files), 1)
 
     def test_add_single_file_to_empty_dataset(self):
-        """ Ensures that when a dataset is empty, it can be added to
-        """
+        """Ensures that when a dataset is empty, it can be added to"""
         resource = Dataset()
         resource.add(Datafile(path="path-within-dataset/a_test_file.csv"))
         self.assertEqual(len(resource.files), 1)
 
     def test_add_single_file_to_existing_dataset(self):
-        """ Ensures that when a dataset is not empty, it can be added to
-        """
+        """Ensures that when a dataset is not empty, it can be added to"""
         files = [Datafile(path="path-within-dataset/a_test_file.csv")]
         resource = Dataset(files=files, tags="one two")
         resource.add(Datafile(path="path-within-dataset/a_test_file.csv"))
         self.assertEqual(len(resource.files), 2)
 
     def test_add_with_datafile_creation_shortcut(self):
-        """ Ensures that when a dataset is not empty, it can be added to
-        """
+        """Ensures that when a dataset is not empty, it can be added to"""
         resource = Dataset()
         resource.add(path="path-within-dataset/a_test_file.csv")
         self.assertEqual(len(resource.files), 1)
 
     def test_add_multiple_files(self):
-        """ Ensures that when a dataset is not empty, it can be added to
-        """
+        """Ensures that when a dataset is not empty, it can be added to"""
         files = [
             Datafile(path="path-within-dataset/a_test_file.csv"),
             Datafile(path="path-within-dataset/a_test_file.csv"),
@@ -76,8 +70,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(len(resource.files), 2)
 
     def test_cannot_add_non_datafiles(self):
-        """ Ensures that exception will be raised if adding a non-datafile object
-        """
+        """Ensures that exception will be raised if adding a non-datafile object"""
 
         class NotADatafile:
             pass
@@ -89,8 +82,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertIn("must be of class Datafile to add it to a Dataset", e.exception.args[0])
 
     def test_filter_catches_single_underscore_mistake(self):
-        """ Ensures that if the field name is a single underscore, that gets caught as an error
-        """
+        """Ensures that if the field name is a single underscore, that gets caught as an error"""
         resource = Dataset(
             files=[
                 Datafile(path="path-within-dataset/A_Test_file.csv"),
@@ -108,8 +100,7 @@ class DatasetTestCase(BaseTestCase):
         )
 
     def test_filter_name_contains(self):
-        """ Ensures that filter works with the name_contains and name_icontains lookups
-        """
+        """Ensures that filter works with the name_contains and name_icontains lookups"""
         resource = Dataset(
             files=[
                 Datafile(path="path-within-dataset/A_Test_file.csv"),
@@ -128,8 +119,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(2, len(files))
 
     def test_filter_name_with(self):
-        """ Ensures that filter works with the name_endswith and name_startswith lookups
-        """
+        """Ensures that filter works with the name_endswith and name_startswith lookups"""
         resource = Dataset(
             files=[
                 Datafile(path="path-within-dataset/a_my_file.csv"),
@@ -154,8 +144,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(0, len(files))
 
     def test_filter_by_tag(self):
-        """ Ensures that filter works with tag lookups
-        """
+        """Ensures that filter works with tag lookups"""
         resource = Dataset(
             files=[
                 Datafile(path="path-within-dataset/a_my_file.csv", tags="one a:2 b:3 all"),
@@ -178,8 +167,7 @@ class DatasetTestCase(BaseTestCase):
         # self.assertEqual(1, len(files))
 
     def test_get_file_by_tag(self):
-        """ Ensures that get_files works with tag lookups
-        """
+        """Ensures that get_files works with tag lookups"""
         files = [
             Datafile(path="path-within-dataset/a_my_file.csv", tags="one a:2 b:3 all"),
             Datafile(path="path-within-dataset/a_your_file.csv", tags="two a:2 b:3 all"),
@@ -204,8 +192,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertIn("No files found with this tag", e.exception.args[0])
 
     def test_filter_by_sequence_not_none(self):
-        """ Ensures that filter works with sequence lookups
-        """
+        """Ensures that filter works with sequence lookups"""
         resource = Dataset(
             files=[
                 Datafile(path="path-within-dataset/a_my_file.csv", sequence=0),
@@ -217,8 +204,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(2, len(files))
 
     def test_get_file_sequence(self):
-        """ Ensures that get_files works with sequence lookups
-        """
+        """Ensures that get_files works with sequence lookups"""
         files = [
             Datafile(path="path-within-dataset/a_my_file.csv", sequence=0),
             Datafile(path="path-within-dataset/a_your_file.csv", sequence=1),
@@ -229,8 +215,7 @@ class DatasetTestCase(BaseTestCase):
         self.assertEqual(got_files, files[:2])
 
     def test_get_broken_file_sequence(self):
-        """ Ensures that get_files works with sequence lookups
-        """
+        """Ensures that get_files works with sequence lookups"""
         resource = Dataset(
             files=[
                 Datafile(path="path-within-dataset/a_my_file.csv", sequence=2),
@@ -242,8 +227,7 @@ class DatasetTestCase(BaseTestCase):
             resource.get_file_sequence("name__ends_with", filter_value=".csv", strict=True)
 
     def test_filter_name_filters_include_extension(self):
-        """ Ensures that filters applied to the name will catch terms in the extension
-        """
+        """Ensures that filters applied to the name will catch terms in the extension"""
         files = [
             Datafile(path="path-within-dataset/a_test_file.csv"),
             Datafile(path="path-within-dataset/a_test_file.txt"),
@@ -254,8 +238,7 @@ class DatasetTestCase(BaseTestCase):
         )
 
     def test_filter_name_filters_exclude_path(self):
-        """ Ensures that filters applied to the name will not catch terms in the extension
-        """
+        """Ensures that filters applied to the name will not catch terms in the extension"""
         resource = Dataset(
             files=[
                 Datafile(path="first-path-within-dataset/a_test_file.csv"),

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -1,8 +1,7 @@
-from tests.base import BaseTestCase
-
 from octue import exceptions
 from octue.mixins import Filterable
 from octue.resources.filter_containers import FilterList, FilterSet
+from tests.base import BaseTestCase
 
 
 class Cat(Filterable):

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -1,4 +1,5 @@
 import copy
+
 from tests.base import BaseTestCase
 
 

--- a/tests/resources/test_tag.py
+++ b/tests/resources/test_tag.py
@@ -1,7 +1,6 @@
-from tests.base import BaseTestCase
-
 from octue.resources.filter_containers import FilterSet
 from octue.resources.tag import Tag, TagSet
+from tests.base import BaseTestCase
 
 
 class TestTag(BaseTestCase):

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -27,8 +27,7 @@ class TemplateAppsTestCase(BaseTestCase):
         self.teardown_templates = []
 
         def set_template(template):
-            """ Sets up the working directory and data paths to run one of the provided templates
-            """
+            """Sets up the working directory and data paths to run one of the provided templates"""
             self.template_path = os.path.join(self.templates_path, template)
             self.template_twine = os.path.join(self.templates_path, template, "twine.json")
 
@@ -46,8 +45,7 @@ class TemplateAppsTestCase(BaseTestCase):
         self.set_template = set_template
 
     def tearDown(self):
-        """ Remove data directories manufactured
-        """
+        """Remove data directories manufactured"""
         super().tearDown()
         os.chdir(self.start_path)
         for path in self.teardown_templates:
@@ -70,7 +68,8 @@ class TemplateAppsTestCase(BaseTestCase):
         """ Ensures using-manifests app works correctly. """
         self.set_template("template-using-manifests")
         runner = Runner(
-            twine=self.template_twine, configuration_values=os.path.join("data", "configuration", "values.json"),
+            twine=self.template_twine,
+            configuration_values=os.path.join("data", "configuration", "values.json"),
         )
         analysis = runner.run(
             app_src=self.template_path,
@@ -81,7 +80,7 @@ class TemplateAppsTestCase(BaseTestCase):
         self.assertTrue(os.path.isfile(os.path.join("data", "output", "cleaned_met_mast_data", "cleaned.csv")))
 
     def test_child_services_template(self):
-        """ Ensure the child services template works correctly (i.e. that children can be accessed by a parent and data
+        """Ensure the child services template works correctly (i.e. that children can be accessed by a parent and data
         collected from them). This template has a parent app and two children - an elevation app and wind speed app. The
         parent sends coordinates to both children, receiving the elevation and wind speed from them at these locations.
         """

--- a/tests/templates/test_templates.py
+++ b/tests/templates/test_templates.py
@@ -8,8 +8,7 @@ from ..base import BaseTestCase
 
 
 class TemplatesTestCase(BaseTestCase):
-    """ Test parts of the utils library not otherwise covered by other tests
-    """
+    """Test parts of the utils library not otherwise covered by other tests"""
 
     def setUp(self):
         super().setUp()
@@ -18,30 +17,26 @@ class TemplatesTestCase(BaseTestCase):
         self.tmp_dir_name = os.path.join(gettempdir(), "octue-sdk-python", f"test-{self.test_id}")
 
     def tearDown(self):
-        """ Remove data directories manufactured and ensure we end up in the right place
-        """
+        """Remove data directories manufactured and ensure we end up in the right place"""
         super().tearDown()
         os.chdir(self.start_path)
 
     def test_copy_templates_to_directory(self):
-        """ Ensures that a known template will copy to a given directory
-        """
+        """Ensures that a known template will copy to a given directory"""
         with TemporaryDirectory() as tmp_dir:
             copy_template("template-python-fractal", tmp_dir)
             twine_file_name = os.path.join(tmp_dir, "template-python-fractal", "twine.json")
             self.assertTrue(os.path.isfile(twine_file_name))
 
     def test_copy_templates_to_current_directory_by_default(self):
-        """ Ensures that a known template will copy to the current directory by default
-        """
+        """Ensures that a known template will copy to the current directory by default"""
         with TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             copy_template("template-python-fractal")
             self.assertTrue(os.path.isfile(os.path.join(".", "template-python-fractal", "twine.json")))
 
     def test_copy_template_raises_if_unknown(self):
-        """ Ensures that a known template will copy to a given directory
-        """
+        """Ensures that a known template will copy to a given directory"""
         with TemporaryDirectory() as tmp_dir:
             with self.assertRaises(exceptions.InvalidInputException) as error:
                 copy_template("template-which-isnt-there", tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,11 @@ import tempfile
 import uuid
 from unittest import mock
 from click.testing import CliRunner
+
+from octue.cli import octue_cli
 from tests import TESTS_DIR
 from tests.app import CUSTOM_APP_RUN_MESSAGE
 from tests.base import BaseTestCase
-
-from octue.cli import octue_cli
 
 
 class RunnerTestCase(BaseTestCase):

--- a/tests/test_logging_handlers.py
+++ b/tests/test_logging_handlers.py
@@ -1,8 +1,8 @@
 import logging
 from unittest import mock
-from tests.base import BaseTestCase
 
 from octue.logging_handlers import get_remote_handler
+from tests.base import BaseTestCase
 
 
 class TestGetRemoteHandler(BaseTestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -9,14 +9,12 @@ def mock_app(analysis):
 
 class RunnerTestCase(BaseTestCase):
     def test_instantiate_runner(self):
-        """ Ensures that runner whose twine requires configuration can be instantiated
-        """
+        """Ensures that runner whose twine requires configuration can be instantiated"""
         runner = Runner(twine="{}")
         self.assertEqual(runner.__class__.__name__, "Runner")
 
     def test_run_with_configuration_passes(self):
-        """ Ensures that runs can be made with configuration only
-        """
+        """Ensures that runs can be made with configuration only"""
         runner = Runner(
             twine="""{
             "configuration_values_schema": {
@@ -34,8 +32,7 @@ class RunnerTestCase(BaseTestCase):
         runner.run(mock_app)
 
     def test_instantiation_without_configuration_fails(self):
-        """ Ensures that runner can be instantiated with a string that points to a path
-        """
+        """Ensures that runner can be instantiated with a string that points to a path"""
         with self.assertRaises(twined.exceptions.TwineValueException) as error:
             Runner(
                 twine="""{
@@ -56,8 +53,7 @@ class RunnerTestCase(BaseTestCase):
         )
 
     def test_run_output_values_validation(self):
-        """ Ensures that runner can be instantiated with a string that points to a path
-        """
+        """Ensures that runner can be instantiated with a string that points to a path"""
         runner = Runner(
             twine="""{
             "output_values_schema": {
@@ -85,8 +81,7 @@ class RunnerTestCase(BaseTestCase):
         runner.run(fcn).finalise()
 
     def test_exception_raised_when_strand_data_missing(self):
-        """ Ensures that protected attributes can't be set
-        """
+        """Ensures that protected attributes can't be set"""
         runner = Runner(
             twine="""{
                 "configuration_values_schema": {


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Use latest versions of `flake8`, `isort`, and `black` in pre-commit
- [x] Apply new versions to all files retrospectively