### PR TITLE
Fix: Allow storage emulator to find and use a free port

### DIFF
--- a/octue/utils/cloud/storage/client.py
+++ b/octue/utils/cloud/storage/client.py
@@ -103,7 +103,7 @@ class GoogleCloudStorageClient:
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
         metadata = bucket.get_blob(blob_name=self._strip_leading_slash(path_in_bucket), timeout=timeout)._properties
 
-        if metadata["metadata"] is not None:
+        if metadata.get("metadata") is not None:
             metadata["metadata"] = {key: json.loads(value) for key, value in metadata["metadata"].items()}
 
         return metadata

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,23 @@
 import os
+import socket
 import unittest
+from contextlib import closing
 
 from tests.emulators import GoogleCloudStorageEmulator
 
 
 TESTS_DIR = os.path.dirname(__file__)
-storage_emulator = GoogleCloudStorageEmulator()
+
+
+def get_free_tcp_port():
+    """Get a free TCP port.
+
+    :return int:
+    """
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        _, port = s.getsockname()
+        return port
 
 
 def startTestRun(instance):
@@ -14,6 +26,7 @@ def startTestRun(instance):
     :param unittest.TestResult instance:
     :return None:
     """
+    os.environ["STORAGE_EMULATOR_HOST"] = STORAGE_EMULATOR_HOST
     storage_emulator.start()
 
 
@@ -24,7 +37,12 @@ def stopTestRun(instance):
     :return None:
     """
     storage_emulator.stop()
+    del os.environ["STORAGE_EMULATOR_HOST"]
 
+
+PORT = get_free_tcp_port()
+STORAGE_EMULATOR_HOST = f"http://localhost:{PORT}"
+storage_emulator = GoogleCloudStorageEmulator(port=PORT)
 
 setattr(unittest.TestResult, "startTestRun", startTestRun)
 setattr(unittest.TestResult, "stopTestRun", stopTestRun)


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Allow storage emulator to find and use a free port
- [x] Remove need for `STORAGE_EMULATOR_HOST` environment variable for tests
- [x] Avoid assuming custom metadata is set in storage client 