### PR TITLE
Release/0.1.11

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           TEST_PROJECT_NAME: ${{ secrets.TEST_PROJECT_NAME }}
-          TEST_BUCKET_NAME: ${{ secrets.TEST_BUCKET_NAME }}
         run: |
           coverage run --source octue -m unittest discover
           coverage report --show-missing

--- a/README.md
+++ b/README.md
@@ -9,8 +9,34 @@
 
 Utilities for running python based data services, digital twins and applications with the Octue toolkit and [twined](https://twined.readthedocs.io/en/latest/?badge=latest) SDK for python based apps running within octue.
 
+## Installation and usage
+For usage as a scientist or engineer, run the following command in your environment:
+```shell
+pip install octue
+```
+
+The command line interface (CLI) can then be accessed via:
+```shell
+octue-app --help
+```
 
 ## Developer notes
+
+### Installation
+For development, run the following from the repository root, which will editably install the package:
+```bash
+pip install -r requirements-dev.txt
+```
+
+### Testing
+These environment variables need to be set to run the tests:
+* `GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/service/account/file.json`
+* `TEST_PROJECT_NAME=<name-of-google-cloud-project-to-run-pub-sub-tests-on>`
+
+Then, from the repository root, run
+```bash
+python3 -m unittest
+```
 
 **Documentation for use of the library is [here](https://octue-python-sdk.readthedocs.io). You don't need to pay attention to the following unless you plan to develop `octue-sdk-python` itself.**
 
@@ -78,7 +104,7 @@ roadmap, into which you can make your PR. We'll help review the changes and impr
 The process for creating a new release is as follows:
 
 1. Check out a branch for the next version, called `vX.Y.Z`
-2. Create a Pull Request into the `master` branch.
+2. Create a Pull Request into the `main` branch.
 3. Undertake your changes, committing and pushing to branch `vX.Y.Z`
 4. Ensure that documentation is updated to match changes, and increment the changelog. **Pull requests which do not update documentation will be refused.**
 5. Ensure that test coverage is sufficient. **Pull requests that decrease test coverage will be refused.**

--- a/octue/utils/cloud/emulators.py
+++ b/octue/utils/cloud/emulators.py
@@ -13,7 +13,7 @@ class GoogleCloudStorageEmulator:
     :return None:
     """
 
-    def __init__(self, host="localhost", port=9090, in_memory=True, default_bucket=os.environ["TEST_BUCKET_NAME"]):
+    def __init__(self, host="localhost", port=9090, in_memory=True, default_bucket=None):
         self._server = create_server(host, port, in_memory=in_memory, default_bucket=default_bucket)
 
     def __enter__(self):
@@ -64,7 +64,7 @@ class GoogleCloudStorageEmulatorTestResultModifier:
 
     STORAGE_EMULATOR_HOST_ENVIRONMENT_VARIABLE_NAME = "STORAGE_EMULATOR_HOST"
 
-    def __init__(self, host="localhost", in_memory=True, default_bucket_name=os.environ["TEST_BUCKET_NAME"]):
+    def __init__(self, host="localhost", in_memory=True, default_bucket_name=None):
         port = get_free_tcp_port()
         self.storage_emulator_host = f"http://{host}:{port}"
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.1.10",
+    version="0.1.11",
     py_modules=["cli"],
     install_requires=[
         "blake3>=0.1.8",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,8 +5,9 @@ from octue.utils.cloud.emulators import GoogleCloudStorageEmulatorTestResultModi
 
 
 TESTS_DIR = os.path.dirname(__file__)
+TEST_PROJECT_NAME = os.environ["TEST_PROJECT_NAME"]
+TEST_BUCKET_NAME = "octue-test-bucket"
 
-
-test_result_modifier = GoogleCloudStorageEmulatorTestResultModifier()
+test_result_modifier = GoogleCloudStorageEmulatorTestResultModifier(default_bucket_name=TEST_BUCKET_NAME)
 setattr(unittest.TestResult, "startTestRun", test_result_modifier.startTestRun)
 setattr(unittest.TestResult, "stopTestRun", test_result_modifier.stopTestRun)

--- a/tests/resources/communication/google_pub_sub/test_service.py
+++ b/tests/resources/communication/google_pub_sub/test_service.py
@@ -1,5 +1,4 @@
 import concurrent.futures
-import os
 import time
 import uuid
 import google.api_core.exceptions
@@ -8,6 +7,7 @@ from octue import exceptions
 from octue.resources.communication.google_pub_sub.service import OCTUE_NAMESPACE, Service
 from octue.resources.communication.service_backends import GCPPubSubBackend
 from octue.resources.manifest import Manifest
+from tests import TEST_PROJECT_NAME
 from tests.base import BaseTestCase
 
 
@@ -34,7 +34,7 @@ class TestService(BaseTestCase):
     (GCP), or a local emulator."""
 
     BACKEND = GCPPubSubBackend(
-        project_name=os.environ["TEST_PROJECT_NAME"], credentials_environment_variable="GOOGLE_APPLICATION_CREDENTIALS"
+        project_name=TEST_PROJECT_NAME, credentials_environment_variable="GOOGLE_APPLICATION_CREDENTIALS"
     )
 
     @staticmethod

--- a/tests/utils/cloud/storage/test_client.py
+++ b/tests/utils/cloud/storage/test_client.py
@@ -1,23 +1,19 @@
 import json
-import os
 import tempfile
 from unittest.mock import patch
 import google.api_core.exceptions
 
 from octue.utils.cloud import storage
-from octue.utils.cloud.storage.client import OCTUE_MANAGED_CREDENTIALS, GoogleCloudStorageClient
+from octue.utils.cloud.storage.client import GoogleCloudStorageClient
+from tests import TEST_BUCKET_NAME, TEST_PROJECT_NAME
 from tests.base import BaseTestCase
 
 
 class TestUploadFileToGoogleCloud(BaseTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.PROJECT_NAME = os.environ["TEST_PROJECT_NAME"]
-        cls.TEST_BUCKET_NAME = os.environ["TEST_BUCKET_NAME"]
         cls.FILENAME = "my_file.txt"
-        cls.storage_client = GoogleCloudStorageClient(
-            project_name=cls.PROJECT_NAME, credentials=OCTUE_MANAGED_CREDENTIALS
-        )
+        cls.storage_client = GoogleCloudStorageClient(project_name=TEST_PROJECT_NAME)
 
     def test_upload_and_download_file(self):
         """Test that a file can be uploaded to Google Cloud storage and downloaded again."""
@@ -29,14 +25,14 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
             self.storage_client.upload_file(
                 local_path=upload_local_path,
-                bucket_name=self.TEST_BUCKET_NAME,
+                bucket_name=TEST_BUCKET_NAME,
                 path_in_bucket=self.FILENAME,
             )
 
             download_local_path = f"{temporary_directory}/{self.FILENAME}-download"
 
             self.storage_client.download_to_file(
-                bucket_name=self.TEST_BUCKET_NAME, path_in_bucket=self.FILENAME, local_path=download_local_path
+                bucket_name=TEST_BUCKET_NAME, path_in_bucket=self.FILENAME, local_path=download_local_path
             )
 
             with open(download_local_path) as f:
@@ -58,7 +54,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
                 with self.assertRaises(google.api_core.exceptions.BadRequest) as e:
                     self.storage_client.upload_file(
                         local_path=upload_local_path,
-                        bucket_name=self.TEST_BUCKET_NAME,
+                        bucket_name=TEST_BUCKET_NAME,
                         path_in_bucket=self.FILENAME,
                     )
 
@@ -69,14 +65,14 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             self.storage_client.upload_from_string(
                 string=json.dumps({"height": 32}),
-                bucket_name=self.TEST_BUCKET_NAME,
+                bucket_name=TEST_BUCKET_NAME,
                 path_in_bucket=self.FILENAME,
             )
 
             download_local_path = f"{temporary_directory}/{self.FILENAME}-download"
 
             self.storage_client.download_to_file(
-                bucket_name=self.TEST_BUCKET_NAME, path_in_bucket=self.FILENAME, local_path=download_local_path
+                bucket_name=TEST_BUCKET_NAME, path_in_bucket=self.FILENAME, local_path=download_local_path
             )
 
             with open(download_local_path) as f:
@@ -91,7 +87,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
             with self.assertRaises(google.api_core.exceptions.BadRequest) as e:
                 self.storage_client.upload_from_string(
                     string=json.dumps({"height": 15}),
-                    bucket_name=self.TEST_BUCKET_NAME,
+                    bucket_name=TEST_BUCKET_NAME,
                     path_in_bucket=self.FILENAME,
                 )
 
@@ -108,12 +104,12 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
             self.storage_client.upload_file(
                 local_path=upload_local_path,
-                bucket_name=self.TEST_BUCKET_NAME,
+                bucket_name=TEST_BUCKET_NAME,
                 path_in_bucket=self.FILENAME,
             )
 
         self.assertEqual(
-            self.storage_client.download_as_string(bucket_name=self.TEST_BUCKET_NAME, path_in_bucket=self.FILENAME),
+            self.storage_client.download_as_string(bucket_name=TEST_BUCKET_NAME, path_in_bucket=self.FILENAME),
             "This is a test upload.",
         )
 
@@ -121,21 +117,21 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         """Test that a file can be deleted."""
         self.storage_client.upload_from_string(
             string=json.dumps({"height": 32}),
-            bucket_name=self.TEST_BUCKET_NAME,
+            bucket_name=TEST_BUCKET_NAME,
             path_in_bucket=self.FILENAME,
         )
 
         self.assertEqual(
             json.loads(
-                self.storage_client.download_as_string(bucket_name=self.TEST_BUCKET_NAME, path_in_bucket=self.FILENAME),
+                self.storage_client.download_as_string(bucket_name=TEST_BUCKET_NAME, path_in_bucket=self.FILENAME),
             ),
             {"height": 32},
         )
 
-        self.storage_client.delete(bucket_name=self.TEST_BUCKET_NAME, path_in_bucket=self.FILENAME)
+        self.storage_client.delete(bucket_name=TEST_BUCKET_NAME, path_in_bucket=self.FILENAME)
 
         with self.assertRaises(google.api_core.exceptions.NotFound):
-            self.storage_client.download_as_string(bucket_name=self.TEST_BUCKET_NAME, path_in_bucket=self.FILENAME)
+            self.storage_client.download_as_string(bucket_name=TEST_BUCKET_NAME, path_in_bucket=self.FILENAME)
 
     def test_scandir(self):
         """Test that Google Cloud storage "directories"' contents can be listed."""
@@ -143,30 +139,30 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
         self.storage_client.upload_from_string(
             string=json.dumps({"height": 32}),
-            bucket_name=self.TEST_BUCKET_NAME,
+            bucket_name=TEST_BUCKET_NAME,
             path_in_bucket=storage.path.join(directory_path, self.FILENAME),
         )
 
-        contents = list(self.storage_client.scandir(bucket_name=self.TEST_BUCKET_NAME, directory_path=directory_path))
+        contents = list(self.storage_client.scandir(bucket_name=TEST_BUCKET_NAME, directory_path=directory_path))
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[0].name, storage.path.join(directory_path, self.FILENAME))
 
     def test_scandir_with_empty_directory(self):
         """Test that an empty directory shows as such."""
         directory_path = storage.path.join("another", "path")
-        contents = list(self.storage_client.scandir(bucket_name=self.TEST_BUCKET_NAME, directory_path=directory_path))
+        contents = list(self.storage_client.scandir(bucket_name=TEST_BUCKET_NAME, directory_path=directory_path))
         self.assertEqual(len(contents), 0)
 
     def test_get_metadata(self):
         """Test that file metadata can be retrieved."""
         self.storage_client.upload_from_string(
             string=json.dumps({"height": 32}),
-            bucket_name=self.TEST_BUCKET_NAME,
+            bucket_name=TEST_BUCKET_NAME,
             path_in_bucket=self.FILENAME,
         )
 
         metadata = self.storage_client.get_metadata(
-            bucket_name=self.TEST_BUCKET_NAME,
+            bucket_name=TEST_BUCKET_NAME,
             path_in_bucket=self.FILENAME,
         )
 

--- a/tests/utils/cloud/test_emulators.py
+++ b/tests/utils/cloud/test_emulators.py
@@ -1,0 +1,22 @@
+import unittest
+
+from octue.utils.cloud.emulators import GoogleCloudStorageEmulatorTestResultModifier
+
+
+class TestGoogleCloudStorageEmulatorTestResultModifier(unittest.TestCase):
+    def test_multiple_emulators_can_be_created_at_once(self):
+        """Test that multiple storage emulators can be created at once without error and that they are given different
+        ports.
+        """
+        emulator_0 = GoogleCloudStorageEmulatorTestResultModifier()
+        emulator_1 = GoogleCloudStorageEmulatorTestResultModifier()
+        self.assertNotEqual(emulator_0.storage_emulator_host, emulator_1.storage_emulator_host)
+
+    def test_multiple_emulators_can_start_at_once(self):
+        """Test that multiple storage emulators can be created and started at once without error."""
+        emulator_0 = GoogleCloudStorageEmulatorTestResultModifier()
+        emulator_0.storage_emulator.start()
+        emulator_1 = GoogleCloudStorageEmulatorTestResultModifier()
+        emulator_1.storage_emulator.start()
+        emulator_0.storage_emulator.stop()
+        emulator_1.storage_emulator.stop()


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Remove test bucket environment variable
- [x] Remove environment variable default argument from `GoogleCloudStorageEmulator`
- [x] Add installation, usage, and testing instructions to README 

### Testing
- [x] Test ability to start more than one Google Cloud Storage emulator at once