### PR TITLE
Fix/hashing dependencies

### DIFF
--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime
-from blake3 import blake3
+from google_crc32c import Checksum
 
 from octue.exceptions import FileNotFoundException, InvalidInputException
 from octue.mixins import Filterable, Hashable, Identifiable, Loggable, Pathable, Serialisable, Taggable
@@ -182,7 +182,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
     def _calculate_hash(self):
         """Calculate the hash of the file."""
-        hash = blake3()
+        hash = Checksum()
 
         with open(self.absolute_path, "rb") as f:
             # Read and update hash value in blocks of 4K

--- a/octue/utils/cloud/storage/client.py
+++ b/octue/utils/cloud/storage/client.py
@@ -1,9 +1,9 @@
 import base64
 import json
 import logging
-from crc32c import crc32c
 from google.cloud import storage
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
+from google_crc32c import Checksum
 
 from octue.utils.cloud.credentials import GCPCredentialsManager
 
@@ -162,8 +162,8 @@ class GoogleCloudStorageClient:
         :param str string:
         :return str:
         """
-        checksum = crc32c(string.encode())
-        return base64.b64encode(checksum.to_bytes(length=4, byteorder="big")).decode("utf-8")
+        checksum = Checksum(string.encode())
+        return base64.b64encode(checksum.digest()).decode("utf-8")
 
     def _update_metadata(self, blob, metadata):
         """Update the metadata for the given blob. Note that this is synced up with Google Cloud.

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,9 @@ setup(
     version="0.1.11",
     py_modules=["cli"],
     install_requires=[
-        "blake3>=0.1.8",
         "click>=7.1.2",
         "coolname>=1.1.0",
-        "crc32c>=2.2",
+        "google-crc32c>=1.1.2",
         "google-cloud-pubsub>=2.2.0",
         "google-cloud-storage>=1.35.1",
         "twined==0.0.16",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "blake3>=0.1.8",
         "click>=7.1.2",
         "coolname>=1.1.0",
-        "crcmod>=1.7",
+        "crc32c>=2.2",
         "google-cloud-pubsub>=2.2.0",
         "google-cloud-storage>=1.35.1",
         "twined==0.0.16",

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -62,7 +62,7 @@ class HashableTestCase(BaseTestCase):
     def test_set_hash_value_overrides_calculated_hash(self):
         """Test that hash values that are set override the calculated value."""
         type_with_hash = TypeWithAttributeToHash()
-        self.assertEqual(len(type_with_hash.hash_value), 64)
+        self.assertEqual(len(type_with_hash.hash_value), 8)
 
         type_with_hash.hash_value = "hello"
         self.assertEqual(type_with_hash.hash_value, "hello")
@@ -71,7 +71,7 @@ class HashableTestCase(BaseTestCase):
         """Test that hash values can be set and then reset to the calculated value."""
         type_with_hash = TypeWithAttributeToHash()
         original_calculated_hash = type_with_hash.hash_value
-        self.assertEqual(len(original_calculated_hash), 64)
+        self.assertEqual(len(original_calculated_hash), 8)
 
         type_with_hash.hash_value = "hello"
         self.assertEqual(type_with_hash.hash_value, "hello")

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -43,4 +43,4 @@ class AnalysisTestCase(BaseTestCase):
         for strand_name in _HASH_FUNCTIONS:
             hash_ = getattr(analysis, f"{strand_name}_hash")
             self.assertTrue(isinstance(hash_, str))
-            self.assertTrue(len(hash_) == 64)
+            self.assertTrue(len(hash_) == 8)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -123,10 +123,10 @@ class DatafileTestCase(BaseTestCase):
             self.assertIn(k, df_dict.keys())
 
     def test_hash_value(self):
-        """ Test hashing a datafile gives a hash of length 128. """
+        """Test hashing a datafile gives a hash of length 8."""
         hash_ = self.create_valid_datafile().hash_value
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 64)
+        self.assertTrue(len(hash_) == 8)
 
     def test_hashes_for_the_same_datafile_are_the_same(self):
         """ Ensure the hashes for two datafiles that are exactly the same are the same."""

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -271,10 +271,10 @@ class DatasetTestCase(BaseTestCase):
             self.assertEqual(len(filtered_files), 0)
 
     def test_hash_value(self):
-        """ Test hashing a dataset with multiple files gives a hash of length 128. """
+        """Test hashing a dataset with multiple files gives a hash of length 8."""
         hash_ = self.create_valid_dataset().hash_value
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 64)
+        self.assertTrue(len(hash_) == 8)
 
     def test_hashes_for_the_same_dataset_are_the_same(self):
         """ Ensure the hashes for two datasets that are exactly the same are the same."""

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -12,11 +12,11 @@ from tests.base import BaseTestCase
 
 class TestManifest(BaseTestCase):
     def test_hash_value(self):
-        """ Test hashing a manifest with multiple datasets gives a hash of length 128. """
+        """Test hashing a manifest with multiple datasets gives a hash of length 8."""
         manifest = self.create_valid_manifest()
         hash_ = manifest.hash_value
         self.assertTrue(isinstance(hash_, str))
-        self.assertTrue(len(hash_) == 64)
+        self.assertTrue(len(hash_) == 8)
 
     def test_hashes_for_the_same_manifest_are_the_same(self):
         """ Ensure the hashes for two manifests that are exactly the same are the same."""


### PR DESCRIPTION
## Contents

### Minor fixes and improvements

- [x] Use CRC32C hash function instead of Blake3 (due to extra requirements of Blake3 and the fact that Google Cloud uses CRC32C)