### PR TITLE
Allow datetime timestamps for datafiles; use GCS custom time field for Datafile.timestamp

### DIFF
--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -198,7 +198,7 @@ class GoogleCloudStorageClient:
         :return None:
         """
         if metadata is not None:
-            blob.custom_time = metadata.pop("timestamp")
+            blob.custom_time = metadata.pop("timestamp", None)
             blob.metadata = self._encode_metadata(metadata)
             blob.patch()
 

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -121,7 +121,10 @@ class GoogleCloudStorageClient:
         blob = bucket.get_blob(blob_name=self._strip_leading_slash(path_in_bucket), timeout=timeout)
         metadata = blob._properties
 
-        # Get custom time from blob rather than properties so that it is a datetime.datetime object and not a string.
+        # Get timestamps from blob rather than properties so they are datetime.datetime objects rather than strings.
+        metadata["updated"] = blob.updated
+        metadata["timeCreated"] = blob.time_created
+        metadata["timeDeleted"] = blob.time_deleted
         metadata["customTime"] = blob.custom_time
 
         # Decode custom metadata from JSON.

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -1,5 +1,6 @@
 import base64
 import collections.abc
+import datetime
 from google_crc32c import Checksum
 
 
@@ -9,6 +10,7 @@ _HASH_PREPARATION_FUNCTIONS = {
     float: str,
     type(None): lambda attribute: "None",
     dict: lambda attribute: str(sorted(attribute.items())),
+    datetime.datetime: str,
 }
 
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import tempfile
@@ -9,7 +10,7 @@ from octue.cloud.storage.path import CLOUD_STORAGE_PROTOCOL
 from octue.exceptions import AttributeConflict, FileNotFoundException, InvalidInputException
 from octue.mixins import Filterable, Hashable, Identifiable, Loggable, Pathable, Serialisable, Taggable
 from octue.utils import isfile
-from octue.utils.time import convert_to_posix_time
+from octue.utils.time import convert_from_posix_time, convert_to_posix_time
 
 
 module_logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
           "sha-512/256": "somesha"
         },
 
-    :parameter datetime.datetime|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when
+    :parameter datetime.datetime|int|float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when
         it was created but could relate to a relevant time point for the data
     :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
     :param logging.Logger logger: A logger instance to which operations with this datafile will be logged. Defaults to
@@ -206,6 +207,27 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     @property
     def name(self):
         return self._name or str(os.path.split(self.path)[-1])
+
+    @property
+    def timestamp(self):
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, value):
+        """Set the datafile's timestamp.
+
+        :param datetime.datetime|int|float|None value:
+        :raise TypeError: if value is of an incorrect type
+        :return None:
+        """
+        if isinstance(value, datetime.datetime) or value is None:
+            self._timestamp = value
+        elif isinstance(value, (int, float)):
+            self._timestamp = convert_from_posix_time(value)
+        else:
+            raise TypeError(
+                f"timestamp should be a datetime.datetime instance, an int, a float, or None; received {value!r}"
+            )
 
     @property
     def posix_timestamp(self):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -211,13 +211,12 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     def _last_modified(self):
         """Get the date/time the file was last modified in units of seconds since epoch (posix time)."""
         if self._path_is_in_google_cloud_storage:
-            unparsed_datetime = self._cloud_metadata.get("updated")
+            last_modified = self._cloud_metadata.get("updated")
 
-            if unparsed_datetime is None:
+            if last_modified is None:
                 return None
 
-            parsed_datetime = datetime.strptime(unparsed_datetime, "%Y-%m-%dT%H:%M:%S.%fZ")
-            return (parsed_datetime - datetime(1970, 1, 1)).total_seconds()
+            return (last_modified - datetime(1970, 1, 1, tzinfo=last_modified.tzinfo)).total_seconds()
 
         return os.path.getmtime(self.absolute_path)
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -35,13 +35,13 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
           "sequence": 0,
           "extension": "csv",
           "tags": "",
-          "timestamp": 0,
+          "timestamp": datetime.datetime(2021, 5, 3, 18, 15, 58, 298086),
           "id": "abff07bc-7c19-4ed5-be6d-a6546eae8e86",
           "size_bytes": 59684813,
           "sha-512/256": "somesha"
         },
 
-    :parameter float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when
+    :parameter datetime.datetime|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when
         it was created but could relate to a relevant time point for the data
     :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
     :param logging.Logger logger: A logger instance to which operations with this datafile will be logged. Defaults to
@@ -173,7 +173,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
                 )
 
         datafile = cls(
-            timestamp=kwargs.get("timestamp", custom_metadata.get("timestamp")),
+            timestamp=kwargs.get("timestamp", metadata.get("customTime")),
             id=kwargs.get("id", custom_metadata.get("id", ID_DEFAULT)),
             path=storage.path.generate_gs_path(bucket_name, datafile_path),
             hash_value=kwargs.get("hash_value", custom_metadata.get("hash_value", metadata.get("crc32c", None))),

--- a/octue/utils/time.py
+++ b/octue/utils/time.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def convert_to_posix_time(timestamp):
@@ -8,3 +8,12 @@ def convert_to_posix_time(timestamp):
     :return float:
     """
     return (timestamp - datetime(1970, 1, 1, tzinfo=timestamp.tzinfo)).total_seconds()
+
+
+def convert_from_posix_time(posix_timestamp):
+    """Convert a posix timestamp to a datetime timestamp.
+
+    :param int|float posix_timestamp:
+    :return datetime.datetime:
+    """
+    return datetime(1970, 1, 1) + timedelta(seconds=posix_timestamp)

--- a/octue/utils/time.py
+++ b/octue/utils/time.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+
+def convert_to_posix_time(timestamp):
+    """Convert a datetime timestamp to posix time (i.e. seconds since epoch: 1st January 1970).
+
+    :param datetime.datetime timestamp:
+    :return float:
+    """
+    return (timestamp - datetime(1970, 1, 1, tzinfo=timestamp.tzinfo)).total_seconds()

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -43,6 +43,16 @@ class DatafileTestCase(BaseTestCase):
 
         self.assertIn("__init__() missing 1 required positional argument: 'path'", error.exception.args[0])
 
+    def test_setting_timestamp(self):
+        """Test that both datetime and posix timestamps can be used for a Datafile, that the timestamp attribute is
+        always converted to a datetime instance, and that invalid timestamps raise an error.
+        """
+        self.assertTrue(isinstance(Datafile(timestamp=datetime.now(), path="a_path").timestamp, datetime))
+        self.assertTrue(isinstance(Datafile(timestamp=50, path="a_path").timestamp, datetime))
+
+        with self.assertRaises(TypeError):
+            Datafile(timestamp="50", path="a_path")
+
     def test_gt(self):
         """Test that datafiles can be ordered using the greater-than operator."""
         a = Datafile(timestamp=None, path="a_path")

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -3,6 +3,7 @@ import json
 import os
 import tempfile
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from octue import exceptions
@@ -147,7 +148,7 @@ class DatafileTestCase(BaseTestCase):
         )
 
         datafile = Datafile.from_cloud(
-            project_name=TEST_PROJECT_NAME, bucket_name=TEST_BUCKET_NAME, datafile_path=path_in_bucket, timestamp=None
+            project_name=TEST_PROJECT_NAME, bucket_name=TEST_BUCKET_NAME, datafile_path=path_in_bucket
         )
 
         self.assertEqual(datafile.path, f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}")
@@ -166,7 +167,11 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("[1, 2, 3]")
 
         datafile = Datafile(
-            timestamp=None, path=temporary_file.name, cluster=0, sequence=1, tags={"blah:shah:nah", "blib", "glib"}
+            timestamp=datetime.now(tz=timezone.utc),
+            path=temporary_file.name,
+            cluster=0,
+            sequence=1,
+            tags={"blah:shah:nah", "blib", "glib"},
         )
         datafile.to_cloud(project_name=TEST_PROJECT_NAME, bucket_name=TEST_BUCKET_NAME, path_in_bucket=path_in_bucket)
 
@@ -176,6 +181,7 @@ class DatafileTestCase(BaseTestCase):
 
         self.assertEqual(persisted_datafile.path, f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}")
         self.assertEqual(persisted_datafile.id, datafile.id)
+        self.assertEqual(persisted_datafile.timestamp, datafile.timestamp)
         self.assertEqual(persisted_datafile.hash_value, datafile.hash_value)
         self.assertEqual(persisted_datafile.cluster, datafile.cluster)
         self.assertEqual(persisted_datafile.sequence, datafile.sequence)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -442,3 +442,11 @@ class DatafileTestCase(BaseTestCase):
         self.assertEqual(datafile.id, deserialised_datafile.id)
         self.assertFalse(pathable.path in deserialised_datafile.path)
         self.assertEqual(deserialised_datafile.path, temporary_file.name)
+
+    def test_posix_timestamp(self):
+        """Test that the posix timestamp property works properly."""
+        datafile = Datafile(path="hello.txt", timestamp=None)
+        self.assertIsNone(datafile.posix_timestamp)
+
+        datafile.timestamp = datetime(1970, 1, 1)
+        self.assertEqual(datafile.posix_timestamp, 0)

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,12 +1,18 @@
 from datetime import datetime
 from unittest import TestCase
 
-from octue.utils.time import convert_to_posix_time
+from octue.utils.time import convert_from_posix_time, convert_to_posix_time
 
 
-class TestConvertToPosixTime(TestCase):
+class TestTime(TestCase):
     def test_convert_to_posix_time(self):
         """Test that datetime instances can be converted to posix time."""
         self.assertEqual(convert_to_posix_time(datetime(1970, 1, 1)), 0)
         self.assertEqual(convert_to_posix_time(datetime(2000, 1, 1)), 946684800)
         self.assertEqual(convert_to_posix_time(datetime(1940, 1, 1)), -946771200)
+
+    def test_convert_from_posix_time(self):
+        """Test that posix timestamps can be converted to datetime instances."""
+        self.assertEqual(convert_from_posix_time(0), datetime(1970, 1, 1))
+        self.assertEqual(convert_from_posix_time(946684800), datetime(2000, 1, 1))
+        self.assertEqual(convert_from_posix_time(-946771200), datetime(1940, 1, 1))

--- a/tests/utils/test_time.py
+++ b/tests/utils/test_time.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from unittest import TestCase
+
+from octue.utils.time import convert_to_posix_time
+
+
+class TestConvertToPosixTime(TestCase):
+    def test_convert_to_posix_time(self):
+        """Test that datetime instances can be converted to posix time."""
+        self.assertEqual(convert_to_posix_time(datetime(1970, 1, 1)), 0)
+        self.assertEqual(convert_to_posix_time(datetime(2000, 1, 1)), 946684800)
+        self.assertEqual(convert_to_posix_time(datetime(1940, 1, 1)), -946771200)


### PR DESCRIPTION
## Contents

### New Features
- [x] Allow `datetime` and posix timestamps for `Datafile.timestamp`
- [x] Add `Datafile.posix_timestamp` property

### Minor improvements
- [x] Close #149: use Google Cloud Storage `custom_time` metadata field for storing `Datafile.timestamp`
- [x] Get `datetime` objects directly from blob instead of parsing string serialisations
- [x] Add `time` utils module 
- [x] Add hash preparation function to `Hashable` for `datetime` instances

## Quality Checklist
- [x] New features are fully tested (No matter how much Coverage Karma you have)
