### PR TITLE
Ensure Google Cloud Storage metadata strings do not appear in quotation marks

### DIFF
--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import logging
 from google.cloud import storage
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
@@ -119,10 +118,6 @@ class GoogleCloudStorageClient:
         """
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
         metadata = bucket.get_blob(blob_name=self._strip_leading_slash(path_in_bucket), timeout=timeout)._properties
-
-        if metadata.get("metadata") is not None:
-            metadata["metadata"] = {key: json.loads(value) for key, value in metadata["metadata"].items()}
-
         return metadata
 
     def delete(self, bucket_name, path_in_bucket, timeout=_DEFAULT_TIMEOUT):
@@ -189,16 +184,6 @@ class GoogleCloudStorageClient:
         :param dict metadata:
         :return None:
         """
-        blob.metadata = self._encode_metadata(metadata or {})
-        blob.patch()
-
-    def _encode_metadata(self, metadata):
-        """Encode metadata as a dictionary of JSON strings.
-
-        :param dict metadata:
-        :return dict:
-        """
-        if not isinstance(metadata, dict):
-            raise TypeError(f"Metadata for Google Cloud storage should be a dictionary; received {metadata!r}")
-
-        return {key: json.dumps(value) for key, value in metadata.items()}
+        if metadata is not None:
+            blob.metadata = metadata
+            blob.patch()

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -172,13 +172,22 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
                     f"overwrite the attribute value, set `allow_overwrite` to `True`."
                 )
 
+        cluster = kwargs.get("cluster", custom_metadata.get("cluster", CLUSTER_DEFAULT))
+        sequence = kwargs.get("sequence", custom_metadata.get("sequence", SEQUENCE_DEFAULT))
+
+        if isinstance(cluster, str):
+            cluster = int(cluster)
+
+        if isinstance(sequence, str):
+            sequence = int(sequence)
+
         datafile = cls(
             timestamp=kwargs.get("timestamp", custom_metadata.get("timestamp")),
             id=kwargs.get("id", custom_metadata.get("id", ID_DEFAULT)),
             path=storage.path.generate_gs_path(bucket_name, datafile_path),
             hash_value=kwargs.get("hash_value", custom_metadata.get("hash_value", metadata.get("crc32c", None))),
-            cluster=kwargs.get("cluster", custom_metadata.get("cluster", CLUSTER_DEFAULT)),
-            sequence=kwargs.get("sequence", custom_metadata.get("sequence", SEQUENCE_DEFAULT)),
+            cluster=cluster,
+            sequence=sequence,
             tags=kwargs.get("tags", custom_metadata.get("tags", TAGS_DEFAULT)),
         )
 
@@ -371,5 +380,5 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
             "hash_value": self.hash_value,
             "cluster": self.cluster,
             "sequence": self.sequence,
-            "tags": self.tags.serialise(),
+            "tags": self.tags.serialise(to_string=True),
         }

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -102,7 +102,7 @@ class TagSet(Serialisable):
         # JSON-encoded list of tag names, or space-delimited string of tag names.
         if isinstance(tags, str):
             try:
-                self.tags = json.loads(tags)
+                self.tags = FilterSet(Tag(tag) for tag in json.loads(tags))
             except json.decoder.JSONDecodeError:
                 self.tags = FilterSet(Tag(tag) for tag in tags.strip().split())
 


### PR DESCRIPTION
## Contents

### Fixes

- [x] Close #146: Stop serialising GCS metadata as JSON. This avoids strings in the metadata appearing in two sets of quotation marks on Google Cloud Storage. This is a breaking change for any files already persisted with JSON-encoded metadata.

The metadata is now stored as e.g.
```
{
    'id': 'aebc3128-03df-4a11-82fd-9611591abbc6', 
    'timestamp': None, 
    'hash_value': 'N7aU4g==', 
    'cluster': '0', 
    'sequence': '1', 
    'tags': '[\n    "blah:shah:nah",\n    "blib",\n    "glib"\n]'
}
```