### PR TITLE
Remove hash value from Datafile GCS metadata

### DIFF
--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -3,6 +3,8 @@ import collections.abc
 from google_crc32c import Checksum
 
 
+EMPTY_STRING_HASH_VALUE = "AAAAAA=="
+
 _HASH_PREPARATION_FUNCTIONS = {
     str: lambda attribute: attribute,
     int: str,

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -19,6 +19,7 @@ class Hashable:
 
     def __init__(self, hash_value=None, *args, **kwargs):
         self._hash_value = hash_value
+        self._ATTRIBUTES_TO_HASH = self._ATTRIBUTES_TO_HASH or []
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -37,9 +38,6 @@ class Hashable:
         """Get the hash of the instance."""
         if self._hash_value:
             return self._hash_value
-
-        if not self._ATTRIBUTES_TO_HASH:
-            return None
 
         self._hash_value = self._calculate_hash()
         return self._hash_value

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -9,6 +9,7 @@ from octue.cloud.storage import GoogleCloudStorageClient
 from octue.cloud.storage.path import CLOUD_STORAGE_PROTOCOL
 from octue.exceptions import AttributeConflict, FileNotFoundException, InvalidInputException
 from octue.mixins import Filterable, Hashable, Identifiable, Loggable, Pathable, Serialisable, Taggable
+from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
 from octue.utils import isfile
 
 
@@ -270,7 +271,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     def _calculate_hash(self):
         """Calculate the hash of the file."""
         if self.is_in_cloud:
-            return self._cloud_metadata["crc32c"]
+            return self._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
 
         hash = Checksum()
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -58,7 +58,6 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     :return None:
     """
 
-    _ATTRIBUTES_TO_HASH = "name", "cluster", "sequence", "timestamp", "tags"
     _SERIALISE_FIELDS = (
         "cluster",
         "hash_value",
@@ -176,7 +175,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
             timestamp=kwargs.get("timestamp", custom_metadata.get("timestamp")),
             id=kwargs.get("id", custom_metadata.get("id", ID_DEFAULT)),
             path=storage.path.generate_gs_path(bucket_name, datafile_path),
-            hash_value=kwargs.get("hash_value", custom_metadata.get("hash_value", metadata.get("crc32c", None))),
+            hash_value=kwargs.get("hash_value", metadata.get("crc32c", None)),
             cluster=kwargs.get("cluster", custom_metadata.get("cluster", CLUSTER_DEFAULT)),
             sequence=kwargs.get("sequence", custom_metadata.get("sequence", SEQUENCE_DEFAULT)),
             tags=kwargs.get("tags", custom_metadata.get("tags", TAGS_DEFAULT)),
@@ -271,7 +270,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     def _calculate_hash(self):
         """Calculate the hash of the file."""
         if self.is_in_cloud:
-            return self._cloud_metadata.get("hash_value", "")
+            return self._cloud_metadata.get("crc32c", "")
 
         hash = Checksum()
 
@@ -368,7 +367,6 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
         return {
             "id": self.id,
             "timestamp": self.timestamp,
-            "hash_value": self.hash_value,
             "cluster": self.cluster,
             "sequence": self.sequence,
             "tags": self.tags.serialise(),

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -61,7 +61,6 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
     _SERIALISE_FIELDS = (
         "cluster",
-        "hash_value",
         "id",
         "name",
         "path",

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -270,7 +270,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     def _calculate_hash(self):
         """Calculate the hash of the file."""
         if self.is_in_cloud:
-            return self._cloud_metadata.get("crc32c", "")
+            return self._cloud_metadata["crc32c"]
 
         hash = Checksum()
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -185,7 +185,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
             timestamp=kwargs.get("timestamp", metadata.get("customTime")),
             id=kwargs.get("id", custom_metadata.get("id", ID_DEFAULT)),
             path=storage.path.generate_gs_path(bucket_name, datafile_path),
-            hash_value=metadata.get("crc32c", None),
+            hash_value=metadata.get("crc32c", EMPTY_STRING_HASH_VALUE),
             cluster=cluster,
             sequence=sequence,
             tags=kwargs.get("tags", custom_metadata.get("tags", TAGS_DEFAULT)),
@@ -309,13 +309,10 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
     def _calculate_hash(self):
         """Calculate the hash of the file."""
-        if self.is_in_cloud:
-            return self._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
-
         hash = Checksum()
 
         with open(self.absolute_path, "rb") as f:
-            # Read and update hash value in blocks of 4K
+            # Read and update hash value in blocks of 4K.
             for byte_block in iter(lambda: f.read(4096), b""):
                 hash.update(byte_block)
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -185,7 +185,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
             timestamp=kwargs.get("timestamp", metadata.get("customTime")),
             id=kwargs.get("id", custom_metadata.get("id", ID_DEFAULT)),
             path=storage.path.generate_gs_path(bucket_name, datafile_path),
-            hash_value=kwargs.get("hash_value", metadata.get("crc32c", None)),
+            hash_value=metadata.get("crc32c", None),
             cluster=cluster,
             sequence=sequence,
             tags=kwargs.get("tags", custom_metadata.get("tags", TAGS_DEFAULT)),

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -27,7 +27,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
     """
 
     _FILTERSET_ATTRIBUTE = "files"
-    _ATTRIBUTES_TO_HASH = "files", "name", "tags"
+    _ATTRIBUTES_TO_HASH = ("files",)
     _SERIALISE_FIELDS = "files", "name", "tags", "hash_value", "id", "path"
 
     def __init__(self, name=None, id=None, logger=None, path=None, path_from=None, tags=None, **kwargs):

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -28,7 +28,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
 
     _FILTERSET_ATTRIBUTE = "files"
     _ATTRIBUTES_TO_HASH = ("files",)
-    _SERIALISE_FIELDS = "files", "name", "tags", "hash_value", "id", "path"
+    _SERIALISE_FIELDS = "files", "name", "tags", "id", "path"
 
     def __init__(self, name=None, id=None, logger=None, path=None, path_from=None, tags=None, **kwargs):
         """Construct a Dataset"""
@@ -84,7 +84,6 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         return Dataset(
             id=serialised_dataset["id"],
             name=serialised_dataset["name"],
-            hash_value=serialised_dataset["hash_value"],
             path=storage.path.generate_gs_path(bucket_name, path_to_dataset_directory),
             tags=TagSet(serialised_dataset["tags"]),
             files=datafiles,

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -17,7 +17,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
     (or leaving), a data service for an analysis at the configuration, input or output stage."""
 
     _ATTRIBUTES_TO_HASH = ("datasets",)
-    _SERIALISE_FIELDS = "datasets", "keys", "hash_value", "id", "name", "path"
+    _SERIALISE_FIELDS = "datasets", "keys", "id", "name", "path"
 
     def __init__(self, id=None, logger=None, path=None, datasets=None, keys=None, **kwargs):
         super().__init__(id=id, logger=logger, path=path)
@@ -73,7 +73,6 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         return Manifest(
             id=serialised_manifest["id"],
             path=storage.path.generate_gs_path(bucket_name, path_to_manifest_file),
-            hash_value=serialised_manifest["hash_value"],
             datasets=datasets,
             keys=serialised_manifest["keys"],
         )

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -16,7 +16,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
     """A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
     (or leaving), a data service for an analysis at the configuration, input or output stage."""
 
-    _ATTRIBUTES_TO_HASH = "datasets", "keys"
+    _ATTRIBUTES_TO_HASH = ("datasets",)
     _SERIALISE_FIELDS = "datasets", "keys", "hash_value", "id", "name", "path"
 
     def __init__(self, id=None, logger=None, path=None, datasets=None, keys=None, **kwargs):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -123,6 +123,12 @@ class TestService(BaseTestCase):
             Datafile(timestamp=None, path="gs://my-dataset/goodbye.csv"),
         ]
 
+        # Set hash values as they will be absent because the Datafiles haven't been instantiated using
+        # Datafile.from_cloud, meaning they have none of the expected cloud metadata. This wouldn't be a valid usage of
+        # Datafile but makes this test simpler. The files aren't actually used by the answering service.
+        for file in files:
+            file._cloud_metadata["crc32c"] = "AAAAAA=="
+
         input_manifest = Manifest(datasets=[Dataset(files=files)], path="gs://my-dataset", keys={"my_dataset": 0})
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -123,12 +123,6 @@ class TestService(BaseTestCase):
             Datafile(timestamp=None, path="gs://my-dataset/goodbye.csv"),
         ]
 
-        # Set hash values as they will be absent because the Datafiles haven't been instantiated using
-        # Datafile.from_cloud, meaning they have none of the expected cloud metadata. This wouldn't be a valid usage of
-        # Datafile but makes this test simpler. The files aren't actually used by the answering service.
-        for file in files:
-            file._cloud_metadata["crc32c"] = "AAAAAA=="
-
         input_manifest = Manifest(datasets=[Dataset(files=files)], path="gs://my-dataset", keys={"my_dataset": 0})
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -20,9 +20,9 @@ class TypeWithIterable(Hashable):
 
 
 class HashableTestCase(BaseTestCase):
-    def test_no_attributes_to_hash_results_if_no_hash(self):
-        """ Assert classes with Hashable mixed in but no attributes to hash give None for their hash. """
-        self.assertIsNone(TypeWithNoAttributesToHash().hash_value)
+    def test_no_attributes_to_hash_results_in_trivial_hash_value(self):
+        """Assert classes with Hashable mixed in but no attributes to hash have a trivial hash value."""
+        self.assertEqual(TypeWithNoAttributesToHash().hash_value, "AAAAAA==")
 
     def test_non_hashable_type_results_in_type_error(self):
         """ Ensure trying to hash unhashable attributes results in a TypeError. """

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -1,4 +1,5 @@
 from octue.mixins import Hashable
+from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
 from ..base import BaseTestCase
 
 
@@ -22,7 +23,7 @@ class TypeWithIterable(Hashable):
 class HashableTestCase(BaseTestCase):
     def test_no_attributes_to_hash_results_in_trivial_hash_value(self):
         """Assert classes with Hashable mixed in but no attributes to hash have a trivial hash value."""
-        self.assertEqual(TypeWithNoAttributesToHash().hash_value, "AAAAAA==")
+        self.assertEqual(TypeWithNoAttributesToHash().hash_value, EMPTY_STRING_HASH_VALUE)
 
     def test_non_hashable_type_results_in_type_error(self):
         """ Ensure trying to hash unhashable attributes results in a TypeError. """

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -113,7 +113,6 @@ class DatafileTestCase(BaseTestCase):
             "timestamp",
             "sequence",
             "tags",
-            "hash_value",
             "_cloud_metadata",
         }
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -323,21 +323,21 @@ class DatasetTestCase(BaseTestCase):
 
             dataset.to_cloud(project_name=project_name, bucket_name=TEST_BUCKET_NAME, output_directory="a_directory")
 
-        persisted_dataset = Dataset.from_cloud(
-            project_name=project_name,
-            bucket_name=TEST_BUCKET_NAME,
-            path_to_dataset_directory=storage.path.join("a_directory", dataset.name),
-        )
+            persisted_dataset = Dataset.from_cloud(
+                project_name=project_name,
+                bucket_name=TEST_BUCKET_NAME,
+                path_to_dataset_directory=storage.path.join("a_directory", dataset.name),
+            )
 
-        self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}")
-        self.assertEqual(persisted_dataset.id, dataset.id)
-        self.assertEqual(persisted_dataset.name, dataset.name)
-        self.assertEqual(persisted_dataset.hash_value, dataset.hash_value)
-        self.assertEqual(persisted_dataset.tags, dataset.tags)
-        self.assertEqual({file.name for file in persisted_dataset.files}, {file.name for file in dataset.files})
+            self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}")
+            self.assertEqual(persisted_dataset.id, dataset.id)
+            self.assertEqual(persisted_dataset.name, dataset.name)
+            self.assertEqual(persisted_dataset.hash_value, dataset.hash_value)
+            self.assertEqual(persisted_dataset.tags, dataset.tags)
+            self.assertEqual({file.name for file in persisted_dataset.files}, {file.name for file in dataset.files})
 
-        for file in persisted_dataset:
-            self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}/{file.name}")
+            for file in persisted_dataset:
+                self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}/{file.name}")
 
     def test_to_cloud(self):
         """Test that a dataset can be uploaded to the cloud, including all its files and a serialised JSON file of the

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -48,14 +48,12 @@ class TestManifest(BaseTestCase):
         self.assertEqual(manifest.name, deserialised_manifest.name)
         self.assertEqual(manifest.id, deserialised_manifest.id)
         self.assertEqual(manifest.absolute_path, deserialised_manifest.absolute_path)
-        self.assertEqual(manifest.hash_value, deserialised_manifest.hash_value)
         self.assertEqual(manifest.keys, deserialised_manifest.keys)
 
         for original_dataset, deserialised_dataset in zip(manifest.datasets, deserialised_manifest.datasets):
             self.assertEqual(original_dataset.name, deserialised_dataset.name)
             self.assertEqual(original_dataset.id, deserialised_dataset.id)
             self.assertEqual(original_dataset.absolute_path, deserialised_dataset.absolute_path)
-            self.assertEqual(original_dataset.hash_value, deserialised_dataset.hash_value)
 
     def test_to_cloud(self):
         """Test that a manifest can be uploaded to the cloud as a serialised JSON file of the Manifest instance. """
@@ -162,21 +160,22 @@ class TestManifest(BaseTestCase):
                 path_to_manifest_file=storage.path.join("my-directory", "manifest.json"),
             )
 
-        persisted_manifest = Manifest.from_cloud(
-            project_name=self.TEST_PROJECT_NAME,
-            bucket_name=TEST_BUCKET_NAME,
-            path_to_manifest_file=storage.path.join("my-directory", "manifest.json"),
-        )
+            persisted_manifest = Manifest.from_cloud(
+                project_name=self.TEST_PROJECT_NAME,
+                bucket_name=TEST_BUCKET_NAME,
+                path_to_manifest_file=storage.path.join("my-directory", "manifest.json"),
+            )
 
-        self.assertEqual(persisted_manifest.path, f"gs://{TEST_BUCKET_NAME}/my-directory/manifest.json")
-        self.assertEqual(persisted_manifest.id, manifest.id)
-        self.assertEqual(persisted_manifest.hash_value, manifest.hash_value)
-        self.assertEqual(persisted_manifest.keys, manifest.keys)
-        self.assertEqual(
-            {dataset.name for dataset in persisted_manifest.datasets}, {dataset.name for dataset in manifest.datasets}
-        )
+            self.assertEqual(persisted_manifest.path, f"gs://{TEST_BUCKET_NAME}/my-directory/manifest.json")
+            self.assertEqual(persisted_manifest.id, manifest.id)
+            self.assertEqual(persisted_manifest.hash_value, manifest.hash_value)
+            self.assertEqual(persisted_manifest.keys, manifest.keys)
+            self.assertEqual(
+                {dataset.name for dataset in persisted_manifest.datasets},
+                {dataset.name for dataset in manifest.datasets},
+            )
 
-        for dataset in persisted_manifest.datasets:
-            self.assertEqual(dataset.path, f"gs://{TEST_BUCKET_NAME}/my-directory/{dataset.name}")
-            self.assertTrue(len(dataset.files), 2)
-            self.assertTrue(all(isinstance(file, Datafile) for file in dataset.files))
+            for dataset in persisted_manifest.datasets:
+                self.assertEqual(dataset.path, f"gs://{TEST_BUCKET_NAME}/my-directory/{dataset.name}")
+                self.assertTrue(len(dataset.files), 2)
+                self.assertTrue(all(isinstance(file, Datafile) for file in dataset.files))


### PR DESCRIPTION
## Contents

### Breaking changes
- [x] Close #148: remove `hash_value` from `Datafile` GCS metadata
- [x] When hashing `Datafile`s, only hash represented file (i.e. stop hashing metadata)
- [x] When hashing `Dataset`s and `Manifest`s, only hash the files contained (i.e. stop hashing metadata)
- [x] Make hash of `Hashable` instance with `_ATTRIBUTES_TO_HASH=None` the empty string hash value `"AAAAAA=="` 

### Fixes
- [x] Use the empty string hash value for `Datafile` if GCS `crc32c` metadata isn't present
- [x] Stop serialising hash value of `Manifest`, `Dataset`, and `Datafile` 

### Minor improvements
- [x] Remove ability to set custom hash value via `kwargs` when using `Datafile.from_cloud`