### PR TITLE
Feature: Allow gs:// paths to be used in resources

### DIFF
--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -50,7 +50,8 @@ class GoogleCloudStorageClient:
     def upload_file(
         self, local_path, gs_path=None, bucket_name=None, path_in_bucket=None, metadata=None, timeout=_DEFAULT_TIMEOUT
     ):
-        """Upload a local file to a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>.
+        """Upload a local file to a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>. Either (`bucket_name`
+        and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str local_path:
         :param str|None gs_path:
@@ -73,7 +74,7 @@ class GoogleCloudStorageClient:
         self, string, gs_path=None, bucket_name=None, path_in_bucket=None, metadata=None, timeout=_DEFAULT_TIMEOUT
     ):
         """Upload serialised data in string form to a file in a Google Cloud bucket at
-        gs://<bucket_name>/<path_in_bucket>.
+        gs://<bucket_name>/<path_in_bucket>. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str string:
         :param str|None gs_path:
@@ -91,7 +92,8 @@ class GoogleCloudStorageClient:
         logger.info("Uploaded data to Google Cloud at %r.", blob.public_url)
 
     def update_metadata(self, metadata, gs_path=None, bucket_name=None, path_in_bucket=None):
-        """Update the metadata for the given cloud file.
+        """Update the metadata for the given cloud file. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must
+        be provided.
 
         :param dict metadata:
         :param str|None gs_path:
@@ -105,7 +107,8 @@ class GoogleCloudStorageClient:
     def download_to_file(
         self, local_path, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT
     ):
-        """Download a file to a file from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>.
+        """Download a file to a file from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>. Either
+        (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str local_path:
         :param str|None gs_path:
@@ -119,7 +122,8 @@ class GoogleCloudStorageClient:
         logger.info("Downloaded %r from Google Cloud to %r.", blob.public_url, local_path)
 
     def download_as_string(self, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
-        """Download a file to a string from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>.
+        """Download a file to a string from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>. Either
+        (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str|None gs_path:
         :param str|None bucket_name:
@@ -133,7 +137,8 @@ class GoogleCloudStorageClient:
         return data.decode()
 
     def get_metadata(self, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
-        """Get the metadata of the given file in the given bucket.
+        """Get the metadata of the given file in the given bucket. Either (`bucket_name` and `path_in_bucket`) or
+        `gs_path` must be provided.
 
         :param str|None gs_path:
         :param str|None bucket_name:
@@ -164,7 +169,8 @@ class GoogleCloudStorageClient:
         }
 
     def delete(self, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
-        """Delete the given file from the given bucket.
+        """Delete the given file from the given bucket. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must
+        be provided.
 
         :param str|None gs_path:
         :param str|None bucket_name:
@@ -177,7 +183,8 @@ class GoogleCloudStorageClient:
         logger.info("Deleted %r from Google Cloud.", blob.public_url)
 
     def scandir(self, gs_path=None, bucket_name=None, directory_path=None, filter=None, timeout=_DEFAULT_TIMEOUT):
-        """Yield the blobs belonging to the given "directory" in the given bucket.
+        """Yield the blobs belonging to the given "directory" in the given bucket. Either (`bucket_name` and
+        `path_in_bucket`) or `gs_path` must be provided.
 
         :param str|None gs_path:
         :param str|None bucket_name:
@@ -208,6 +215,7 @@ class GoogleCloudStorageClient:
 
     def _blob(self, gs_path=None, bucket_name=None, path_in_bucket=None):
         """Instantiate a blob for the given bucket at the given path. Note that this is not synced up with Google Cloud.
+        Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str|None gs_path:
         :param str|None bucket_name:

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -48,20 +48,26 @@ class GoogleCloudStorageClient:
         self.client.create_bucket(bucket_or_name=name, location=location, timeout=timeout)
 
     def upload_file(
-        self, local_path, gs_path=None, bucket_name=None, path_in_bucket=None, metadata=None, timeout=_DEFAULT_TIMEOUT
+        self,
+        local_path,
+        cloud_path=None,
+        bucket_name=None,
+        path_in_bucket=None,
+        metadata=None,
+        timeout=_DEFAULT_TIMEOUT,
     ):
         """Upload a local file to a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>. Either (`bucket_name`
-        and `path_in_bucket`) or `gs_path` must be provided.
+        and `path_in_bucket`) or `cloud_path` must be provided.
 
         :param str local_path:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :param dict metadata:
         :param float timeout:
         :return None:
         """
-        blob = self._blob(gs_path, bucket_name, path_in_bucket)
+        blob = self._blob(cloud_path, bucket_name, path_in_bucket)
 
         with open(local_path) as f:
             blob.crc32c = self._compute_crc32c_checksum(f.read())
@@ -71,83 +77,83 @@ class GoogleCloudStorageClient:
         logger.info("Uploaded %r to Google Cloud at %r.", local_path, blob.public_url)
 
     def upload_from_string(
-        self, string, gs_path=None, bucket_name=None, path_in_bucket=None, metadata=None, timeout=_DEFAULT_TIMEOUT
+        self, string, cloud_path=None, bucket_name=None, path_in_bucket=None, metadata=None, timeout=_DEFAULT_TIMEOUT
     ):
         """Upload serialised data in string form to a file in a Google Cloud bucket at
-        gs://<bucket_name>/<path_in_bucket>. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
+        gs://<bucket_name>/<path_in_bucket>. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided.
 
         :param str string:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :param dict metadata:
         :param float timeout:
         :return None:
         """
-        blob = self._blob(gs_path, bucket_name, path_in_bucket)
+        blob = self._blob(cloud_path, bucket_name, path_in_bucket)
         blob.crc32c = self._compute_crc32c_checksum(string)
 
         blob.upload_from_string(data=string, timeout=timeout)
         self._update_metadata(blob, metadata)
         logger.info("Uploaded data to Google Cloud at %r.", blob.public_url)
 
-    def update_metadata(self, metadata, gs_path=None, bucket_name=None, path_in_bucket=None):
-        """Update the metadata for the given cloud file. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must
+    def update_metadata(self, metadata, cloud_path=None, bucket_name=None, path_in_bucket=None):
+        """Update the metadata for the given cloud file. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must
         be provided.
 
         :param dict metadata:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :return None:
         """
-        blob = self._blob(gs_path, bucket_name, path_in_bucket)
+        blob = self._blob(cloud_path, bucket_name, path_in_bucket)
         self._update_metadata(blob, metadata)
 
     def download_to_file(
-        self, local_path, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT
+        self, local_path, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT
     ):
         """Download a file to a file from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>. Either
-        (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
+        (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided.
 
         :param str local_path:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :param float timeout:
         :return None:
         """
-        blob = self._blob(gs_path, bucket_name, path_in_bucket)
+        blob = self._blob(cloud_path, bucket_name, path_in_bucket)
         blob.download_to_filename(local_path, timeout=timeout)
         logger.info("Downloaded %r from Google Cloud to %r.", blob.public_url, local_path)
 
-    def download_as_string(self, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
+    def download_as_string(self, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
         """Download a file to a string from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>. Either
-        (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
+        (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided.
 
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :param float timeout:
         :return str:
         """
-        blob = self._blob(gs_path, bucket_name, path_in_bucket)
+        blob = self._blob(cloud_path, bucket_name, path_in_bucket)
         data = blob.download_as_bytes(timeout=timeout)
         logger.info("Downloaded %r from Google Cloud to as string.", blob.public_url)
         return data.decode()
 
-    def get_metadata(self, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
+    def get_metadata(self, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
         """Get the metadata of the given file in the given bucket. Either (`bucket_name` and `path_in_bucket`) or
-        `gs_path` must be provided.
+        `cloud_path` must be provided.
 
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :param float timeout:
         :return dict:
         """
-        if gs_path:
-            bucket_name, path_in_bucket = split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, path_in_bucket = split_bucket_name_from_gs_path(cloud_path)
 
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
         blob = bucket.get_blob(blob_name=self._strip_leading_slash(path_in_bucket), timeout=timeout)
@@ -168,33 +174,33 @@ class GoogleCloudStorageClient:
             "path_in_bucket": path_in_bucket,
         }
 
-    def delete(self, gs_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
-        """Delete the given file from the given bucket. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must
+    def delete(self, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
+        """Delete the given file from the given bucket. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must
         be provided.
 
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :param float timeout:
         :return None:
         """
-        blob = self._blob(gs_path, bucket_name, path_in_bucket)
+        blob = self._blob(cloud_path, bucket_name, path_in_bucket)
         blob.delete(timeout=timeout)
         logger.info("Deleted %r from Google Cloud.", blob.public_url)
 
-    def scandir(self, gs_path=None, bucket_name=None, directory_path=None, filter=None, timeout=_DEFAULT_TIMEOUT):
+    def scandir(self, cloud_path=None, bucket_name=None, directory_path=None, filter=None, timeout=_DEFAULT_TIMEOUT):
         """Yield the blobs belonging to the given "directory" in the given bucket. Either (`bucket_name` and
-        `path_in_bucket`) or `gs_path` must be provided.
+        `path_in_bucket`) or `cloud_path` must be provided.
 
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None directory_path:
         :param callable filter:
         :param float timeout:
         :yield google.cloud.storage.blob.Blob:
         """
-        if gs_path:
-            bucket_name, directory_path = split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, directory_path = split_bucket_name_from_gs_path(cloud_path)
 
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
         blobs = bucket.list_blobs(timeout=timeout)
@@ -213,17 +219,17 @@ class GoogleCloudStorageClient:
         """
         return path.lstrip("/")
 
-    def _blob(self, gs_path=None, bucket_name=None, path_in_bucket=None):
+    def _blob(self, cloud_path=None, bucket_name=None, path_in_bucket=None):
         """Instantiate a blob for the given bucket at the given path. Note that this is not synced up with Google Cloud.
-        Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
+        Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided.
 
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :return google.cloud.storage.blob.Blob:
         """
-        if gs_path:
-            bucket_name, path_in_bucket = split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, path_in_bucket = split_bucket_name_from_gs_path(cloud_path)
 
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
         return bucket.blob(blob_name=self._strip_leading_slash(path_in_bucket))

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -194,7 +194,7 @@ class GoogleCloudStorageClient:
         :yield google.cloud.storage.blob.Blob:
         """
         if gs_path:
-            bucket_name, path_in_bucket = split_bucket_name_from_gs_path(gs_path)
+            bucket_name, directory_path = split_bucket_name_from_gs_path(gs_path)
 
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
         blobs = bucket.list_blobs(timeout=timeout)

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -78,8 +78,12 @@ class Serialisable:
         self_as_primitive = {}
         for name in names_of_attributes_to_serialise:
             attribute = getattr(self, name, None)
+
             # Serialise sets as sorted list (JSON doesn't support sets).
-            self_as_primitive[name] = sorted(attribute) if isinstance(attribute, set) else attribute
+            if isinstance(attribute, set):
+                self_as_primitive[name] = sorted(attribute)
+            else:
+                self_as_primitive[name] = attribute
 
         # TODO this conversion backward-and-forward is very inefficient but allows us to use the same encoder for
         #  converting the object to a dict as to strings, which ensures that nested attributes are also cast to

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -177,16 +177,13 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
         Either (`bucket_name` and `datafile_path`) or `cloud_path` must be provided.
 
-        :param str project_name:
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None datafile_path: path to file represented by datafile
-        :param bool allow_overwrite: if `True`, allow attributes of the datafile to be overwritten by values given in
-            kwargs
-        :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode
-            options are the same as for the builtin open function)
-        :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of
-            the datafile when the context is exited
+        :param str project_name: name of Google Cloud project datafile is stored in
+        :param str|None cloud_path: full path to datafile in cloud storage (e.g. `gs://bucket_name/path/to/file.csv`)
+        :param str|None bucket_name: name of bucket datafile is stored in
+        :param str|None datafile_path: cloud storage path of datafile (e.g. `path/to/file.csv`)
+        :param bool allow_overwrite: if `True`, allow attributes of the datafile to be overwritten by values given in kwargs
+        :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin open function)
+        :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of the datafile when the context is exited
         :return Datafile:
         """
         if not cloud_path:
@@ -223,11 +220,11 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
         """Upload a datafile to Google Cloud Storage. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be
         provided.
 
-        :param str|None project_name:
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_in_bucket:
-        :param bool update_cloud_metadata:
+        :param str|None project_name: name of Google Cloud project to store datafile in
+        :param str|None cloud_path: full path to cloud storage location to store datafile at (e.g. `gs://bucket_name/path/to/file.csv`)
+        :param str|None bucket_name: name of bucket to store datafile in
+        :param str|None path_in_bucket: cloud storage path to store datafile at (e.g. `path/to/file.csv`)
+        :param bool update_cloud_metadata: if `True`, update the metadata of the datafile in the cloud at upload time
         :return str: gs:// path for datafile
         """
         project_name, bucket_name, path_in_bucket = self._get_cloud_location(

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -175,6 +175,8 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
         Note that a value provided for an attribute in kwargs will override any existing value for the attribute.
 
+        Either (`bucket_name` and `datafile_path`) or `gs_path` must be provided.
+
         :param str project_name:
         :param str|None gs_path:
         :param str|None bucket_name:
@@ -218,7 +220,8 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
     def to_cloud(
         self, project_name=None, gs_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True
     ):
-        """Upload a datafile to Google Cloud Storage.
+        """Upload a datafile to Google Cloud Storage. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be
+        provided.
 
         :param str|None project_name:
         :param str|None gs_path:
@@ -253,6 +256,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
     def get_cloud_metadata(self, project_name=None, gs_path=None, bucket_name=None, path_in_bucket=None):
         """Get the cloud metadata for the datafile, casting the types of the cluster and sequence fields to integer.
+        Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str|None project_name:
         :param str|None gs_path:
@@ -286,7 +290,8 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
         self._cloud_metadata = cloud_metadata
 
     def update_cloud_metadata(self, project_name=None, gs_path=None, bucket_name=None, path_in_bucket=None):
-        """Update the cloud metadata for the datafile.
+        """Update the cloud metadata for the datafile. Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be
+        provided.
 
         :param str|None project_name:
         :param str|None gs_path:
@@ -426,6 +431,7 @@ class Datafile(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashabl
 
     def _get_cloud_location(self, project_name=None, gs_path=None, bucket_name=None, path_in_bucket=None):
         """Get the cloud location details for the bucket, allowing the keyword arguments to override any stored values.
+        Either (`bucket_name` and `path_in_bucket`) or `gs_path` must be provided.
 
         :param str|None project_name:
         :param str|None gs_path:

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -56,7 +56,8 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
 
     @classmethod
     def from_cloud(cls, project_name, gs_path=None, bucket_name=None, path_to_dataset_directory=None):
-        """Instantiate a Dataset from Google Cloud storage.
+        """Instantiate a Dataset from Google Cloud storage. Either (`bucket_name` and `path_to_dataset_directory`) or
+        `gs_path` must be provided.
 
         :param str project_name:
         :param str|None gs_path:
@@ -92,7 +93,8 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         )
 
     def to_cloud(self, project_name, gs_path=None, bucket_name=None, output_directory=None):
-        """Upload a dataset to a cloud location.
+        """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `gs_path` must be
+        provided.
 
         :param str project_name:
         :param str|None gs_path:

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -59,10 +59,10 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         """Instantiate a Dataset from Google Cloud storage. Either (`bucket_name` and `path_to_dataset_directory`) or
         `cloud_path` must be provided.
 
-        :param str project_name:
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_to_dataset_directory: path to dataset directory (directory containing dataset's files)
+        :param str project_name: name of Google Cloud project dataset is stored in
+        :param str|None cloud_path: full path to dataset in cloud storage (e.g. `gs://bucket_name/path/to/dataset`)
+        :param str|None bucket_name: name of bucket dataset is stored in
+        :param str|None path_to_dataset_directory: path to dataset directory (containing dataset's files) in cloud (e.g. `path/to/dataset`)
         :return Dataset:
         """
         if cloud_path:
@@ -96,11 +96,11 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `cloud_path` must be
         provided.
 
-        :param str project_name:
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None output_directory:
-        :return str: gs:// path for dataset
+        :param str project_name: name of Google Cloud project to store dataset in
+        :param str|None cloud_path: full cloud storage path to store dataset at (e.g. `gs://bucket_name/path/to/dataset`)
+        :param str|None bucket_name: name of bucket to store dataset in
+        :param str|None output_directory: path to output directory in cloud storage (e.g. `path/to/dataset`)
+        :return str: cloud path for dataset
         """
         if cloud_path:
             bucket_name, output_directory = storage.path.split_bucket_name_from_gs_path(cloud_path)

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -55,18 +55,18 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
         return len(self.files)
 
     @classmethod
-    def from_cloud(cls, project_name, gs_path=None, bucket_name=None, path_to_dataset_directory=None):
+    def from_cloud(cls, project_name, cloud_path=None, bucket_name=None, path_to_dataset_directory=None):
         """Instantiate a Dataset from Google Cloud storage. Either (`bucket_name` and `path_to_dataset_directory`) or
-        `gs_path` must be provided.
+        `cloud_path` must be provided.
 
         :param str project_name:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_to_dataset_directory: path to dataset directory (directory containing dataset's files)
         :return Dataset:
         """
-        if gs_path:
-            bucket_name, path_to_dataset_directory = storage.path.split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, path_to_dataset_directory = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
         serialised_dataset = json.loads(
             GoogleCloudStorageClient(project_name=project_name).download_as_string(
@@ -92,18 +92,18 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
             files=datafiles,
         )
 
-    def to_cloud(self, project_name, gs_path=None, bucket_name=None, output_directory=None):
-        """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `gs_path` must be
+    def to_cloud(self, project_name, cloud_path=None, bucket_name=None, output_directory=None):
+        """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `cloud_path` must be
         provided.
 
         :param str project_name:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None output_directory:
         :return str: gs:// path for dataset
         """
-        if gs_path:
-            bucket_name, output_directory = storage.path.split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, output_directory = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
         files = []
 
@@ -126,7 +126,7 @@ class Dataset(Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable
             path_in_bucket=storage.path.join(output_directory, self.name, definitions.DATASET_FILENAME),
         )
 
-        return gs_path or storage.path.generate_gs_path(bucket_name, output_directory, self.name)
+        return cloud_path or storage.path.generate_gs_path(bucket_name, output_directory, self.name)
 
     @property
     def name(self):

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -45,18 +45,18 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         vars(self).update(**kwargs)
 
     @classmethod
-    def from_cloud(cls, project_name, gs_path=None, bucket_name=None, path_to_manifest_file=None):
+    def from_cloud(cls, project_name, cloud_path=None, bucket_name=None, path_to_manifest_file=None):
         """Instantiate a Manifest from Google Cloud storage. Either (`bucket_name` and `path_to_manifest_file`) or
-        `gs_path` must be provided.
+        `cloud_path` must be provided.
 
         :param str project_name:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_to_manifest_file:
         :return Dataset:
         """
-        if gs_path:
-            bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
         serialised_manifest = json.loads(
             GoogleCloudStorageClient(project_name=project_name).download_as_string(
@@ -82,19 +82,21 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
             keys=serialised_manifest["keys"],
         )
 
-    def to_cloud(self, project_name, gs_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=True):
+    def to_cloud(
+        self, project_name, cloud_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=True
+    ):
         """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory. Either
-        (`bucket_name` and `path_to_manifest_file`) or `gs_path` must be provided.
+        (`bucket_name` and `path_to_manifest_file`) or `cloud_path` must be provided.
 
         :param str project_name:
-        :param str|None gs_path:
+        :param str|None cloud_path:
         :param str|None bucket_name:
         :param str|None path_to_manifest_file:
         :param bool store_datasets: if True, upload datasets to same directory as manifest file
         :return str: gs:// path for manifest file
         """
-        if gs_path:
-            bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(gs_path)
+        if cloud_path:
+            bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
         datasets = []
         output_directory = storage.path.dirname(path_to_manifest_file)
@@ -121,7 +123,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
             path_in_bucket=path_to_manifest_file,
         )
 
-        return gs_path or storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
+        return cloud_path or storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
 
     @property
     def all_datasets_are_in_cloud(self):

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -46,7 +46,8 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
 
     @classmethod
     def from_cloud(cls, project_name, gs_path=None, bucket_name=None, path_to_manifest_file=None):
-        """Instantiate a Manifest from Google Cloud storage.
+        """Instantiate a Manifest from Google Cloud storage. Either (`bucket_name` and `path_to_manifest_file`) or
+        `gs_path` must be provided.
 
         :param str project_name:
         :param str|None gs_path:
@@ -82,7 +83,8 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         )
 
     def to_cloud(self, project_name, gs_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=True):
-        """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory.
+        """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory. Either
+        (`bucket_name` and `path_to_manifest_file`) or `gs_path` must be provided.
 
         :param str project_name:
         :param str|None gs_path:

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -49,10 +49,10 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         """Instantiate a Manifest from Google Cloud storage. Either (`bucket_name` and `path_to_manifest_file`) or
         `cloud_path` must be provided.
 
-        :param str project_name:
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_to_manifest_file:
+        :param str project_name: name of Google Cloud project manifest is stored in
+        :param str|None cloud_path: full path to manifest in cloud storage (e.g. `gs://bucket_name/path/to/manifest.json`)
+        :param str|None bucket_name: name of bucket manifest is stored in
+        :param str|None path_to_manifest_file: path to manifest in cloud storage e.g. `path/to/manifest.json`
         :return Dataset:
         """
         if cloud_path:
@@ -88,10 +88,10 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
         """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory. Either
         (`bucket_name` and `path_to_manifest_file`) or `cloud_path` must be provided.
 
-        :param str project_name:
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_to_manifest_file:
+        :param str project_name: name of Google Cloud project to store manifest in
+        :param str|None cloud_path: full path to cloud storage location to store manifest at (e.g. `gs://bucket_name/path/to/manifest.json`)
+        :param str|None bucket_name: name of bucket to store manifest in
+        :param str|None path_to_manifest_file: cloud storage path to store manifest at e.g. `path/to/manifest.json`
         :param bool store_datasets: if True, upload datasets to same directory as manifest file
         :return str: gs:// path for manifest file
         """

--- a/octue/utils/encoders.py
+++ b/octue/utils/encoders.py
@@ -1,3 +1,5 @@
+import datetime
+
 from twined.utils import TwinedEncoder
 
 
@@ -9,6 +11,9 @@ class OctueJSONEncoder(TwinedEncoder):
         # If the class defines a serialise() method then use it
         if hasattr(obj, "serialise"):
             return obj.serialise()
+
+        if isinstance(obj, datetime.datetime):
+            return str(obj)
 
         # Otherwise let the base class default method raise the TypeError
         return TwinedEncoder.default(self, obj)

--- a/octue/utils/encoders.py
+++ b/octue/utils/encoders.py
@@ -13,7 +13,7 @@ class OctueJSONEncoder(TwinedEncoder):
             return obj.serialise()
 
         if isinstance(obj, datetime.datetime):
-            return str(obj)
+            return obj.isoformat()
 
         # Otherwise let the base class default method raise the TypeError
         return TwinedEncoder.default(self, obj)

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -176,7 +176,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         path_in_bucket = storage.path.join(directory_path, self.FILENAME)
         gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
 
-        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), gs_path=gs_path)
+        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), cloud_path=gs_path)
         contents = list(self.storage_client.scandir(gs_path))
 
         self.assertEqual(len(contents), 1)
@@ -206,7 +206,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
     def test_get_metadata_with_gs_path(self):
         """Test that file metadata can be retrieved when a GS path is used."""
         gs_path = f"gs://{TEST_BUCKET_NAME}/{self.FILENAME}"
-        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), gs_path=gs_path)
+        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), cloud_path=gs_path)
 
         metadata = self.storage_client.get_metadata(gs_path)
         self.assertTrue(len(metadata) > 0)

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -170,6 +170,18 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[0].name, storage.path.join(directory_path, self.FILENAME))
 
+    def test_scandir_with_gs_path(self):
+        """Test that Google Cloud storage "directories"' contents can be listed when a GS path is used."""
+        directory_path = storage.path.join("my", "path")
+        path_in_bucket = storage.path.join(directory_path, self.FILENAME)
+        gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
+
+        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), gs_path=gs_path)
+        contents = list(self.storage_client.scandir(gs_path))
+
+        self.assertEqual(len(contents), 1)
+        self.assertEqual(contents[0].name, storage.path.join(directory_path, self.FILENAME))
+
     def test_scandir_with_empty_directory(self):
         """Test that an empty directory shows as such."""
         directory_path = storage.path.join("another", "path")
@@ -189,4 +201,12 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
             path_in_bucket=self.FILENAME,
         )
 
+        self.assertTrue(len(metadata) > 0)
+
+    def test_get_metadata_with_gs_path(self):
+        """Test that file metadata can be retrieved when a GS path is used."""
+        gs_path = f"gs://{TEST_BUCKET_NAME}/{self.FILENAME}"
+        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), gs_path=gs_path)
+
+        metadata = self.storage_client.get_metadata(gs_path)
         self.assertTrue(len(metadata) > 0)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -204,7 +204,7 @@ class DatafileTestCase(BaseTestCase):
             tags={"blah:shah:nah", "blib", "glib"},
         )
         gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
-        downloaded_datafile = Datafile.from_cloud(project_name, gs_path=gs_path)
+        downloaded_datafile = Datafile.from_cloud(project_name, cloud_path=gs_path)
 
         self.assertEqual(downloaded_datafile.path, gs_path)
         self.assertEqual(downloaded_datafile.id, datafile.id)

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -203,10 +203,10 @@ class DatafileTestCase(BaseTestCase):
             sequence=1,
             tags={"blah:shah:nah", "blib", "glib"},
         )
+        gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
+        downloaded_datafile = Datafile.from_cloud(project_name, gs_path=gs_path)
 
-        downloaded_datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
-
-        self.assertEqual(downloaded_datafile.path, f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}")
+        self.assertEqual(downloaded_datafile.path, gs_path)
         self.assertEqual(downloaded_datafile.id, datafile.id)
         self.assertEqual(downloaded_datafile.timestamp, datafile.timestamp)
         self.assertEqual(downloaded_datafile.hash_value, datafile.hash_value)
@@ -257,9 +257,11 @@ class DatafileTestCase(BaseTestCase):
         datafile, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud(cluster=0)
 
         datafile.cluster = 3
-        datafile.to_cloud(project_name, bucket_name, path_in_bucket)
+        datafile.to_cloud(project_name, bucket_name=bucket_name, path_in_bucket=path_in_bucket)
 
-        self.assertEqual(Datafile.from_cloud(project_name, bucket_name, path_in_bucket).cluster, 3)
+        self.assertEqual(
+            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 3
+        )
 
     def test_to_cloud_does_not_update_cloud_metadata_if_update_cloud_metadata_is_false(self):
         """Test that calling Datafile.to_cloud with `update_cloud_metadata=False` doesn't update the cloud metadata."""
@@ -267,16 +269,20 @@ class DatafileTestCase(BaseTestCase):
         datafile.cluster = 3
 
         with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
-            datafile.to_cloud(project_name, bucket_name, path_in_bucket, update_cloud_metadata=False)
+            datafile.to_cloud(
+                project_name, bucket_name=bucket_name, path_in_bucket=path_in_bucket, update_cloud_metadata=False
+            )
             self.assertFalse(mock.called)
 
-        self.assertEqual(Datafile.from_cloud(project_name, bucket_name, path_in_bucket).cluster, 0)
+        self.assertEqual(
+            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 0
+        )
 
     def test_to_cloud_does_not_update_metadata_if_no_metadata_change_has_been_made(self):
         """Test that Datafile.to_cloud does not try to update cloud metadata if no metadata change has been made."""
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud(cluster=0)
 
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
 
         with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
             datafile.to_cloud()
@@ -296,7 +302,7 @@ class DatafileTestCase(BaseTestCase):
         provided.
         """
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
         datafile.to_cloud()
 
     def test_to_cloud_does_not_try_to_update_file_if_no_change_has_been_made_locally(self):
@@ -312,9 +318,11 @@ class DatafileTestCase(BaseTestCase):
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
 
         new_datafile = Datafile(path="glib.txt", cluster=32)
-        new_datafile.update_cloud_metadata(project_name, bucket_name, path_in_bucket)
+        new_datafile.update_cloud_metadata(project_name, bucket_name=bucket_name, path_in_bucket=path_in_bucket)
 
-        self.assertEqual(Datafile.from_cloud(project_name, bucket_name, path_in_bucket).cluster, 32)
+        self.assertEqual(
+            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 32
+        )
 
     def test_update_cloud_metadata_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
         """Test that datafile.update_metadata works with an implicit cloud location if the cloud location has been
@@ -322,11 +330,13 @@ class DatafileTestCase(BaseTestCase):
         """
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
 
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
         datafile.cluster = 32
         datafile.update_cloud_metadata()
 
-        self.assertEqual(Datafile.from_cloud(project_name, bucket_name, path_in_bucket).cluster, 32)
+        self.assertEqual(
+            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 32
+        )
 
     def test_update_cloud_metadata_raises_error_if_no_cloud_location_provided_and_datafile_not_from_cloud(self):
         """Test that trying to update a cloud datafile's metadata with no cloud location provided when the datafile was
@@ -340,7 +350,7 @@ class DatafileTestCase(BaseTestCase):
     def test_get_local_path(self):
         """Test that a file in the cloud can be temporarily downloaded and its local path returned."""
         _, project_name, bucket_name, path_in_bucket, contents = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
 
         with open(datafile.get_local_path()) as f:
             self.assertEqual(f.read(), contents)
@@ -348,7 +358,7 @@ class DatafileTestCase(BaseTestCase):
     def test_get_local_path_with_cached_file_avoids_downloading_again(self):
         """Test that attempting to download a cached file avoids downloading it again."""
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
 
         # Download for first time.
         datafile.get_local_path()
@@ -388,7 +398,7 @@ class DatafileTestCase(BaseTestCase):
     def test_open_with_reading_cloud_file(self):
         """Test that a cloud datafile can be opened for reading."""
         _, project_name, bucket_name, path_in_bucket, contents = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
 
         with datafile.open() as f:
             self.assertEqual(f.read(), contents)
@@ -396,7 +406,7 @@ class DatafileTestCase(BaseTestCase):
     def test_open_with_writing_to_cloud_file(self):
         """Test that a cloud datafile can be opened for writing and that both the remote and local copies are updated."""
         _, project_name, bucket_name, path_in_bucket, original_contents = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
 
         new_file_contents = "nanana"
 
@@ -499,12 +509,17 @@ class DatafileTestCase(BaseTestCase):
         new_contents = "Here is the new content."
         self.assertNotEqual(original_content, new_contents)
 
-        with Datafile.from_cloud(project_name, bucket_name, path_in_bucket, mode="w") as (datafile, f):
+        with Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket, mode="w") as (
+            datafile,
+            f,
+        ):
             datafile.add_tags("blue")
             f.write(new_contents)
 
         # Check that the cloud metadata has been updated.
-        re_downloaded_datafile = Datafile.from_cloud(project_name, bucket_name, path_in_bucket)
+        re_downloaded_datafile = Datafile.from_cloud(
+            project_name, bucket_name=bucket_name, datafile_path=path_in_bucket
+        )
         self.assertTrue("blue" in re_downloaded_datafile.tags)
 
         # The file cache must be cleared so the modified cloud file is downloaded.

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -329,8 +329,12 @@ class DatasetTestCase(BaseTestCase):
             gs_path = f"gs://{bucket_name}/{path_to_dataset_directory}"
 
             for location_parameters in (
-                {"bucket_name": bucket_name, "path_to_dataset_directory": path_to_dataset_directory, "gs_path": None},
-                {"bucket_name": None, "path_to_dataset_directory": None, "gs_path": gs_path},
+                {
+                    "bucket_name": bucket_name,
+                    "path_to_dataset_directory": path_to_dataset_directory,
+                    "cloud_path": None,
+                },
+                {"bucket_name": None, "path_to_dataset_directory": None, "cloud_path": gs_path},
             ):
 
                 persisted_dataset = Dataset.from_cloud(
@@ -375,8 +379,8 @@ class DatasetTestCase(BaseTestCase):
             gs_path = storage.path.generate_gs_path(bucket_name, output_directory)
 
             for location_parameters in (
-                {"bucket_name": bucket_name, "output_directory": output_directory, "gs_path": None},
-                {"bucket_name": None, "output_directory": None, "gs_path": gs_path},
+                {"bucket_name": bucket_name, "output_directory": output_directory, "cloud_path": None},
+                {"bucket_name": None, "output_directory": None, "cloud_path": gs_path},
             ):
                 dataset.to_cloud(project_name, **location_parameters)
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -363,7 +363,7 @@ class DatasetTestCase(BaseTestCase):
                 }
             )
 
-            dataset.to_cloud(project_name, TEST_BUCKET_NAME, output_directory)
+            dataset.to_cloud(project_name, bucket_name=TEST_BUCKET_NAME, output_directory=output_directory)
 
             storage_client = GoogleCloudStorageClient(project_name)
 

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -56,7 +56,9 @@ class TestManifest(BaseTestCase):
             self.assertEqual(original_dataset.absolute_path, deserialised_dataset.absolute_path)
 
     def test_to_cloud(self):
-        """Test that a manifest can be uploaded to the cloud as a serialised JSON file of the Manifest instance. """
+        """Test that a manifest can be uploaded to the cloud as a serialised JSON file of the Manifest instance via
+        (`bucket_name`, `output_directory`) and via `gs_path`.
+        """
         with tempfile.TemporaryDirectory() as temporary_directory:
             file_0_path = os.path.join(temporary_directory, "file_0.txt")
             file_1_path = os.path.join(temporary_directory, "file_1.txt")
@@ -77,11 +79,15 @@ class TestManifest(BaseTestCase):
 
             manifest = Manifest(datasets=[dataset], keys={"my-dataset": 0})
 
-            manifest.to_cloud(
-                self.TEST_PROJECT_NAME,
-                bucket_name=TEST_BUCKET_NAME,
-                path_to_manifest_file=storage.path.join("blah", "manifest.json"),
-            )
+            bucket_name = TEST_BUCKET_NAME
+            path_to_manifest_file = storage.path.join("blah", "manifest.json")
+            gs_path = storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
+
+            for location_parameters in (
+                {"bucket_name": bucket_name, "path_to_manifest_file": path_to_manifest_file, "gs_path": None},
+                {"bucket_name": None, "path_to_manifest_file": None, "gs_path": gs_path},
+            ):
+                manifest.to_cloud(self.TEST_PROJECT_NAME, **location_parameters)
 
         persisted_manifest = json.loads(
             GoogleCloudStorageClient(self.TEST_PROJECT_NAME).download_as_string(
@@ -134,7 +140,9 @@ class TestManifest(BaseTestCase):
         self.assertEqual(persisted_manifest["keys"], {"my-dataset": 0})
 
     def test_from_cloud(self):
-        """Test that a Manifest can be instantiated from the cloud."""
+        """Test that a Manifest can be instantiated from the cloud via (`bucket_name`, `output_directory`) and via
+        `gs_path`.
+        """
         with tempfile.TemporaryDirectory() as temporary_directory:
             file_0_path = os.path.join(temporary_directory, "file_0.txt")
             file_1_path = os.path.join(temporary_directory, "file_1.txt")
@@ -160,22 +168,26 @@ class TestManifest(BaseTestCase):
                 path_to_manifest_file=storage.path.join("my-directory", "manifest.json"),
             )
 
-            persisted_manifest = Manifest.from_cloud(
-                project_name=self.TEST_PROJECT_NAME,
-                bucket_name=TEST_BUCKET_NAME,
-                path_to_manifest_file=storage.path.join("my-directory", "manifest.json"),
-            )
+            bucket_name = TEST_BUCKET_NAME
+            path_to_manifest_file = storage.path.join("my-directory", "manifest.json")
+            gs_path = storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
 
-            self.assertEqual(persisted_manifest.path, f"gs://{TEST_BUCKET_NAME}/my-directory/manifest.json")
-            self.assertEqual(persisted_manifest.id, manifest.id)
-            self.assertEqual(persisted_manifest.hash_value, manifest.hash_value)
-            self.assertEqual(persisted_manifest.keys, manifest.keys)
-            self.assertEqual(
-                {dataset.name for dataset in persisted_manifest.datasets},
-                {dataset.name for dataset in manifest.datasets},
-            )
+            for location_parameters in (
+                {"bucket_name": bucket_name, "path_to_manifest_file": path_to_manifest_file, "gs_path": None},
+                {"bucket_name": None, "path_to_manifest_file": None, "gs_path": gs_path},
+            ):
+                persisted_manifest = Manifest.from_cloud(project_name=self.TEST_PROJECT_NAME, **location_parameters)
 
-            for dataset in persisted_manifest.datasets:
-                self.assertEqual(dataset.path, f"gs://{TEST_BUCKET_NAME}/my-directory/{dataset.name}")
-                self.assertTrue(len(dataset.files), 2)
-                self.assertTrue(all(isinstance(file, Datafile) for file in dataset.files))
+                self.assertEqual(persisted_manifest.path, f"gs://{TEST_BUCKET_NAME}/my-directory/manifest.json")
+                self.assertEqual(persisted_manifest.id, manifest.id)
+                self.assertEqual(persisted_manifest.hash_value, manifest.hash_value)
+                self.assertEqual(persisted_manifest.keys, manifest.keys)
+                self.assertEqual(
+                    {dataset.name for dataset in persisted_manifest.datasets},
+                    {dataset.name for dataset in manifest.datasets},
+                )
+
+                for dataset in persisted_manifest.datasets:
+                    self.assertEqual(dataset.path, f"gs://{TEST_BUCKET_NAME}/my-directory/{dataset.name}")
+                    self.assertTrue(len(dataset.files), 2)
+                    self.assertTrue(all(isinstance(file, Datafile) for file in dataset.files))

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -79,7 +79,7 @@ class TestManifest(BaseTestCase):
 
             manifest.to_cloud(
                 self.TEST_PROJECT_NAME,
-                TEST_BUCKET_NAME,
+                bucket_name=TEST_BUCKET_NAME,
                 path_to_manifest_file=storage.path.join("blah", "manifest.json"),
             )
 
@@ -118,7 +118,7 @@ class TestManifest(BaseTestCase):
 
             manifest.to_cloud(
                 self.TEST_PROJECT_NAME,
-                TEST_BUCKET_NAME,
+                bucket_name=TEST_BUCKET_NAME,
                 path_to_manifest_file=storage.path.join("my-manifests", "manifest.json"),
                 store_datasets=False,
             )
@@ -156,7 +156,7 @@ class TestManifest(BaseTestCase):
             manifest = Manifest(datasets=[dataset], keys={"my-dataset": 0})
             manifest.to_cloud(
                 self.TEST_PROJECT_NAME,
-                TEST_BUCKET_NAME,
+                bucket_name=TEST_BUCKET_NAME,
                 path_to_manifest_file=storage.path.join("my-directory", "manifest.json"),
             )
 

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -84,8 +84,8 @@ class TestManifest(BaseTestCase):
             gs_path = storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
 
             for location_parameters in (
-                {"bucket_name": bucket_name, "path_to_manifest_file": path_to_manifest_file, "gs_path": None},
-                {"bucket_name": None, "path_to_manifest_file": None, "gs_path": gs_path},
+                {"bucket_name": bucket_name, "path_to_manifest_file": path_to_manifest_file, "cloud_path": None},
+                {"bucket_name": None, "path_to_manifest_file": None, "cloud_path": gs_path},
             ):
                 manifest.to_cloud(self.TEST_PROJECT_NAME, **location_parameters)
 
@@ -173,8 +173,8 @@ class TestManifest(BaseTestCase):
             gs_path = storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
 
             for location_parameters in (
-                {"bucket_name": bucket_name, "path_to_manifest_file": path_to_manifest_file, "gs_path": None},
-                {"bucket_name": None, "path_to_manifest_file": None, "gs_path": gs_path},
+                {"bucket_name": bucket_name, "path_to_manifest_file": path_to_manifest_file, "cloud_path": None},
+                {"bucket_name": None, "path_to_manifest_file": None, "cloud_path": gs_path},
             ):
                 persisted_manifest = Manifest.from_cloud(project_name=self.TEST_PROJECT_NAME, **location_parameters)
 


### PR DESCRIPTION
<!-- PRs from release/x.y.z branches will be used to create Release Notes so make sure they contain everything -->
<!-- Please don't add features not discussed in an issue first -->

## Contents

### New Features
- [x] Allow `gs://` paths to be used in `Datafile`, `Dataset`, and `Manifest`
- [x] Allow `gs://` paths to be used in storage client 

### Minor fixes and improvements
- [x] Remove a line of duplicated code in `Datafile`

## Quality Checklist
- [x] New features are fully tested (No matter how much Coverage Karma you have)