### PR TITLE
Feature: Add more filter types

### DIFF
--- a/octue/mixins/filterable.py
+++ b/octue/mixins/filterable.py
@@ -31,6 +31,11 @@ ICONTAINS_FILTER_ACTIONS = {
     "not_icontains": lambda item, filter_value: filter_value.lower() not in item.lower(),
 }
 
+IN_RANGE_FILTER_ACTIONS = {
+    "in_range": lambda item, filter_value: filter_value[0] <= item <= filter_value[1],
+    "not_in_range": lambda item, filter_value: item < filter_value[0] or item > filter_value[1],
+}
+
 
 # Filters for specific types e.g. list or int.
 TYPE_FILTERS = {
@@ -43,12 +48,39 @@ TYPE_FILTERS = {
         "ends_with": lambda item, filter_value: item.endswith(filter_value),
         "not_ends_with": lambda item, filter_value: not item.endswith(filter_value),
         **EQUALS_FILTER_ACTIONS,
-        **COMPARISON_FILTER_ACTIONS,
         **IS_FILTER_ACTIONS,
+        **COMPARISON_FILTER_ACTIONS,
         **CONTAINS_FILTER_ACTIONS,
         **ICONTAINS_FILTER_ACTIONS,
+        **IN_RANGE_FILTER_ACTIONS,
     },
     "NoneType": IS_FILTER_ACTIONS,
+    "datetime": {
+        **EQUALS_FILTER_ACTIONS,
+        **IS_FILTER_ACTIONS,
+        **COMPARISON_FILTER_ACTIONS,
+        **IN_RANGE_FILTER_ACTIONS,
+        "year_equals": lambda item, filter_value: item.year == filter_value,
+        "year_in": lambda item, filter_value: item.year in filter_value,
+        "month_equals": lambda item, filter_value: item.month == filter_value,
+        "month_in": lambda item, filter_value: item.month in filter_value,
+        "day_equals": lambda item, filter_value: item.day == filter_value,
+        "day_in": lambda item, filter_value: item.day in filter_value,
+        "weekday_equals": lambda item, filter_value: item.weekday() == filter_value,
+        "weekday_in": lambda item, filter_value: item.weekday() in filter_value,
+        "iso_weekday_equals": lambda item, filter_value: item.isoweekday() == filter_value,
+        "iso_weekday_in": lambda item, filter_value: item.isoweekday() in filter_value,
+        "time_equals": lambda item, filter_value: item.time() == filter_value,
+        "time_in": lambda item, filter_value: item.time() in filter_value,
+        "hour_equals": lambda item, filter_value: item.hour == filter_value,
+        "hour_in": lambda item, filter_value: item.hour in filter_value,
+        "minute_equals": lambda item, filter_value: item.minute == filter_value,
+        "minute_in": lambda item, filter_value: item.minute in filter_value,
+        "second_equals": lambda item, filter_value: item.second == filter_value,
+        "second_in": lambda item, filter_value: item.second in filter_value,
+        "in_date_range": lambda item, filter_value: filter_value[0] <= item.date() <= filter_value[1],
+        "in_time_range": lambda item, filter_value: filter_value[0] <= item.time() <= filter_value[1],
+    },
     "TagSet": {
         "any_tag_contains": lambda item, filter_value: item.any_tag_contains(filter_value),
         "not_any_tag_contains": lambda item, filter_value: not item.any_tag_contains(filter_value),
@@ -64,7 +96,12 @@ TYPE_FILTERS = {
 
 # Filters for interfaces e.g. iterables or numbers.
 INTERFACE_FILTERS = {
-    numbers.Number: {**EQUALS_FILTER_ACTIONS, **COMPARISON_FILTER_ACTIONS, **IS_FILTER_ACTIONS},
+    numbers.Number: {
+        **EQUALS_FILTER_ACTIONS,
+        **COMPARISON_FILTER_ACTIONS,
+        **IS_FILTER_ACTIONS,
+        **IN_RANGE_FILTER_ACTIONS,
+    },
     collections.abc.Iterable: {
         **EQUALS_FILTER_ACTIONS,
         **CONTAINS_FILTER_ACTIONS,

--- a/octue/mixins/filterable.py
+++ b/octue/mixins/filterable.py
@@ -4,36 +4,42 @@ import numbers
 from octue import exceptions
 
 
-IS_FILTER_ACTIONS = {
-    "is": lambda item, filter_value: item is filter_value,
-    "is_not": lambda item, filter_value: item is not filter_value,
-}
+def generate_complementary_filters(name, func):
+    """Use a filter to generate its complementary filter, then return them together mapped to their names in a
+    dictionary. The complementary filter is named f"not_{name}" or, if the name is "is", "is_not".
 
-EQUALS_FILTER_ACTIONS = {
-    "equals": lambda item, filter_value: filter_value == item,
-    "not_equals": lambda item, filter_value: filter_value != item,
-}
+    :param str name:
+    :param callable func:
+    :return dict:
+    """
+    filter_action = {name: func}
+
+    if name == "is":
+        not_filter_name = "is_not"
+    else:
+        not_filter_name = f"not_{name}"
+
+    not_filter_action = {
+        not_filter_name: lambda item, value: not action(item, value) for name, action in filter_action.items()
+    }
+
+    return {**filter_action, **not_filter_action}
+
+
+IS_FILTER_ACTIONS = generate_complementary_filters("is", lambda item, value: item is value)
+EQUALS_FILTER_ACTIONS = generate_complementary_filters("equals", lambda item, value: value == item)
+CONTAINS_FILTER_ACTIONS = generate_complementary_filters("contains", lambda item, value: value in item)
+IN_RANGE_FILTER_ACTIONS = generate_complementary_filters("in_range", lambda item, value: value[0] <= item <= value[1])
+
+ICONTAINS_FILTER_ACTIONS = generate_complementary_filters(
+    "icontains", lambda item, value: value.lower() in item.lower()
+)
 
 COMPARISON_FILTER_ACTIONS = {
-    "lt": lambda item, filter_value: item < filter_value,
-    "lte": lambda item, filter_value: item <= filter_value,
-    "gt": lambda item, filter_value: item > filter_value,
-    "gte": lambda item, filter_value: item >= filter_value,
-}
-
-CONTAINS_FILTER_ACTIONS = {
-    "contains": lambda item, filter_value: filter_value in item,
-    "not_contains": lambda item, filter_value: filter_value not in item,
-}
-
-ICONTAINS_FILTER_ACTIONS = {
-    "icontains": lambda item, filter_value: filter_value.lower() in item.lower(),
-    "not_icontains": lambda item, filter_value: filter_value.lower() not in item.lower(),
-}
-
-IN_RANGE_FILTER_ACTIONS = {
-    "in_range": lambda item, filter_value: filter_value[0] <= item <= filter_value[1],
-    "not_in_range": lambda item, filter_value: item < filter_value[0] or item > filter_value[1],
+    "lt": lambda item, value: item < value,
+    "lte": lambda item, value: item <= value,
+    "gt": lambda item, value: item > value,
+    "gte": lambda item, value: item >= value,
 }
 
 
@@ -41,12 +47,9 @@ IN_RANGE_FILTER_ACTIONS = {
 TYPE_FILTERS = {
     "bool": IS_FILTER_ACTIONS,
     "str": {
-        "iequals": lambda item, filter_value: filter_value.lower() == item.lower(),
-        "not_iequals": lambda item, filter_value: filter_value.lower() != item.lower(),
-        "starts_with": lambda item, filter_value: item.startswith(filter_value),
-        "not_starts_with": lambda item, filter_value: not item.startswith(filter_value),
-        "ends_with": lambda item, filter_value: item.endswith(filter_value),
-        "not_ends_with": lambda item, filter_value: not item.endswith(filter_value),
+        **generate_complementary_filters("iequals", lambda item, value: value.lower() == item.lower()),
+        **generate_complementary_filters("starts_with", lambda item, value: item.startswith(value)),
+        **generate_complementary_filters("ends_with", lambda item, value: item.endswith(value)),
         **EQUALS_FILTER_ACTIONS,
         **IS_FILTER_ACTIONS,
         **COMPARISON_FILTER_ACTIONS,
@@ -60,34 +63,31 @@ TYPE_FILTERS = {
         **IS_FILTER_ACTIONS,
         **COMPARISON_FILTER_ACTIONS,
         **IN_RANGE_FILTER_ACTIONS,
-        "year_equals": lambda item, filter_value: item.year == filter_value,
-        "year_in": lambda item, filter_value: item.year in filter_value,
-        "month_equals": lambda item, filter_value: item.month == filter_value,
-        "month_in": lambda item, filter_value: item.month in filter_value,
-        "day_equals": lambda item, filter_value: item.day == filter_value,
-        "day_in": lambda item, filter_value: item.day in filter_value,
-        "weekday_equals": lambda item, filter_value: item.weekday() == filter_value,
-        "weekday_in": lambda item, filter_value: item.weekday() in filter_value,
-        "iso_weekday_equals": lambda item, filter_value: item.isoweekday() == filter_value,
-        "iso_weekday_in": lambda item, filter_value: item.isoweekday() in filter_value,
-        "time_equals": lambda item, filter_value: item.time() == filter_value,
-        "time_in": lambda item, filter_value: item.time() in filter_value,
-        "hour_equals": lambda item, filter_value: item.hour == filter_value,
-        "hour_in": lambda item, filter_value: item.hour in filter_value,
-        "minute_equals": lambda item, filter_value: item.minute == filter_value,
-        "minute_in": lambda item, filter_value: item.minute in filter_value,
-        "second_equals": lambda item, filter_value: item.second == filter_value,
-        "second_in": lambda item, filter_value: item.second in filter_value,
-        "in_date_range": lambda item, filter_value: filter_value[0] <= item.date() <= filter_value[1],
-        "in_time_range": lambda item, filter_value: filter_value[0] <= item.time() <= filter_value[1],
+        "year_equals": lambda item, value: item.year == value,
+        "year_in": lambda item, value: item.year in value,
+        "month_equals": lambda item, value: item.month == value,
+        "month_in": lambda item, value: item.month in value,
+        "day_equals": lambda item, value: item.day == value,
+        "day_in": lambda item, value: item.day in value,
+        "weekday_equals": lambda item, value: item.weekday() == value,
+        "weekday_in": lambda item, value: item.weekday() in value,
+        "iso_weekday_equals": lambda item, value: item.isoweekday() == value,
+        "iso_weekday_in": lambda item, value: item.isoweekday() in value,
+        "time_equals": lambda item, value: item.time() == value,
+        "time_in": lambda item, value: item.time() in value,
+        "hour_equals": lambda item, value: item.hour == value,
+        "hour_in": lambda item, value: item.hour in value,
+        "minute_equals": lambda item, value: item.minute == value,
+        "minute_in": lambda item, value: item.minute in value,
+        "second_equals": lambda item, value: item.second == value,
+        "second_in": lambda item, value: item.second in value,
+        "in_date_range": lambda item, value: value[0] <= item.date() <= value[1],
+        "in_time_range": lambda item, value: value[0] <= item.time() <= value[1],
     },
     "TagSet": {
-        "any_tag_contains": lambda item, filter_value: item.any_tag_contains(filter_value),
-        "not_any_tag_contains": lambda item, filter_value: not item.any_tag_contains(filter_value),
-        "any_tag_starts_with": lambda item, filter_value: item.any_tag_starts_with(filter_value),
-        "not_any_tag_starts_with": lambda item, filter_value: not item.any_tag_starts_with(filter_value),
-        "any_tag_ends_with": lambda item, filter_value: item.any_tag_ends_with(filter_value),
-        "not_any_tag_ends_with": lambda item, filter_value: not item.any_tag_ends_with(filter_value),
+        **generate_complementary_filters("any_tag_contains", lambda item, value: item.any_tag_contains(value)),
+        **generate_complementary_filters("any_tag_starts_with", lambda item, value: item.any_tag_starts_with(value)),
+        **generate_complementary_filters("any_tag_ends_with", lambda item, value: item.any_tag_ends_with(value)),
         **EQUALS_FILTER_ACTIONS,
         **CONTAINS_FILTER_ACTIONS,
         **IS_FILTER_ACTIONS,

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, time
 
 from octue import exceptions
 from octue.mixins.filterable import Filterable
@@ -184,6 +184,24 @@ class TestFilterable(BaseTestCase):
         self.assertFalse(filterable_thing.satisfies("timestamp__iso_weekday_equals", 4))
         self.assertTrue(filterable_thing.satisfies("timestamp__iso_weekday_in", {5, 6, 7}))
         self.assertFalse(filterable_thing.satisfies("timestamp__iso_weekday_in", {7, 8}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__time_equals", time(0, 0, 0)))
+        self.assertFalse(filterable_thing.satisfies("timestamp__time_equals", time(1, 2, 3)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__hour_equals", 0))
+        self.assertFalse(filterable_thing.satisfies("timestamp__hour_equals", 1))
+        self.assertTrue(filterable_thing.satisfies("timestamp__hour_in", {0, 1, 2}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__hour_in", {1, 2}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__minute_equals", 0))
+        self.assertFalse(filterable_thing.satisfies("timestamp__minute_equals", 1))
+        self.assertTrue(filterable_thing.satisfies("timestamp__minute_in", {0, 1, 2}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__minute_in", {1, 2}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__second_equals", 0))
+        self.assertFalse(filterable_thing.satisfies("timestamp__second_equals", 1))
+        self.assertTrue(filterable_thing.satisfies("timestamp__second_in", {0, 1, 2}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__second_in", {1, 2}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__in_date_range", (date(1000, 1, 4), date(3000, 7, 10))))
+        self.assertFalse(filterable_thing.satisfies("timestamp__in_date_range", (date(2000, 1, 4), date(3000, 7, 10))))
+        self.assertTrue(filterable_thing.satisfies("timestamp__in_time_range", (time(0, 0, 0), time(13, 2, 22))))
+        self.assertFalse(filterable_thing.satisfies("timestamp__in_time_range", (time(0, 0, 1), time(13, 2, 22))))
 
     def test_tag_set_filters(self):
         """ Test the filters for TagSet. """

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from octue import exceptions
 from octue.mixins.filterable import Filterable
 from octue.resources.tag import TagSet
@@ -5,12 +7,13 @@ from tests.base import BaseTestCase
 
 
 class FilterableSubclass(Filterable):
-    def __init__(self, name=None, is_alive=None, iterable=None, age=None, owner=None):
+    def __init__(self, name=None, is_alive=None, iterable=None, age=None, owner=None, timestamp=None):
         self.name = name
         self.is_alive = is_alive
         self.iterable = iterable
         self.age = age
         self.owner = owner
+        self.timestamp = timestamp
 
 
 class TestFilterable(BaseTestCase):
@@ -131,6 +134,56 @@ class TestFilterable(BaseTestCase):
             self.assertFalse(filterable_thing.satisfies("iterable__is", None))
             self.assertTrue(filterable_thing.satisfies("iterable__is_not", None))
             self.assertFalse(filterable_thing.satisfies("iterable__is_not", iterable))
+
+    def test_datetime_filters(self):
+        my_datetime = datetime(2000, 1, 1)
+        filterable_thing = FilterableSubclass(timestamp=my_datetime)
+        self.assertTrue(filterable_thing.satisfies("timestamp__equals", my_datetime))
+        self.assertFalse(filterable_thing.satisfies("timestamp__equals", datetime(2, 2, 2)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__not_equals", datetime(2, 2, 2)))
+        self.assertFalse(filterable_thing.satisfies("timestamp__not_equals", my_datetime))
+        self.assertTrue(filterable_thing.satisfies("timestamp__is", my_datetime))
+        self.assertFalse(filterable_thing.satisfies("timestamp__is", datetime(2, 2, 2)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__is_not", datetime(2, 2, 2)))
+        self.assertFalse(filterable_thing.satisfies("timestamp__is_not", my_datetime))
+        self.assertTrue(filterable_thing.satisfies("timestamp__gt", datetime(1900, 1, 2)))
+        self.assertFalse(filterable_thing.satisfies("timestamp__gt", datetime(3000, 1, 2)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__gte", my_datetime))
+        self.assertFalse(filterable_thing.satisfies("timestamp__gte", datetime(3000, 1, 2)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__lt", datetime(3000, 1, 2)))
+        self.assertFalse(filterable_thing.satisfies("timestamp__lt", datetime(1990, 1, 2)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__lte", my_datetime))
+        self.assertFalse(filterable_thing.satisfies("timestamp__lte", datetime(1900, 1, 2)))
+        self.assertTrue(filterable_thing.satisfies("timestamp__in_range", (datetime(1900, 1, 2), datetime(3000, 1, 2))))
+        self.assertFalse(
+            filterable_thing.satisfies("timestamp__in_range", (datetime(2100, 1, 2), datetime(3000, 1, 2)))
+        )
+        self.assertTrue(
+            filterable_thing.satisfies("timestamp__not_in_range", (datetime(2100, 1, 2), datetime(3000, 1, 2)))
+        )
+        self.assertFalse(
+            filterable_thing.satisfies("timestamp__not_in_range", (datetime(1900, 1, 2), datetime(3000, 1, 2)))
+        )
+        self.assertTrue(filterable_thing.satisfies("timestamp__year_equals", 2000))
+        self.assertFalse(filterable_thing.satisfies("timestamp__year_equals", 3000))
+        self.assertTrue(filterable_thing.satisfies("timestamp__year_in", {2000, 3000, 4000}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__year_in", {3000, 4000}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__month_equals", 1))
+        self.assertFalse(filterable_thing.satisfies("timestamp__month_equals", 9))
+        self.assertTrue(filterable_thing.satisfies("timestamp__month_in", {1, 2, 3}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__month_in", {2, 3}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__day_equals", 1))
+        self.assertFalse(filterable_thing.satisfies("timestamp__day_equals", 2))
+        self.assertTrue(filterable_thing.satisfies("timestamp__day_in", {1, 2, 3}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__day_in", {2, 3}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__weekday_equals", 5))
+        self.assertFalse(filterable_thing.satisfies("timestamp__weekday_equals", 3))
+        self.assertTrue(filterable_thing.satisfies("timestamp__weekday_in", {5, 6, 7}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__weekday_in", {6, 7}))
+        self.assertTrue(filterable_thing.satisfies("timestamp__iso_weekday_equals", 6))
+        self.assertFalse(filterable_thing.satisfies("timestamp__iso_weekday_equals", 4))
+        self.assertTrue(filterable_thing.satisfies("timestamp__iso_weekday_in", {5, 6, 7}))
+        self.assertFalse(filterable_thing.satisfies("timestamp__iso_weekday_in", {7, 8}))
 
     def test_tag_set_filters(self):
         """ Test the filters for TagSet. """

--- a/tests/mixins/test_filterable.py
+++ b/tests/mixins/test_filterable.py
@@ -81,6 +81,10 @@ class TestFilterable(BaseTestCase):
         self.assertFalse(filterable_thing.satisfies("name__gt", "Noel"))
         self.assertTrue(filterable_thing.satisfies("name__gte", "Michael"))
         self.assertFalse(filterable_thing.satisfies("name__gte", "Noel"))
+        self.assertTrue(filterable_thing.satisfies("name__in_range", ("Amy", "Zoe")))
+        self.assertFalse(filterable_thing.satisfies("name__in_range", ("Noel", "Peter")))
+        self.assertTrue(filterable_thing.satisfies("name__not_in_range", ("Noel", "Peter")))
+        self.assertFalse(filterable_thing.satisfies("name__not_in_range", ("Amy", "Zoe")))
 
     def test_none_filters(self):
         """ Test that the None filters work as expected. """
@@ -110,6 +114,10 @@ class TestFilterable(BaseTestCase):
             self.assertFalse(filterable_thing.satisfies("age__is", 63))
             self.assertTrue(filterable_thing.satisfies("age__is_not", 63))
             self.assertFalse(filterable_thing.satisfies("age__is_not", age))
+            self.assertTrue(filterable_thing.satisfies("age__in_range", (0, 10)))
+            self.assertFalse(filterable_thing.satisfies("age__in_range", (0, 3)))
+            self.assertTrue(filterable_thing.satisfies("age__not_in_range", (0, 3)))
+            self.assertFalse(filterable_thing.satisfies("age__not_in_range", (0, 10)))
 
     def test_iterable_filters(self):
         """ Test that the iterable filters work as expected with lists, sets, and tuples. """


### PR DESCRIPTION
## Contents

### New Features
- [x] Add `datetime` filters
- [x] Add in-range filters to `str`, `datetime`, and `Number` filters

### Minor fixes and improvements
- [x] Automatically generate complementary (`not`) filters from other filters

## Quality Checklist
- [x] New features are fully tested (No matter how much Coverage Karma you have)
- [ ] **[v0.2 onward]** New features are included in the documentation