### PR TITLE
Release/0.1.20

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -47,34 +47,34 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  publish:
-    if: contains(github.ref, 'main') || contains(github.ref, 'release/')
-    runs-on: ubuntu-latest
-    needs: tests
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Make package
-        run: |
-          python3 -m pip install --upgrade setuptools wheel
-          python3 setup.py sdist bdist_wheel
-      - name: Test package is publishable with PyPI test server
-        if: contains(github.ref, 'release/')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
-      - name: Publish latest package to PyPI
-        if: contains(github.ref, 'main')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-          verbose: true
-
+#  publish:
+#    if: contains(github.ref, 'main') || contains(github.ref, 'release/')
+#    runs-on: ubuntu-latest
+#    needs: tests
+#    steps:
+#      - name: Checkout Repository
+#        uses: actions/checkout@v2
+#      - name: Setup Python
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.8
+#      - name: Make package
+#        run: |
+#          python3 -m pip install --upgrade setuptools wheel
+#          python3 setup.py sdist bdist_wheel
+#      - name: Test package is publishable with PyPI test server
+#        if: contains(github.ref, 'release/')
+#        uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          user: __token__
+#          password: ${{ secrets.TEST_PYPI_TOKEN }}
+#          repository_url: https://test.pypi.org/legacy/
+#          skip_existing: true
+#      - name: Publish latest package to PyPI
+#        if: contains(github.ref, 'main')
+#        uses: pypa/gh-action-pypi-publish@master
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_TOKEN }}
+#          verbose: true
+#

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release the package on merge of release/x.y.z into main
+name: Update the version and release the package on merge into main
 
 # Only trigger when a pull request into main branch is closed.
 on:
@@ -8,21 +8,43 @@ on:
       - main
 
 jobs:
-  release:
-    # This job will only run if the PR has been merged (and not closed without merging).
-    if: github.event.pull_request.merged == true && startsWith( github.head_ref, 'release/' )
+  update-version:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Get package version
-      run: echo "PACKAGE_VERSION=$(python setup.py --version)" >> $GITHUB_ENV
-    - name: Create Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, no need to create your own.
       with:
-        tag_name: ${{ env.PACKAGE_VERSION }}
-        release_name: ${{ github.event.pull_request.title }}
-        body: ${{ github.event.pull_request.body }}
-        draft: false
-        prerelease: false
+        ref: main
+    - name: Install git-mkver
+      run: curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.1/git-mkver-linux-amd64-1.2.1.tar.gz | tar xvz && sudo mv git-mkver /usr/local/bin
+    - name: Update version in setup.py
+      run: git-mkver patch
+    - name: Get new version
+      run: echo "NEW_PACKAGE_VERSION=$( git-mkver next )" >> $GITHUB_ENV
+    - name: Commit and push change
+      uses: EndBug/add-and-commit@v7
+      with:
+        add: "setup.py"
+        message: "OPS: Update version number"
+        branch: main
+        push: "true"
+        tag: ${{ env.NEW_PACKAGE_VERSION }}
+
+#  release:
+#    # This job will only run if the PR has been merged (and not closed without merging).
+#    if: github.event.pull_request.merged == true
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Get package version
+#      run: echo "PACKAGE_VERSION=$(python setup.py --version)" >> $GITHUB_ENV
+#    - name: Create Release
+#      uses: actions/create-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, no need to create your own.
+#      with:
+#        tag_name: ${{ env.PACKAGE_VERSION }}
+#        release_name: ${{ github.event.pull_request.title }}
+#        body: ${{ github.event.pull_request.body }}
+#        draft: false
+#        prerelease: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
           - '^review/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^refactor/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^release/(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+
+  - repo: https://github.com/octue/pre-commit-hooks
+    rev: 0.0.2
+    hooks:
+      - id: check-commit-message-is-conventional
+        stages: [commit-msg]

--- a/mkver.conf
+++ b/mkver.conf
@@ -1,0 +1,38 @@
+tagPrefix: ""
+defaults {
+  tag: false
+  tagMessageFormat: "Release/{Tag}"
+  preReleaseFormat: "RC{PreReleaseNumber}"
+  buildMetaDataFormat: "{Branch}.{ShortHash}"
+  includeBuildMetaData: false
+  whenNoValidCommitMessages: NoIncrement
+  patches: [setup.py]
+}
+
+patches: [
+  {
+    name: setup.py
+    filePatterns: ["setup.py"]
+    replacements: [
+      {
+        find: "version=\"{VersionRegex}\""
+        replace: "version=\"{Version}\""
+      }
+    ]
+  }
+]
+
+commitMessageActions: [
+  {
+    pattern: "BREAKING CHANGE"
+    action: IncrementMajor
+  }
+  {
+    pattern: "FEA:"
+    action: IncrementMinor
+  }
+  {
+    pattern: "FIX:"
+    action: IncrementPatch
+  }
+]


### PR DESCRIPTION
## Contents
### Operations
- [x] Add [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) `pre-commit` hook
- [x]  Add `update-version` job to release workflow that automatically updates the version in `setup.py`, commits it to main, and tags it on merge into main
- [x] Temporarily disable `publish` job and `release` job in case `update-version` goes wrong