### PR TITLE
Fix: Ensure Service.wait_for_answer timeout value is respected

### DIFF
--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Compile new pull request description
       run: |
         echo 'PULL_REQUEST_NOTES<<EOF' >> $GITHUB_ENV
-        echo "$(python .github/workflows/scripts/compile-release-notes.py LAST_PULL_REQUEST '${{ github.event.pull_request.body }}')" >> $GITHUB_ENV
+        echo "$(python .github/workflows/scripts/compile-release-notes.py LAST_RELEASE '${{ github.event.pull_request.body }}')" >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
     - name: Update pull request body
       uses: riskledger/update-pr-description@v2

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -92,7 +92,9 @@ class Service(CoolNameable):
         topic = Topic(name=self.id, namespace=OCTUE_NAMESPACE, service=self)
         topic.create(allow_existing=True)
 
-        subscription = Subscription(name=self.id, topic=topic, namespace=OCTUE_NAMESPACE, service=self)
+        subscription = Subscription(
+            name=self.id, topic=topic, namespace=OCTUE_NAMESPACE, service=self, expiration_time=None
+        )
         subscription.create(allow_existing=True)
 
         future = self.subscriber.subscribe(subscription=subscription.path, callback=self.receive_question_then_answer)

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import uuid
 from concurrent.futures import TimeoutError
 import google.api_core
@@ -187,23 +188,43 @@ class Service(CoolNameable):
     def wait_for_answer(self, subscription, timeout=30):
         """Wait for an answer to a question on the given subscription, deleting the subscription and its topic once
         the answer is received.
+
+        :param octue.cloud.pub_sub.subscription.Subscription subscription: the subscription for the question's answer
+        :param float timeout: how long to wait for an answer before raising a TimeoutError
+        :raise TimeoutError: if the timeout is exceeded
+        :return dict: dictionary containing the keys "output_values" and "output_manifest"
         """
-        pull_response = self.subscriber.pull(
-            request={"subscription": subscription.path, "max_messages": 1},
-            timeout=timeout,
-            retry=create_custom_retry(timeout),
-        )
+        start_time = time.perf_counter()
+        no_message = True
+        attempt = 1
 
-        try:
-            answer = pull_response.received_messages[0]
-        except IndexError:
-            raise TimeoutError("No answer received from topic %r", subscription.topic.path)
+        with self.subscriber:
+            while no_message:
+                logger.debug("Pulling messages from Google Pub/Sub: attempt %d.", attempt)
 
-        self.subscriber.acknowledge(request={"subscription": subscription.path, "ack_ids": [answer.ack_id]})
-        logger.debug("%r received a response to question on topic %r", self, subscription.topic.path)
+                pull_response = self.subscriber.pull(
+                    request={"subscription": subscription.path, "max_messages": 1},
+                    retry=create_custom_retry(timeout),
+                )
 
-        subscription.delete()
-        subscription.topic.delete()
+                try:
+                    answer = pull_response.received_messages[0]
+                    no_message = False
+
+                except IndexError:
+                    logger.debug("Google Pub/Sub pull response timed out early.")
+                    attempt += 1
+
+                    if (time.perf_counter() - start_time) > timeout:
+                        raise TimeoutError(
+                            f"No answer received from topic {subscription.topic.path!r} after {timeout} seconds.",
+                        )
+
+            self.subscriber.acknowledge(request={"subscription": subscription.path, "ack_ids": [answer.ack_id]})
+            logger.debug("%r received a response to question on topic %r.", self, subscription.topic.path)
+
+            subscription.delete()
+            subscription.topic.delete()
 
         data = json.loads(answer.message.data.decode())
 

--- a/octue/cloud/pub_sub/subscription.py
+++ b/octue/cloud/pub_sub/subscription.py
@@ -1,16 +1,40 @@
 import logging
 import google.api_core.exceptions
+from google.protobuf.duration_pb2 import Duration
+from google.pubsub_v1.types.pubsub import ExpirationPolicy, Subscription as _Subscription
 
 
 logger = logging.getLogger(__name__)
+
+# Useful time periods in seconds.
+SEVEN_DAYS = 7 * 24 * 3600
+THIRTY_ONE_DAYS = 31 * 24 * 3600
 
 
 class Subscription:
     """A candidate subscription to use with Google Pub/Sub. The subscription represented by an instance of this class
     does not necessarily already exist on the Google Pub/Sub servers.
+
+    :param str name: the name of the subscription excluding "projects/<project_name>/subscriptions/<namespace>"
+    :param octue.cloud.pub_sub.topic.Topic topic: the topic the subscription is attached to
+    :param str namespace: a namespace to put before the subscription's name in its path
+    :param octue.cloud.pub_sub.service.Service service: the service using this subscription
+    :param int ack_deadline: message acknowledgement deadline in seconds
+    :param int message_retention_duration: unacknowledged message retention time in seconds
+    :param int|None expiration_time: number of seconds after which the subscription is deleted (infinite time if None)
+    :return None:
     """
 
-    def __init__(self, name, topic, namespace, service):
+    def __init__(
+        self,
+        name,
+        topic,
+        namespace,
+        service,
+        ack_deadline=60,
+        message_retention_duration=SEVEN_DAYS,
+        expiration_time=THIRTY_ONE_DAYS,
+    ):
         if name.startswith(namespace):
             self.name = name
         else:
@@ -19,19 +43,40 @@ class Subscription:
         self.topic = topic
         self.service = service
         self.path = self.service.subscriber.subscription_path(self.service.backend.project_name, self.name)
+        self.ack_deadline = ack_deadline
+        self.message_retention_duration = Duration(seconds=message_retention_duration)
+
+        # If expiration_time is None, the subscription will never expire.
+        if expiration_time is None:
+            self.expiration_policy = ExpirationPolicy(mapping=None)
+        else:
+            self.expiration_policy = ExpirationPolicy(mapping=None, ttl=Duration(seconds=expiration_time))
 
     def __repr__(self):
         return f"<{type(self).__name__}({self.name})>"
 
     def create(self, allow_existing=False):
-        """ Create a Google Pub/Sub subscription that can be subscribed to. """
+        """Create a Google Pub/Sub subscription that can be subscribed to.
+
+        :param bool allow_existing: if `False`, raise an error if the subscription already exists; if `True`, do nothing (the existing subscription is not overwritten)
+        :return None:
+        """
+        subscription = _Subscription(
+            mapping=None,
+            name=self.path,
+            topic=self.topic.path,
+            ack_deadline_seconds=self.ack_deadline,
+            message_retention_duration=self.message_retention_duration,
+            expiration_policy=self.expiration_policy,
+        )
+
         if not allow_existing:
-            self.service.subscriber.create_subscription(topic=self.topic.path, name=self.path)
+            self.service.subscriber.create_subscription(request=subscription)
             self._log_creation()
             return
 
         try:
-            self.service.subscriber.create_subscription(topic=self.topic.path, name=self.path)
+            self.service.subscriber.create_subscription(request=subscription)
         except google.api_core.exceptions.AlreadyExists:
             pass
         self._log_creation()

--- a/octue/cloud/pub_sub/subscription.py
+++ b/octue/cloud/pub_sub/subscription.py
@@ -65,9 +65,9 @@ class Subscription:
             mapping=None,
             name=self.path,
             topic=self.topic.path,
-            ack_deadline_seconds=self.ack_deadline,
-            message_retention_duration=self.message_retention_duration,
-            expiration_policy=self.expiration_policy,
+            ack_deadline_seconds=self.ack_deadline,  # noqa
+            message_retention_duration=self.message_retention_duration,  # noqa
+            expiration_policy=self.expiration_policy,  # noqa
         )
 
         if not allow_existing:

--- a/octue/cloud/pub_sub/subscription.py
+++ b/octue/cloud/pub_sub/subscription.py
@@ -59,7 +59,7 @@ class Subscription:
         """Create a Google Pub/Sub subscription that can be subscribed to.
 
         :param bool allow_existing: if `False`, raise an error if the subscription already exists; if `True`, do nothing (the existing subscription is not overwritten)
-        :return None:
+        :return google.pubsub_v1.types.pubsub.Subscription:
         """
         subscription = _Subscription(
             mapping=None,
@@ -79,7 +79,9 @@ class Subscription:
             self.service.subscriber.create_subscription(request=subscription)
         except google.api_core.exceptions.AlreadyExists:
             pass
+
         self._log_creation()
+        return subscription
 
     def delete(self):
         """ Delete the subscription from Google Pub/Sub. """

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "click>=7.1.2",
         "coolname>=1.1.0",
         "Flask>=1.1",
-        "google-cloud-pubsub>=2.2.0",
+        "google-cloud-pubsub>=2.5.0",
         "google-cloud-secret-manager>=2.3.0",
         "google-cloud-storage>=1.35.1",
         "google-crc32c>=1.1.2",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.1.22",  # Ensure all requirements files containing octue are updated, too (e.g. docs build).
+    version="0.1.23",  # Ensure all requirements files containing octue are updated, too (e.g. docs build).
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -39,7 +39,10 @@ class MockTopic(Topic):
 
         :return None:
         """
-        del MESSAGES[get_service_id(self.path)]
+        try:
+            del MESSAGES[get_service_id(self.path)]
+        except KeyError:
+            pass
 
     def exists(self):
         """Check if the topic exists in the global messages dictionary.

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -88,7 +88,7 @@ class TestService(BaseTestCase):
 
         with patch("octue.cloud.pub_sub.service.pubsub_v1.SubscriberClient.pull", return_value=MockPullResponse()):
             with self.assertRaises(concurrent.futures.TimeoutError):
-                service.wait_for_answer(subscription=mock_subscription)
+                service.wait_for_answer(subscription=mock_subscription, timeout=0.01)
 
     def test_ask(self):
         """ Test that a service can ask a question to another service that is serving and receive an answer. """


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] Add more configuration options to `Subscription`
- [x] Make serving services' subscriptions never expire

### Fixes
- [x] Ensure `Service.wait_for_answer` `timeout` parameter is respected
- [x] Delete answer topic and subscription after service wait timeout

### Operations
- [x] Use `LAST_RELEASE` mode when compiling release notes

### Dependencies
- [x] `Use google-cloud-pubsub>=2.5.0`

<!--- END AUTOGENERATED NOTES --->