### PR TITLE
Fix: Remove disparity between Datafile instantiation methods

### DIFF
--- a/docs/source/cloud_storage.rst
+++ b/docs/source/cloud_storage.rst
@@ -24,7 +24,7 @@ Assuming you have an instance of ``Datafile`` called ``my_datafile``:
     my_datafile.to_cloud(project_name=<project-name>, bucket_name=<bucket-name>, path_in_bucket=<path/in/bucket>)
     >>> gs://<bucket-name>/<path/in/bucket>
 
-    downloaded_datafile = Datafile.from_cloud(project_name=<project-name>, bucket_name=<bucket-name>, datafile_path=<path/in/bucket>)
+    downloaded_datafile = Datafile(path="gs://<bucket-name>/<path/in/bucket>, project_name=<project-name>)
 
 
 Dataset

--- a/docs/source/datafile.rst
+++ b/docs/source/datafile.rst
@@ -41,10 +41,9 @@ Example A
 
 
     project_name = "my-project"
-    bucket_name = "my-bucket",
-    datafile_path = "path/to/data.csv"
+    path = "gs://my-bucket/path/to/data.csv"
 
-    with Datafile.from_cloud(project_name, bucket_name, datafile_path, mode="r") as (datafile, f):
+    with Datafile(path, project_name=project_name, mode="r") as (datafile, f):
         data = f.read()
         new_metadata = metadata_calculating_function(data)
 
@@ -70,10 +69,9 @@ Example B
 
 
     project_name = "my-project"
-    bucket_name = "my-bucket"
-    datafile_path = "path/to/data.csv"
+    path = "gs://my-bucket/path/to/data.csv"
 
-    datafile = Datafile.from_cloud(project_name, bucket_name, datafile_path):
+    datafile = Datafile(path, project_name=project_name)
 
     datafile.timestamp = datetime.now()
     datafile.cluster = 0
@@ -98,10 +96,9 @@ Example C
 
 
     project_name = "my-project"
-    bucket_name = "my-bucket"
-    datafile_path = "path/to/data.csv"
+    path = "gs://my-bucket/path/to/data.csv"
 
-    datafile = Datafile.from_cloud(project_name, bucket_name, datafile_path)
+    datafile = Datafile(path, project_name=project_name)
 
     with datafile.open("r") as f:
         data = f.read()
@@ -132,7 +129,7 @@ For creating new data in a new local file:
     with Datafile(path="path/to/local/file.dat", sequence=sequence, tags=tags, labels=labels, mode="w") as (datafile, f):
         f.write("This is some cleaned data.")
 
-    datafile.to_cloud(project_name="my-project", bucket_name="my-bucket", path_in_bucket="path/to/data.dat")
+    datafile.to_cloud(project_name="my-project", cloud_path="gs://my-bucket/path/to/data.dat")
 
 
 For existing data in an existing local file:
@@ -147,4 +144,4 @@ For existing data in an existing local file:
     labels = {"Vestas"}
 
     datafile = Datafile(path="path/to/local/file.dat", sequence=sequence, tags=tags, labels=labels)
-    datafile.to_cloud(project_name="my-project", bucket_name="my-bucket", path_in_bucket="path/to/data.dat")
+    datafile.to_cloud(project_name="my-project", cloud_path="gs://my-bucket/path/to/data.dat")

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -9,7 +9,7 @@ from google_crc32c import Checksum
 from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.cloud.storage.path import CLOUD_STORAGE_PROTOCOL
-from octue.exceptions import AttributeConflict, CloudLocationNotSpecified, FileNotFoundException, InvalidInputException
+from octue.exceptions import CloudLocationNotSpecified, FileNotFoundException, InvalidInputException
 from octue.mixins import Filterable, Hashable, Identifiable, Labelable, Loggable, Pathable, Serialisable, Taggable
 from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
 from octue.utils import isfile
@@ -47,24 +47,20 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
           "sha-512/256": "somesha"
         },
 
-    :parameter datetime.datetime|int|float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when
-        it was created but could relate to a relevant time point for the data
+    :parameter datetime.datetime|int|float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when it was created but could relate to a relevant time point for the data
     :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
-    :param logging.Logger logger: A logger instance to which operations with this datafile will be logged. Defaults to
-        the module logger.
-    :param Union[str, path-like] path: The path of this file, which may include folders or subfolders, within the
-        dataset. If no path_from parameter is set, then absolute paths are acceptable, otherwise relative paths are
-        required.
+    :param logging.Logger logger: A logger instance to which operations with this datafile will be logged. Defaults to the module logger.
+    :param Union[str, path-like] path: The path of this file, which may include folders or subfolders, within the dataset. If no path_from parameter is set, then absolute paths are acceptable, otherwise relative paths are required.
     :param Pathable path_from: The root Pathable object (typically a Dataset) that this Datafile's path is relative to.
+    :param str|None project_name: The name of the cloud project if the datafile is located in the cloud
     :param int cluster: The cluster of files, within a dataset, to which this belongs (default 0)
     :param int sequence: A sequence number of this file within its cluster (if sequences are appropriate)
     :param dict|TagDict tags: key-value pairs with string keys conforming to the Octue tag format (see TagDict)
     :param iter(str) labels: Space-separated string of labels relevant to this file
     :param bool skip_checks:
-    :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode
-        options are the same as for the builtin open function)
-    :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of
-        the datafile when the context is exited
+    :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin open function)
+    :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of the datafile when the context is exited
+    :param bool hypothetical: True if the file does not actually exist or access is not available at instantiation
     :return None:
     """
 
@@ -87,6 +83,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         id=ID_DEFAULT,
         logger=None,
         path_from=None,
+        project_name=None,
         cluster=CLUSTER_DEFAULT,
         sequence=SEQUENCE_DEFAULT,
         tags=TAGS_DEFAULT,
@@ -94,6 +91,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         skip_checks=True,
         mode="r",
         update_cloud_metadata=True,
+        hypothetical=False,
         **kwargs,
     ):
         super().__init__(
@@ -107,19 +105,23 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
             path_from=path_from,
         )
 
+        # Set up the file extension or get it from the file path if none passed
+        self.extension = self._get_extension_from_path()
+        self.hypothetical = hypothetical
+        self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
+        self._cloud_metadata = {"project_name": project_name}
+
+        if self.is_in_cloud and not self.hypothetical:
+            self._from_cloud()
+            return
+
         self.cluster = cluster
         self.sequence = sequence
         self.timestamp = timestamp
 
-        # Set up the file extension or get it from the file path if none passed
-        self.extension = self._get_extension_from_path()
-
         # Run integrity checks on the file
         if not skip_checks:
             self.check(**kwargs)
-
-        self._cloud_metadata = {}
-        self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
 
     def __enter__(self):
         self._open_context_manager = self.open(**self._open_attributes)
@@ -160,66 +162,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
             datafile = Datafile(**serialised_datafile)
 
         datafile._cloud_metadata = cloud_metadata
-        return datafile
-
-    @classmethod
-    def from_cloud(
-        cls,
-        project_name,
-        cloud_path=None,
-        bucket_name=None,
-        datafile_path=None,
-        allow_overwrite=False,
-        mode="r",
-        update_cloud_metadata=True,
-        **kwargs,
-    ):
-        """Instantiate a Datafile from a previously-persisted Datafile in Google Cloud storage. To instantiate a
-        Datafile from a regular file on Google Cloud storage, the usage is the same, but a meaningful value for each of
-        the instantiated Datafile's attributes can be included in the kwargs (a "regular" file is a file that has been
-        uploaded to storage without being wrapped in a Datafile instance - i.e. a normal file).
-
-        Note that a value provided for an attribute in kwargs will override any existing value for the attribute.
-
-        Either (`bucket_name` and `datafile_path`) or `cloud_path` must be provided.
-
-        :param str project_name: name of Google Cloud project datafile is stored in
-        :param str|None cloud_path: full path to datafile in cloud storage (e.g. `gs://bucket_name/path/to/file.csv`)
-        :param str|None bucket_name: name of bucket datafile is stored in
-        :param str|None datafile_path: cloud storage path of datafile (e.g. `path/to/file.csv`)
-        :param bool allow_overwrite: if `True`, allow attributes of the datafile to be overwritten by values given in kwargs
-        :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin open function)
-        :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of the datafile when the context is exited
-        :return Datafile:
-        """
-        if not cloud_path:
-            cloud_path = storage.path.generate_gs_path(bucket_name, datafile_path)
-
-        datafile = cls(path=cloud_path)
-        datafile.get_cloud_metadata(project_name, cloud_path=cloud_path)
-        custom_metadata = datafile._cloud_metadata.get("custom_metadata", {})
-
-        if not allow_overwrite:
-            cls._check_for_attribute_conflict(custom_metadata, **kwargs)
-
-        datafile._set_id(kwargs.pop("id", custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__id", ID_DEFAULT)))
-        datafile.immutable_hash_value = datafile._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
-        datafile.timestamp = kwargs.get("timestamp", custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__timestamp"))
-        datafile.tags = kwargs.pop("tags", custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__tags", TAGS_DEFAULT))
-
-        datafile.cluster = kwargs.pop(
-            "cluster", custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__cluster", CLUSTER_DEFAULT)
-        )
-
-        datafile.sequence = kwargs.pop(
-            "sequence", custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__sequence", SEQUENCE_DEFAULT)
-        )
-
-        datafile.labels = kwargs.pop(
-            "labels", custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__labels", LABELS_DEFAULT)
-        )
-
-        datafile._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
         return datafile
 
     def to_cloud(
@@ -313,8 +255,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
             bucket_name=bucket_name,
             path_in_bucket=path_in_bucket,
         )
-
-        self._store_cloud_location(project_name, bucket_name, path_in_bucket)
 
     @property
     def name(self):
@@ -418,6 +358,23 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         if self.absolute_path in TEMPORARY_LOCAL_FILE_CACHE:
             del TEMPORARY_LOCAL_FILE_CACHE[self.absolute_path]
 
+    def _from_cloud(self):
+        """Populate the datafile's attributes from the cloud location defined by its path (by necessity a cloud path)
+        and project name.
+
+        :return None:
+        """
+        self.get_cloud_metadata(project_name=self._cloud_metadata["project_name"], cloud_path=self.path)
+        custom_metadata = self._cloud_metadata.get("custom_metadata", {})
+
+        self._set_id(custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__id", ID_DEFAULT))
+        self.immutable_hash_value = self._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
+        self.timestamp = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__timestamp")
+        self.tags = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__tags", TAGS_DEFAULT)
+        self.cluster = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__cluster", CLUSTER_DEFAULT)
+        self.sequence = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__sequence", SEQUENCE_DEFAULT)
+        self.labels = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__labels", LABELS_DEFAULT)
+
     def _get_extension_from_path(self, path=None):
         """Gets extension of a file, either from a provided file path or from self.path field"""
         path = path or self.path
@@ -436,7 +393,8 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
 
     def _get_cloud_location(self, project_name=None, cloud_path=None, bucket_name=None, path_in_bucket=None):
         """Get the cloud location details for the bucket, allowing the keyword arguments to override any stored values.
-        Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided.
+        Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided. Once the cloud location details
+        have been determined, update the stored cloud location details.
 
         :param str|None project_name:
         :param str|None cloud_path:
@@ -459,6 +417,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
                 f"specify its exact location (its project_name, bucket_name, and path_in_bucket)."
             )
 
+        self._store_cloud_location(project_name, bucket_name, path_in_bucket)
         return project_name, bucket_name, path_in_bucket
 
     def _store_cloud_location(self, project_name, bucket_name, path_in_bucket):
@@ -472,25 +431,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         self._cloud_metadata["project_name"] = project_name
         self._cloud_metadata["bucket_name"] = bucket_name
         self._cloud_metadata["path_in_bucket"] = path_in_bucket
-
-    @classmethod
-    def _check_for_attribute_conflict(cls, custom_metadata, **kwargs):
-        """Raise an error if there is a conflict between the custom metadata and the kwargs.
-
-        :param dict custom_metadata:
-        :raise octue.exceptions.AttributeConflict: if any of the custom metadata conflicts with kwargs
-        :return None:
-        """
-        for attribute_name, attribute_value in kwargs.items():
-
-            if custom_metadata.get(attribute_name) == attribute_value:
-                continue
-
-            raise AttributeConflict(
-                f"The value {custom_metadata.get(attribute_name)!r} of the {cls.__name__} attribute "
-                f"{attribute_name!r} conflicts with the value given in kwargs {attribute_value!r}. If you wish to "
-                f"overwrite the attribute value, set `allow_overwrite` to `True`."
-            )
 
     def check(self, size_bytes=None, sha=None, last_modified=None, extension=None):
         """Check file presence and integrity"""

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -30,7 +30,10 @@ LABELS_DEFAULT = None
 
 
 class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiable, Hashable, Filterable):
-    """Class for representing data files on the Octue system.
+    """A representation of a data file on the Octue system. If the given path is a cloud path and `hypothetical` is not
+    `True`, the datafile's metadata is pulled from the given cloud location, and any conflicting parameters (see the
+    `Datafile.metadata` method description for the parameter names concerned) are ignored. The metadata of cloud
+    datafiles can be changed using the `Datafile.update_metadata` method, but not during instantiation.
 
     Files in a manifest look like this:
 
@@ -370,9 +373,9 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         self._set_id(custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__id", ID_DEFAULT))
         self.immutable_hash_value = self._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
         self.timestamp = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__timestamp")
-        self.tags = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__tags", TAGS_DEFAULT)
         self.cluster = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__cluster", CLUSTER_DEFAULT)
         self.sequence = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__sequence", SEQUENCE_DEFAULT)
+        self.tags = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__tags", TAGS_DEFAULT)
         self.labels = custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__labels", LABELS_DEFAULT)
 
     def _get_extension_from_path(self, path=None):
@@ -460,7 +463,8 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         return functools.partial(_DatafileContextManager, self)
 
     def metadata(self, use_octue_namespace=True):
-        """Get the datafile's metadata in a serialised form.
+        """Get the datafile's metadata in a serialised form (i.e. the attributes `id`, `timestamp`, `cluster`,
+        `sequence`, `labels`, `tags`, and `sdk_version`).
 
         :param bool use_octue_namespace: if True, prefix metadata names with "octue__"
         :return dict:
@@ -470,8 +474,8 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
             "timestamp": self.timestamp,
             "cluster": self.cluster,
             "sequence": self.sequence,
-            "labels": self.labels,
             "tags": self.tags,
+            "labels": self.labels,
             "sdk_version": pkg_resources.get_distribution("octue").version,
         }
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -78,10 +78,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
 
         for file in serialised_dataset["files"]:
             file_bucket_name, path = storage.path.split_bucket_name_from_gs_path(file)
-
-            datafiles.add(
-                Datafile.from_cloud(project_name=project_name, bucket_name=file_bucket_name, datafile_path=path)
-            )
+            datafiles.add(Datafile(storage.path.generate_gs_path(file_bucket_name, path), project_name=project_name))
 
         return Dataset(
             id=serialised_dataset["id"],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.1.25",  # Ensure all requirements files containing octue are updated, too (e.g. docs build).
+    version="0.1.26",  # Ensure all requirements files containing octue are updated, too (e.g. docs build).
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -119,8 +119,8 @@ class TestService(BaseTestCase):
         asking_service = MockService(backend=self.BACKEND, children={responding_service.id: responding_service})
 
         files = [
-            Datafile(path="gs://my-dataset/hello.txt"),
-            Datafile(path="gs://my-dataset/goodbye.csv"),
+            Datafile(path="gs://my-dataset/hello.txt", hypothetical=True),
+            Datafile(path="gs://my-dataset/goodbye.csv", hypothetical=True),
         ]
 
         input_manifest = Manifest(datasets=[Dataset(files=files)], path="gs://my-dataset", keys={"my_dataset": 0})

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from octue import exceptions
+from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.mixins import MixinBase, Pathable
 from octue.resources.datafile import TEMPORARY_LOCAL_FILE_CACHE, Datafile
@@ -172,7 +173,7 @@ class DatafileTestCase(BaseTestCase):
     def test_is_in_cloud(self):
         """Test whether a file is in the cloud or not can be determined."""
         self.assertFalse(self.create_valid_datafile().is_in_cloud)
-        self.assertTrue(Datafile(path="gs://hello/file.txt").is_in_cloud)
+        self.assertTrue(Datafile(path="gs://hello/file.txt", hypothetical=True).is_in_cloud)
 
     def test_from_cloud_with_bare_file(self):
         """Test that a Datafile can be constructed from a file on Google Cloud storage with no custom metadata."""
@@ -184,8 +185,8 @@ class DatafileTestCase(BaseTestCase):
             path_in_bucket=path_in_bucket,
         )
 
-        datafile = Datafile.from_cloud(
-            project_name=TEST_PROJECT_NAME, bucket_name=TEST_BUCKET_NAME, datafile_path=path_in_bucket
+        datafile = Datafile(
+            path=storage.path.generate_gs_path(TEST_BUCKET_NAME, path_in_bucket), project_name=TEST_PROJECT_NAME
         )
 
         self.assertEqual(datafile.path, f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}")
@@ -206,9 +207,10 @@ class DatafileTestCase(BaseTestCase):
             labels={"blah-shah-nah", "blib", "glib"},
             tags={"good": True, "how_good": "very"},
         )
-        gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
-        downloaded_datafile = Datafile.from_cloud(project_name, cloud_path=gs_path)
 
+        gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
+
+        downloaded_datafile = Datafile(path=gs_path, project_name=project_name)
         self.assertEqual(downloaded_datafile.path, gs_path)
         self.assertEqual(downloaded_datafile.id, datafile.id)
         self.assertEqual(downloaded_datafile.timestamp, datafile.timestamp)
@@ -220,40 +222,6 @@ class DatafileTestCase(BaseTestCase):
         self.assertEqual(downloaded_datafile.size_bytes, datafile.size_bytes)
         self.assertTrue(isinstance(downloaded_datafile._last_modified, float))
 
-    def test_from_cloud_with_overwrite(self):
-        """Test that a datafile can be instantiated from the cloud and have its attributes overwritten if new values
-        are given in kwargs.
-        """
-        datafile, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
-
-        new_id = str(uuid.uuid4())
-
-        downloaded_datafile = Datafile.from_cloud(
-            project_name=project_name,
-            bucket_name=bucket_name,
-            datafile_path=path_in_bucket,
-            allow_overwrite=True,
-            id=new_id,
-        )
-
-        self.assertEqual(downloaded_datafile.id, new_id)
-        self.assertNotEqual(datafile.id, downloaded_datafile.id)
-
-    def test_from_cloud_with_overwrite_when_disallowed_results_in_error(self):
-        """Test that attempting to overwrite the attributes of a datafile instantiated from the cloud when not allowed
-        results in an error.
-        """
-        _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
-
-        with self.assertRaises(exceptions.AttributeConflict):
-            Datafile.from_cloud(
-                project_name=project_name,
-                bucket_name=bucket_name,
-                datafile_path=path_in_bucket,
-                allow_overwrite=False,
-                id=str(uuid.uuid4()),
-            )
-
     def test_to_cloud_updates_cloud_metadata(self):
         """Test that calling Datafile.to_cloud on a datafile that is already cloud-based updates its metadata in the
         cloud.
@@ -264,7 +232,7 @@ class DatafileTestCase(BaseTestCase):
         datafile.to_cloud(project_name, bucket_name=bucket_name, path_in_bucket=path_in_bucket)
 
         self.assertEqual(
-            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 3
+            Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name).cluster, 3
         )
 
     def test_to_cloud_does_not_update_cloud_metadata_if_update_cloud_metadata_is_false(self):
@@ -279,14 +247,14 @@ class DatafileTestCase(BaseTestCase):
             self.assertFalse(mock.called)
 
         self.assertEqual(
-            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 0
+            Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name).cluster, 0
         )
 
     def test_to_cloud_does_not_update_metadata_if_no_metadata_change_has_been_made(self):
         """Test that Datafile.to_cloud does not try to update cloud metadata if no metadata change has been made."""
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud(cluster=0)
 
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
 
         with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
             datafile.to_cloud()
@@ -306,7 +274,7 @@ class DatafileTestCase(BaseTestCase):
         provided.
         """
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
         datafile.to_cloud()
 
     def test_to_cloud_does_not_try_to_update_file_if_no_change_has_been_made_locally(self):
@@ -325,7 +293,7 @@ class DatafileTestCase(BaseTestCase):
         new_datafile.update_cloud_metadata(project_name, bucket_name=bucket_name, path_in_bucket=path_in_bucket)
 
         self.assertEqual(
-            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 32
+            Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name).cluster, 32
         )
 
     def test_update_cloud_metadata_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
@@ -334,12 +302,12 @@ class DatafileTestCase(BaseTestCase):
         """
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
 
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
         datafile.cluster = 32
         datafile.update_cloud_metadata()
 
         self.assertEqual(
-            Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket).cluster, 32
+            Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name).cluster, 32
         )
 
     def test_update_cloud_metadata_raises_error_if_no_cloud_location_provided_and_datafile_not_from_cloud(self):
@@ -354,7 +322,7 @@ class DatafileTestCase(BaseTestCase):
     def test_get_local_path(self):
         """Test that a file in the cloud can be temporarily downloaded and its local path returned."""
         _, project_name, bucket_name, path_in_bucket, contents = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
 
         with open(datafile.get_local_path()) as f:
             self.assertEqual(f.read(), contents)
@@ -362,7 +330,7 @@ class DatafileTestCase(BaseTestCase):
     def test_get_local_path_with_cached_file_avoids_downloading_again(self):
         """Test that attempting to download a cached file avoids downloading it again."""
         _, project_name, bucket_name, path_in_bucket, _ = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
 
         # Download for first time.
         datafile.get_local_path()
@@ -402,7 +370,7 @@ class DatafileTestCase(BaseTestCase):
     def test_open_with_reading_cloud_file(self):
         """Test that a cloud datafile can be opened for reading."""
         _, project_name, bucket_name, path_in_bucket, contents = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
 
         with datafile.open() as f:
             self.assertEqual(f.read(), contents)
@@ -410,7 +378,7 @@ class DatafileTestCase(BaseTestCase):
     def test_open_with_writing_to_cloud_file(self):
         """Test that a cloud datafile can be opened for writing and that both the remote and local copies are updated."""
         _, project_name, bucket_name, path_in_bucket, original_contents = self.create_datafile_in_cloud()
-        datafile = Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket)
+        datafile = Datafile(storage.path.generate_gs_path(bucket_name, path_in_bucket), project_name=project_name)
 
         new_file_contents = "nanana"
 
@@ -513,17 +481,14 @@ class DatafileTestCase(BaseTestCase):
         new_contents = "Here is the new content."
         self.assertNotEqual(original_content, new_contents)
 
-        with Datafile.from_cloud(project_name, bucket_name=bucket_name, datafile_path=path_in_bucket, mode="w") as (
-            datafile,
-            f,
-        ):
+        path = storage.path.generate_gs_path(bucket_name, path_in_bucket)
+
+        with Datafile(path, project_name=project_name, mode="w") as (datafile, f):
             datafile.add_labels("blue")
             f.write(new_contents)
 
         # Check that the cloud metadata has been updated.
-        re_downloaded_datafile = Datafile.from_cloud(
-            project_name, bucket_name=bucket_name, datafile_path=path_in_bucket
-        )
+        re_downloaded_datafile = Datafile(path, project_name=project_name)
         self.assertTrue("blue" in re_downloaded_datafile.labels)
 
         # The file cache must be cleared so the modified cloud file is downloaded.

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -476,7 +476,7 @@ class DatafileTestCase(BaseTestCase):
             self.assertEqual(f.read(), contents)
 
     def test_from_datafile_as_context_manager(self):
-        """Test that Datafile.from_cloud can be used as a context manager to manage cloud changes."""
+        """Test that Datafile can be used as a context manager to manage cloud changes."""
         _, project_name, bucket_name, path_in_bucket, original_content = self.create_datafile_in_cloud()
         new_contents = "Here is the new content."
         self.assertNotEqual(original_content, new_contents)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -287,8 +287,8 @@ class DatasetTestCase(BaseTestCase):
         self.assertFalse(self.create_valid_dataset().all_files_are_in_cloud)
 
         files = [
-            Datafile(path="gs://hello/file.txt"),
-            Datafile(path="gs://goodbye/file.csv"),
+            Datafile(path="gs://hello/file.txt", hypothetical=True),
+            Datafile(path="gs://goodbye/file.csv", hypothetical=True),
         ]
 
         self.assertTrue(Dataset(files=files).all_files_are_in_cloud)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -32,8 +32,8 @@ class TestManifest(BaseTestCase):
         self.assertFalse(self.create_valid_manifest().all_datasets_are_in_cloud)
 
         files = [
-            Datafile(path="gs://hello/file.txt"),
-            Datafile(path="gs://goodbye/file.csv"),
+            Datafile(path="gs://hello/file.txt", hypothetical=True),
+            Datafile(path="gs://goodbye/file.csv", hypothetical=True),
         ]
 
         manifest = Manifest(datasets=[Dataset(files=files)], keys={"my_dataset": 0})


### PR DESCRIPTION
## Contents

### Refactoring
- [x] Combine `Datafile.__init__` with `Datafile.from_cloud` for simpler and more robust interface
- [x] Carry out functionality of former `Datafile.from_cloud` method in `Datafile.__init__` if the `path` parameter is a cloud path 

### Reversions
- [x] Remove ability to override cloud metadata on locally instantiated `Datafile` during instantiation

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->