### PR TITLE
Use question UUID as analysis ID

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -130,7 +130,7 @@ class Service(CoolNameable):
         in the format specified in the Service's Twine file.
 
         :param dict data:
-        :param int question_uuid:
+        :param str question_uuid:
         :param float timeout:
         :raise Exception: if any exception arises during running analysis and sending its results
         :return None:
@@ -140,7 +140,9 @@ class Service(CoolNameable):
         )
 
         try:
-            analysis = self.run_function(input_values=data["input_values"], input_manifest=data["input_manifest"])
+            analysis = self.run_function(
+                input_values=data["input_values"], input_manifest=data["input_manifest"], analysis_id=question_uuid
+            )
 
             if analysis.output_manifest is None:
                 serialised_output_manifest = None
@@ -178,7 +180,7 @@ class Service(CoolNameable):
         if not question_topic.exists():
             raise octue.exceptions.ServiceNotFound(f"Service with ID {service_id!r} cannot be found.")
 
-        question_uuid = str(int(uuid.uuid4()))
+        question_uuid = str(uuid.uuid4())
 
         response_topic_and_subscription_name = ".".join((service_id, ANSWERS_NAMESPACE, question_uuid))
         response_topic = Topic(name=response_topic_and_subscription_name, namespace=OCTUE_NAMESPACE, service=self)

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -310,4 +310,4 @@ class Service(CoolNameable):
 
         # Allow unknown exception types to still be raised.
         except KeyError:
-            raise Exception(f"{data['exception_type']}: {message}")
+            raise type(data["exception_type"], (Exception,), {})(message)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.2.1",  # Ensure all requirements files containing octue are updated, too (e.g. docs build).
+    version="0.2.2",  # Ensure all requirements files containing octue are updated, too (e.g. docs build).
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -52,7 +52,7 @@ class TestService(BaseTestCase):
         :param bool use_mock:
         :return tests.cloud.pub_sub.mocks.MockService:
         """
-        run_function = lambda input_values, input_manifest: run_function_returnee  # noqa
+        run_function = lambda input_values, input_manifest, analysis_id: run_function_returnee  # noqa
 
         if use_mock:
             return MockService(backend=backend, run_function=run_function)
@@ -65,7 +65,7 @@ class TestService(BaseTestCase):
         :param tests.cloud.pub_sub.mocks.MockService asking_service:
         :param tests.cloud.pub_sub.mocks.MockService responding_service:
         :param dict input_values:
-        :param octue.resources.manifest.Manifest input_manifest:
+        :param octue.resources.manifest.Manifest|None input_manifest:
         :return dict:
         """
         subscription, _ = asking_service.ask(responding_service.id, input_values, input_manifest)
@@ -79,7 +79,7 @@ class TestService(BaseTestCase):
         """
         responding_service = self.make_new_server(self.BACKEND, run_function_returnee=None, use_mock=True)
 
-        def error_run_function(input_values, input_manifest):
+        def error_run_function(input_values, input_manifest, analysis_id):
             raise exception_to_raise
 
         responding_service.run_function = error_run_function
@@ -327,7 +327,7 @@ class TestService(BaseTestCase):
             self.BACKEND, run_function_returnee=DifferentMockAnalysis(), use_mock=True
         )
 
-        def child_run_function(input_values, input_manifest):
+        def child_run_function(input_values, input_manifest, analysis_id):
             subscription, _ = child.ask(service_id=child_of_child.id, input_values=input_values)
             return MockAnalysis(output_values={input_values["question"]: child.wait_for_answer(subscription)})
 
@@ -369,7 +369,7 @@ class TestService(BaseTestCase):
         )
         second_child_of_child = self.make_new_server(self.BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
 
-        def child_run_function(input_values, input_manifest):
+        def child_run_function(input_values, input_manifest, analysis_id):
             subscription_1, _ = child.ask(service_id=first_child_of_child.id, input_values=input_values)
             subscription_2, _ = child.ask(service_id=second_child_of_child.id, input_values=input_values)
 

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -164,7 +164,7 @@ class TestService(BaseTestCase):
                         input_manifest=None,
                     )
 
-                self.assertIn("AnUnknownException: ", context.exception.args[0])
+                self.assertEqual(type(context.exception).__name__, "AnUnknownException")
                 self.assertIn("This is an exception unknown to the asker.", context.exception.args[0])
 
     def test_ask(self):


### PR DESCRIPTION
## Summary
Use service question UUIDs as analysis IDs to allow log messages for a Google Cloud Run service to be filtered for a given question. Also improve the presentation of error messages forwarded from the responding service to the asking service.

## Contents

### Enhancements
- [x] Use service question UUIDs as analysis IDs
- [x] Dynamically create exception class in `Service._raise_exception_from_responder` if the received type name is unknown to the asker

### Minor improvements
- [x] Use a string UUID for question IDs rather than an integer UUID

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->