### PR TITLE
Ensure datafile metadata can be set at instantiation for bare cloud objects

### DIFF
--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -105,7 +105,17 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         self._cloud_metadata = {"project_name": project_name}
 
         if self.is_in_cloud and not self._hypothetical:
-            self._use_cloud_metadata(id=id, timestamp=timestamp, tags=tags, labels=labels)
+
+            # Collect any non-`None` metadata instantiation parameters so the user can be warned if they conflict with
+            # any metadata already on the cloud object.
+            initialisation_parameters = {}
+
+            for parameter in ("id", "timestamp", "tags", "labels"):
+                value = locals().get(parameter)
+                if value is not None:
+                    initialisation_parameters[parameter] = value
+
+            self._use_cloud_metadata(**initialisation_parameters)
             return
 
         # Run integrity checks on the file
@@ -352,11 +362,22 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         cloud_custom_metadata = self._cloud_metadata.get("custom_metadata", {})
         self._check_for_attribute_conflict(cloud_custom_metadata, **initialisation_parameters)
 
-        self._set_id(cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__id", ID_DEFAULT))
+        self._set_id(
+            initialisation_parameters.get(
+                "id", cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__id", ID_DEFAULT)
+            )
+        )
+
         self.immutable_hash_value = self._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
-        self.timestamp = cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__timestamp")
-        self.tags = cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__tags", TAGS_DEFAULT)
-        self.labels = cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__labels", LABELS_DEFAULT)
+
+        for attribute in ("timestamp", "tags", "labels"):
+            setattr(
+                self,
+                attribute,
+                initialisation_parameters.get(
+                    attribute, cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__{attribute}")
+                ),
+            )
 
     def _check_for_attribute_conflict(self, cloud_custom_metadata, **initialisation_parameters):
         """Raise a warning if there is a conflict between the cloud custom metadata and the given initialisation
@@ -367,19 +388,15 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         """
         for attribute_name, attribute_value in initialisation_parameters.items():
 
-            if attribute_value is None:
-                continue
-
             cloud_metadata_value = cloud_custom_metadata.get(f"{OCTUE_METADATA_NAMESPACE}__{attribute_name}")
 
-            if cloud_metadata_value == attribute_value:
+            if cloud_metadata_value == attribute_value or not cloud_metadata_value:
                 continue
 
             module_logger.warning(
                 f"The value {cloud_metadata_value!r} of the {type(self).__name__} attribute {attribute_name!r} from "
-                f"the cloud conflicts with the value given locally at instantiation {attribute_value!r}. This may not "
-                f"be a problem, but note that cloud datafile metadata cannot be changed at instantiation. The cloud "
-                f"value has been used."
+                f"the cloud conflicts with the value given locally at instantiation {attribute_value!r}. The local "
+                f"value has been used and will overwrite the cloud value if the datafile is saved."
             )
 
     def _get_extension_from_path(self, path=None):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -381,7 +381,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
 
     def _check_for_attribute_conflict(self, cloud_custom_metadata, **initialisation_parameters):
         """Raise a warning if there is a conflict between the cloud custom metadata and the given initialisation
-        parameters if the initialisation parameters are not `None`.
+        parameters if the cloud value is not `None` or an empty collection.
 
         :param dict cloud_custom_metadata:
         :return None:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.2.6",
+    version="0.2.7",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Contents

### Fixes
- [x] Allow local metadata values to override cloud values if provided at `Datafile` instantiation

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->