### PR TITLE
Format answerer exceptions properly when sending to asker

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -258,7 +258,7 @@ class Service(CoolNameable):
         """
         exception_info = sys.exc_info()
         exception = exception_info[1]
-        exception_message = f"Error in {self!r}: " + exception.args[0]
+        exception_message = f"Error in {self!r}: {exception}"
         traceback = tb.format_list(tb.extract_tb(exception_info[2]))
 
         self.publisher.publish(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.2.9",
+    version="0.2.10",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary
Ensure exceptions with multiple arguments of any type are formatted and sent correctly to the asking service by the answering service.

<!--- START AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Format answerer exceptions properly when sending to asker

<!--- END AUTOGENERATED NOTES --->