### PR TITLE
Only retry transient errors in Google Pub/Sub code

### DIFF
--- a/octue/cloud/pub_sub/__init__.py
+++ b/octue/cloud/pub_sub/__init__.py
@@ -1,31 +1,5 @@
-import google.api_core
-from google.api_core import retry
-
 from .subscription import Subscription
 from .topic import Topic
 
 
-__all__ = ["Subscription", "Topic", "create_custom_retry"]
-
-
-def create_custom_retry(timeout):
-    """Create a custom `Retry` object specifying that the given Google Cloud request should retry for the given amount
-    of time for the given exceptions.
-
-    :param float timeout:
-    :return google.api_core.retry.Retry:
-    """
-    return retry.Retry(
-        maximum=timeout / 4,
-        deadline=timeout,
-        predicate=google.api_core.retry.if_exception_type(
-            google.api_core.exceptions.NotFound,
-            google.api_core.exceptions.Aborted,
-            google.api_core.exceptions.DeadlineExceeded,
-            google.api_core.exceptions.InternalServerError,
-            google.api_core.exceptions.ResourceExhausted,
-            google.api_core.exceptions.ServiceUnavailable,
-            google.api_core.exceptions.Unknown,
-            google.api_core.exceptions.Cancelled,
-        ),
-    )
+__all__ = ["Subscription", "Topic"]

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -1,7 +1,6 @@
 import json
 from logging import Handler
-
-from octue.cloud.pub_sub import create_custom_retry
+from google.api_core import retry
 
 
 class GooglePubSubHandler(Handler):
@@ -35,7 +34,7 @@ class GooglePubSubHandler(Handler):
                         "message_number": self.topic.messages_published,
                     }
                 ).encode(),
-                retry=create_custom_retry(self.timeout),
+                retry=retry.Retry(deadline=self.timeout),
             )
 
             self.topic.messages_published += 1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.2.12",
+    version="0.2.13",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary
Simplify Google Pub/Sub retries and restrict them to transient errors, specifically removing retries for `NotFound` errors (these were triggering many unneeded retries on Google Cloud Run). This also stops the retry schedule being proportional to the timeout for waiting for an answer to a question, which could lead to very long retry schedules for large timeouts (e.g. for questions that involve long analyses).

<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] Add `timeout` parameter to `Service.ask`

### Fixes
- [x] Only retry transient errors in Google Pub/Sub `Service` and `GooglePubSubHandler`