### PR TITLE
Make input values optional when asking a question

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -182,7 +182,13 @@ class Service(CoolNameable):
         )
 
     def ask(
-        self, service_id, input_values, input_manifest=None, subscribe_to_logs=True, allow_local_files=False, timeout=30
+        self,
+        service_id,
+        input_values=None,
+        input_manifest=None,
+        subscribe_to_logs=True,
+        allow_local_files=False,
+        timeout=30,
     ):
         """Ask a serving Service a question (i.e. send it input values for it to run its app on). The input values must
         be in the format specified by the serving Service's Twine file. A single-use topic and subscription are created

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.0",
+    version="0.3.1",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -207,13 +207,19 @@ class MockService(Service):
         self.subscriber = MockSubscriber()
 
     def ask(
-        self, service_id, input_values, input_manifest=None, subscribe_to_logs=True, allow_local_files=False, timeout=30
+        self,
+        service_id,
+        input_values=None,
+        input_manifest=None,
+        subscribe_to_logs=True,
+        allow_local_files=False,
+        timeout=30,
     ):
         """Put the question into the messages register, register the existence of the corresponding response topic, add
         the response to the register, and return a MockFuture containing the answer subscription path.
 
         :param str service_id:
-        :param dict|list input_values:
+        :param dict|list|None input_values:
         :param octue.resources.manifest.Manifest|None input_manifest:
         :param bool subscribe_to_logs:
         :param bool allow_local_files:


### PR DESCRIPTION
## Summary
Allow questions with only an input manifest to be asked (questions with only input values are already allowed).

<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Make `input_values` optional in `Service.ask`

<!--- END AUTOGENERATED NOTES --->