### PR TITLE
Acknowledge Pub/Sub messages received on Google Cloud Run straight away

### DIFF
--- a/octue/cloud/deployment/google/cloud_run.py
+++ b/octue/cloud/deployment/google/cloud_run.py
@@ -2,6 +2,7 @@ import functools
 import json
 import logging
 import os
+import threading
 from flask import Flask, request
 
 from octue.cloud.pub_sub.service import Service
@@ -37,7 +38,9 @@ def index():
         return _log_bad_request_and_return_400_response("Invalid Pub/Sub message format.")
 
     project_name = envelope["subscription"].split("/")[1]
-    answer_question(project_name=project_name, question=question)
+
+    analysis_thread = threading.Thread(target=answer_question, args=(project_name, question))
+    analysis_thread.start()
     return ("", 204)
 
 

--- a/octue/cloud/deployment/google/cloud_run.py
+++ b/octue/cloud/deployment/google/cloud_run.py
@@ -39,6 +39,9 @@ def index():
 
     project_name = envelope["subscription"].split("/")[1]
 
+    # Run the analysis in a separate thread so a 204 status code can be returned straight away, indicating
+    # acknowledgement of the Pub/Sub message. This avoids the message being resent multiple times and triggering
+    # multiple identical analyses if each analysis takes a while to run.
     analysis_thread = threading.Thread(target=answer_question, args=(project_name, question))
     analysis_thread.start()
     return ("", 204)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.1",
+    version="0.3.2",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary
Acknowledge Pub/Sub messages received on Google Cloud Run straight away rather than waiting for the analysis to complete first. This avoids triggering the same analysis multiple times (due to Pub/Sub sending the same message multiple times), wasting compute resource, and adding a large amount of noise to the logs.

<!--- START AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Answer questions from Google Cloud Run in a thread

<!--- END AUTOGENERATED NOTES --->