### PR TITLE
Revert "Acknowledge Pub/Sub messages received on Google Cloud Run straight away"

### DIFF
--- a/octue/cloud/deployment/google/cloud_run.py
+++ b/octue/cloud/deployment/google/cloud_run.py
@@ -2,7 +2,6 @@ import functools
 import json
 import logging
 import os
-import threading
 from flask import Flask, request
 
 from octue.cloud.pub_sub.service import Service
@@ -38,12 +37,7 @@ def index():
         return _log_bad_request_and_return_400_response("Invalid Pub/Sub message format.")
 
     project_name = envelope["subscription"].split("/")[1]
-
-    # Run the analysis in a separate thread so a 204 status code can be returned straight away, indicating
-    # acknowledgement of the Pub/Sub message. This avoids the message being resent multiple times and triggering
-    # multiple identical analyses if each analysis takes a while to run.
-    analysis_thread = threading.Thread(target=answer_question, args=(project_name, question))
-    analysis_thread.start()
+    answer_question(project_name=project_name, question=question)
     return ("", 204)
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.1",
+    version="0.3.3",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.2",
+    version="0.3.1",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
Reverts octue/octue-sdk-python#221

We've had to revert due to limitations in Google Cloud Run:
* Only instances that haven't returned an HTTP status code yet are counted as active
* Acknowledgement of trigger Pub/Sub messages can only be done by returning a status code
* Threads can be launched so the trigger message can be acknowledged to avoid it being sent again, but the instance will then be treated as idle and killed after around 15 minutes
* Together, this means that acknowledgement of trigger Pub/Sub messages can only be done after all processing has completed
* There is also a 600s maximum acknowledgement deadline, after which the message is sent again, resulting in extra containers being spawned and the same computation being carried out multilple times until the first instance of it has finished and acknowledged the trigger message
* This means that long-running processes on Google Cloud Run cause the same processing to happen potentially many times, wasting a lot of compute resource.
* The only solution we can see to this currently (while staying on Google Cloud Run) is to set the acknowledgement deadline to its maximum of 600s and set the message retention deadline to its minimum of 600s so messages for longer-running processes aren't resent
* The long-term solution is to stop using Cloud Run and use something like Knative instead

<!--- SKIP AUTOGENERATED NOTES --->