### PR TITLE
Add function for logging subprocess stdout and stderr

### DIFF
--- a/octue/utils/processes.py
+++ b/octue/utils/processes.py
@@ -43,6 +43,6 @@ def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", 
     process.wait()
 
     if process.returncode != 0:
-        raise CalledProcessError(returncode=process.returncode, cmd="".join(command))
+        raise CalledProcessError(returncode=process.returncode, cmd=" ".join(command))
 
     return process

--- a/octue/utils/processes.py
+++ b/octue/utils/processes.py
@@ -3,7 +3,7 @@ from threading import Thread
 
 
 class ProcessesContextManager:
-    """ A context manager that kills any processes given to it on exit from its context. """
+    """A context manager that kills any processes given to it on exit from its context."""
 
     def __init__(self, processes):
         self.processes = processes

--- a/octue/utils/processes.py
+++ b/octue/utils/processes.py
@@ -1,3 +1,7 @@
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen
+from threading import Thread
+
+
 class ProcessesContextManager:
     """ A context manager that kills any processes given to it on exit from its context. """
 
@@ -10,3 +14,35 @@ class ProcessesContextManager:
     def __exit__(self, exc_type, exc_val, exc_tb):
         for process in self.processes:
             process.kill()
+
+
+def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", *args, **kwargs):
+    """Run a subprocess, sending its stdout and stderr output to the given logger. Extra `args` and `kwargs` are
+    provided to the `subprocess.Popen` instance used.
+
+    :param iter(str) command: command to run
+    :param logging.Logger logger: logger to use to log stdout and stderr
+    :param str log_level: level to log output at
+    :raise CalledProcessError: if the subprocess fails (i.e. if it doesn't exit with a 0 return code)
+    :return subprocess.CompletedProcess:
+    """
+
+    def _log_lines_from_stream(stream, logger):
+        """Log lines from the given stream.
+
+        :param io.BufferedReader stream:
+        :param logging.Logger logger:
+        :return None:
+        """
+        with stream:
+            for line in iter(stream.readline, b""):
+                getattr(logger, log_level.lower())(line.decode().strip())
+
+    process = Popen(command, stdout=PIPE, stderr=STDOUT, *args, **kwargs)
+    Thread(target=_log_lines_from_stream, args=[process.stdout, logger]).start()
+    process.wait()
+
+    if process.returncode != 0:
+        raise CalledProcessError(returncode=process.returncode, cmd="".join(command))
+
+    return process

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.6",
+    version="0.3.7",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/utils/test_processes.py
+++ b/tests/utils/test_processes.py
@@ -1,31 +1,28 @@
-import logging
 import subprocess
-from unittest.mock import patch
+from unittest.mock import Mock
 
 from octue.utils.processes import run_subprocess_and_log_stdout_and_stderr
 from tests.base import BaseTestCase
 
 
-LOGGER = logging.getLogger(__name__)
-
-
 class TestRunSubprocessAndLogStdoutAndStderr(BaseTestCase):
     def test_error_raised_if_process_fails(self):
         """Test that an error is raised if the process fails."""
-        with patch("logging.StreamHandler.emit") as mock_local_logger_emit:
+        mock_logger = Mock()
 
-            with self.assertRaises(subprocess.CalledProcessError):
-                run_subprocess_and_log_stdout_and_stderr(command=["blah blah blah"], logger=LOGGER, shell=True)
+        with self.assertRaises(subprocess.CalledProcessError):
+            run_subprocess_and_log_stdout_and_stderr(command=["blah blah blah"], logger=mock_logger, shell=True)
 
-        self.assertIn("blah: command not found", mock_local_logger_emit.call_args_list[0][0][0].msg)
+        self.assertIn("blah: command not found", mock_logger.method_calls[0][1][0])
 
     def test_stdout_is_logged(self):
         """Test that any output to stdout is logged."""
-        with patch("logging.StreamHandler.emit") as mock_local_logger_emit:
-            process = run_subprocess_and_log_stdout_and_stderr(
-                command=["echo hello && echo goodbye"], logger=LOGGER, shell=True
-            )
+        mock_logger = Mock()
+
+        process = run_subprocess_and_log_stdout_and_stderr(
+            command=["echo hello && echo goodbye"], logger=mock_logger, shell=True
+        )
 
         self.assertEqual(process.returncode, 0)
-        self.assertEqual(mock_local_logger_emit.call_args_list[0][0][0].msg, "hello")
-        self.assertEqual(mock_local_logger_emit.call_args_list[1][0][0].msg, "goodbye")
+        self.assertEqual(mock_logger.method_calls[0][1][0], "hello")
+        self.assertEqual(mock_logger.method_calls[1][1][0], "goodbye")

--- a/tests/utils/test_processes.py
+++ b/tests/utils/test_processes.py
@@ -1,4 +1,6 @@
+import os
 import subprocess
+import unittest
 from unittest.mock import Mock
 
 from octue.utils.processes import run_subprocess_and_log_stdout_and_stderr
@@ -13,8 +15,10 @@ class TestRunSubprocessAndLogStdoutAndStderr(BaseTestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             run_subprocess_and_log_stdout_and_stderr(command=["blah blah blah"], logger=mock_logger, shell=True)
 
-        self.assertIn("not found", mock_logger.method_calls[0][1][0])
+        log_message = mock_logger.method_calls[0][1][0]
+        self.assertTrue("not found" in log_message or "not recognized" in log_message)
 
+    @unittest.skipIf(condition=os.name == "nt", reason="See issue https://github.com/octue/octue-sdk-python/issues/228")
     def test_stdout_is_logged(self):
         """Test that any output to stdout is logged."""
         mock_logger = Mock()

--- a/tests/utils/test_processes.py
+++ b/tests/utils/test_processes.py
@@ -13,7 +13,7 @@ class TestRunSubprocessAndLogStdoutAndStderr(BaseTestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             run_subprocess_and_log_stdout_and_stderr(command=["blah blah blah"], logger=mock_logger, shell=True)
 
-        self.assertIn("blah: command not found", mock_logger.method_calls[0][1][0])
+        self.assertIn("not found", mock_logger.method_calls[0][1][0])
 
     def test_stdout_is_logged(self):
         """Test that any output to stdout is logged."""

--- a/tests/utils/test_processes.py
+++ b/tests/utils/test_processes.py
@@ -1,0 +1,31 @@
+import logging
+import subprocess
+from unittest.mock import patch
+
+from octue.utils.processes import run_subprocess_and_log_stdout_and_stderr
+from tests.base import BaseTestCase
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestRunSubprocessAndLogStdoutAndStderr(BaseTestCase):
+    def test_error_raised_if_process_fails(self):
+        """Test that an error is raised if the process fails."""
+        with patch("logging.StreamHandler.emit") as mock_local_logger_emit:
+
+            with self.assertRaises(subprocess.CalledProcessError):
+                run_subprocess_and_log_stdout_and_stderr(command=["blah blah blah"], logger=LOGGER, shell=True)
+
+        self.assertIn("blah: command not found", mock_local_logger_emit.call_args_list[0][0][0].msg)
+
+    def test_stdout_is_logged(self):
+        """Test that any output to stdout is logged."""
+        with patch("logging.StreamHandler.emit") as mock_local_logger_emit:
+            process = run_subprocess_and_log_stdout_and_stderr(
+                command=["echo hello && echo goodbye"], logger=LOGGER, shell=True
+            )
+
+        self.assertEqual(process.returncode, 0)
+        self.assertEqual(mock_local_logger_emit.call_args_list[0][0][0].msg, "hello")
+        self.assertEqual(mock_local_logger_emit.call_args_list[1][0][0].msg, "goodbye")


### PR DESCRIPTION
## Summary
Add a function that makes it easy to run and capture any `stdout` and `stderr` output of subprocesses. This is useful for child services that forward their logs back to the parent as all output produced by non-python processes can be included.

<!--- START AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] Add function for logging subprocess stdout and stderr

<!--- END AUTOGENERATED NOTES --->

## Quality Checklist
- [x] New features are fully tested (No matter how much Coverage Karma you have)