### PR TITLE
Allow Datafile instantiation with local and cloud paths simultaneously

### DIFF
--- a/docs/source/datafile.rst
+++ b/docs/source/datafile.rst
@@ -37,7 +37,7 @@ these happen, the cloud object is downloaded to a temporary local file. Any chan
 ``Datafile.open`` method (which can be used analogously to the python built-in ``open`` function) are synced up with
 the cloud object. The temporary file will exist as long as the python session is running. Calling ``download`` again
 will not re-download the file as it will be up to date with any changes made locally. However, external changes to the
-cloud object will not be synced locally unless the ``reset_local_path`` method is called, followed by the ``download``
+cloud object will not be synced locally unless the ``local_path`` is set to ``None``, followed by the ``download``
 method again.
 
 If you want a cloud object to be permanently downloaded, you can either:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -268,10 +268,19 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
 
     @property
     def cloud_path(self):
+        """Get the cloud path of the datafile.
+
+        :return str|None:
+        """
         return self._cloud_path
 
     @cloud_path.setter
     def cloud_path(self, path):
+        """Set the cloud path of the datafile.
+
+        :param str|None path:
+        :return None:
+        """
         if path is None:
 
             if not self.exists_locally:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -70,8 +70,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         "path",
         "cloud_path",
         "project_name",
-        "bucket_name",
-        "path_in_bucket",
         "tags",
         "labels",
         "timestamp",

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -68,7 +68,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         "id",
         "name",
         "path",
-        "local_path",
         "cloud_path",
         "project_name",
         "bucket_name",

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -528,7 +528,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiab
         :param str|None bucket_name:
         :param str|None path_in_bucket:
         :raise octue.exceptions.CloudLocationNotSpecified: if an exact cloud location isn't provided and isn't available implicitly (i.e. the Datafile wasn't loaded from the cloud previously)
-        :return (str, str, str):
+        :return (str, str): project name and cloud path
         """
         project_name = project_name or self.project_name
         cloud_path = cloud_path or self.cloud_path

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.9",
+    version="0.3.10",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -143,8 +143,6 @@ class DatafileTestCase(BaseTestCase):
             "path",
             "cloud_path",
             "project_name",
-            "bucket_name",
-            "path_in_bucket",
             "timestamp",
             "tags",
             "labels",

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -142,7 +142,6 @@ class DatafileTestCase(BaseTestCase):
             "name",
             "path",
             "cloud_path",
-            "local_path",
             "project_name",
             "bucket_name",
             "path_in_bucket",

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -716,3 +716,13 @@ class DatafileTestCase(BaseTestCase):
 
             with open(datafile.local_path) as f:
                 self.assertEqual(f.read(), "yumyum")
+
+    def test_bucket_name_and_path_in_bucket_properties(self):
+        """Test the bucket_name and path_in_bucket properties work as expected for cloud and local datafiles."""
+        datafile = Datafile(path="gs://my-bucket/directory/hello.txt", project_name="blah", hypothetical=True)
+        self.assertEqual(datafile.bucket_name, "my-bucket")
+        self.assertEqual(datafile.path_in_bucket, "directory/hello.txt")
+
+        datafile = Datafile(path="local_file.txt")
+        self.assertIsNone(datafile.bucket_name)
+        self.assertIsNone(datafile.path_in_bucket)


### PR DESCRIPTION
## Summary
Improve the `Datafile` interface and allow instantiation with local and cloud paths simultaneously.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] Allow `Datafile` instantiation with local and cloud paths simultaneously
- [x] Add `cloud_path` property to Datafile

### Fixes
- [x] Ensure `Datafile` serializes with its `cloud_path` and `project_name`

### Refactoring
- [x] Convert `Datafile.cloud_protocol`, `Datafile.bucket_name`, and `Datafile.path_in_bucket` to properties
- [x] Remove redundant `Datafile.reset_local_path` method
- [x] Simplify cloud location setting and getting within `Datafile` 

<!--- END AUTOGENERATED NOTES --->