### PR TITLE
Give cloud scandir option to include subdirectories

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,6 +11,7 @@ on: [push]
 jobs:
 
   check-semantic-version:
+    if: "!contains(github.event.head_commit.message, 'skipci')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +30,7 @@ jobs:
         run: check-semantic-version setup.py
 
   run-tests:
-    if: "!contains(github.event.head_commit.message, 'skip_ci_tests')"
+    if: "!contains(github.event.head_commit.message, 'skipci')"
     runs-on: ${{ matrix.os }}
     env:
       USING_COVERAGE: '3.8'
@@ -59,7 +60,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
-    if: "!contains(github.event.head_commit.message, 'skip_ci_publish')"
+    if: "!contains(github.event.head_commit.message, 'skipci')"
     runs-on: ubuntu-latest
     needs: [check-semantic-version, run-tests]
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     # This job will only run if the PR has been merged (and not closed without merging).
-    if: "github.event.pull_request.merged == true && !contains(github.event.pull_request.head.message, 'skip_ci_release')"
+    if: "github.event.pull_request.merged == true && !contains(github.event.pull_request.head.message, 'skipci')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   description:
-    if: "!contains(github.event.head_commit.message, 'skip_ci_update_description')"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -240,7 +240,7 @@ class GoogleCloudStorageClient:
         :param str directory_path:
         :return bool:
         """
-        return blob.name.startswith(directory_path) and blob.name.replace(directory_path, "").count("/") <= 1
+        return blob.name.startswith(directory_path) and blob.name.strip("/").replace(directory_path, "").count("/") == 1
 
     def _blob(self, cloud_path=None, bucket_name=None, path_in_bucket=None):
         """Instantiate a blob for the given bucket at the given path. Note that this is not synced up with Google Cloud.

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -218,7 +218,7 @@ class GoogleCloudStorageClient:
         :param str|None bucket_name: name of bucket cloud directory is located in
         :param str|None directory_path: path of cloud directory to scan (e.g. `path/to/file.csv`)
         :param callable filter: blob filter to constrain the yielded results
-        :param bool include_directories: if False, subdirectories are ignored
+        :param bool include_subdirectories: if False, subdirectories are ignored
         :param float timeout: time in seconds to allow for the request to complete
         :yield google.cloud.storage.blob.Blob:
         """

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -7,7 +7,7 @@ from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google_crc32c import Checksum
 
 from octue.cloud.credentials import GCPCredentialsManager
-from octue.cloud.storage.path import split_bucket_name_from_gs_path
+from octue.cloud.storage.path import split, split_bucket_name_from_gs_path
 from octue.utils.decoders import OctueJSONDecoder
 from octue.utils.encoders import OctueJSONEncoder
 
@@ -240,7 +240,7 @@ class GoogleCloudStorageClient:
         :param str directory_path:
         :return bool:
         """
-        return blob.name.startswith(directory_path) and blob.name.strip("/").replace(directory_path, "").count("/") == 1
+        return split(blob.name)[0] == directory_path
 
     def _blob(self, cloud_path=None, bucket_name=None, path_in_bucket=None):
         """Instantiate a blob for the given bucket at the given path. Note that this is not synced up with Google Cloud.

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -90,7 +90,9 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
                     path=storage.path.generate_gs_path(bucket_name, blob.name),
                     project_name=project_name,
                 )
-                for blob in GoogleCloudStorageClient(project_name=project_name).scandir(cloud_path)
+                for blob in GoogleCloudStorageClient(project_name=project_name).scandir(
+                    cloud_path, include_subdirectories=False
+                )
             )
 
         return Dataset(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Testing
 # ------------------------------------------------------------------------------
 pluggy
-gcp-storage-emulator>=2021.5.5
+gcp-storage-emulator>=2021.9.8
 tox>=3.23.0
 
 # Code quality

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.11",
+    version="0.3.12",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -173,15 +173,15 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
     def test_scandir_with_cloud_path(self):
         """Test that Google Cloud storage "directories"' contents can be listed when a cloud path is used."""
-        directory_path = storage.path.join("my", "path")
-        path_in_bucket = storage.path.join(directory_path, self.FILENAME)
-        gs_path = f"gs://{TEST_BUCKET_NAME}/{path_in_bucket}"
+        cloud_directory_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "my", "path")
 
-        self.storage_client.upload_from_string(string=json.dumps({"height": 32}), cloud_path=gs_path)
-        contents = list(self.storage_client.scandir(gs_path))
+        self.storage_client.upload_from_string(
+            string=json.dumps({"height": 32}), cloud_path=storage.path.join(cloud_directory_path, self.FILENAME)
+        )
 
+        contents = list(self.storage_client.scandir(cloud_directory_path))
         self.assertEqual(len(contents), 1)
-        self.assertEqual(contents[0].name, storage.path.join(directory_path, self.FILENAME))
+        self.assertEqual(contents[0].name, "my/path/my_file.txt")
 
     def test_scandir_with_empty_directory(self):
         """Test that an empty directory shows as such."""

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -173,7 +173,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
     def test_scandir_with_cloud_path(self):
         """Test that Google Cloud storage "directories"' contents can be listed when a cloud path is used."""
-        cloud_directory_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "my", "path")
+        cloud_directory_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "a", "path")
 
         self.storage_client.upload_from_string(
             string=json.dumps({"height": 32}), cloud_path=storage.path.join(cloud_directory_path, self.FILENAME)
@@ -181,7 +181,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
         contents = list(self.storage_client.scandir(cloud_directory_path))
         self.assertEqual(len(contents), 1)
-        self.assertEqual(contents[0].name, "my/path/my_file.txt")
+        self.assertEqual(contents[0].name, "a/path/my_file.txt")
 
     def test_scandir_with_empty_directory(self):
         """Test that an empty directory shows as such."""
@@ -191,7 +191,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
 
     def test_scandir_with_directory_of_subdirectories_includes_subdirectories_by_default(self):
         """Test that subdirectories of the given directory are included by scandir by default."""
-        directory_path = storage.path.join("my", "path")
+        directory_path = storage.path.join("the", "path")
 
         self.storage_client.upload_from_string(
             string=json.dumps({"height": 32}),

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -189,8 +189,8 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         contents = list(self.storage_client.scandir(bucket_name=TEST_BUCKET_NAME, directory_path=directory_path))
         self.assertEqual(len(contents), 0)
 
-    def test_scandir_with_directory_of_subdirectories_ignores_subdirectories(self):
-        """Test that subdirectories of the given directory are ignored by scandir."""
+    def test_scandir_with_directory_of_subdirectories_includes_subdirectories_by_default(self):
+        """Test that subdirectories of the given directory are included by scandir by default."""
         directory_path = storage.path.join("my", "path")
 
         self.storage_client.upload_from_string(
@@ -207,6 +207,38 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         )
 
         contents = list(self.storage_client.scandir(bucket_name=TEST_BUCKET_NAME, directory_path=directory_path))
+        self.assertEqual(len(contents), 2)
+
+        self.assertEqual(
+            {blob.name for blob in contents},
+            {
+                storage.path.join(directory_path, self.FILENAME),
+                storage.path.join(directory_path, "sub_directory", "blah.txt"),
+            },
+        )
+
+    def test_scandir_with_directory_of_subdirectories_ignores_subdirectories_if_told_to(self):
+        """Test that subdirectories of the given directory are ignored by scandir if told to."""
+        directory_path = storage.path.join("my", "path")
+
+        self.storage_client.upload_from_string(
+            string=json.dumps({"height": 32}),
+            bucket_name=TEST_BUCKET_NAME,
+            path_in_bucket=storage.path.join(directory_path, self.FILENAME),
+        )
+
+        # Add a file in a subdirectory.
+        self.storage_client.upload_from_string(
+            string=json.dumps({"height": 32}),
+            bucket_name=TEST_BUCKET_NAME,
+            path_in_bucket=storage.path.join(directory_path, "sub_directory", "blah.txt"),
+        )
+
+        contents = list(
+            self.storage_client.scandir(
+                bucket_name=TEST_BUCKET_NAME, directory_path=directory_path, include_subdirectories=False
+            )
+        )
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[0].name, storage.path.join(directory_path, self.FILENAME))
 


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] Give cloud `scandir` option to include subdirectories

### Fixes
- [x] Ensure `Dataset` construction from a cloud directory with no `dataset.json` file does not include subdirectories

### Dependencies
- [x] Upgrade GCP storage emulator version

### Operations
- [x] Unify GitHub workflow skip commands

<!--- END AUTOGENERATED NOTES --->