### PR TITLE
Allow Manifest construction from any serialized cloud dataset

### DIFF
--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -6,6 +6,7 @@ from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.exceptions import InvalidInputException, InvalidManifestException
 from octue.mixins import Hashable, Identifiable, Loggable, Pathable, Serialisable
+from octue.resources.datafile import CLOUD_STORAGE_PROTOCOL
 from .dataset import Dataset
 
 
@@ -185,7 +186,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
 
             else:
                 if "path" in dataset:
-                    if not os.path.isabs(dataset["path"]):
+                    if not os.path.isabs(dataset["path"]) and not dataset["path"].startswith(CLOUD_STORAGE_PROTOCOL):
                         path = dataset.pop("path")
                         self.datasets.append(Dataset(**dataset, path=path, path_from=self))
                     else:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.12",
+    version="0.3.13",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -322,17 +322,21 @@ class DatasetTestCase(BaseTestCase):
             "[4, 5, 6]", bucket_name=TEST_BUCKET_NAME, path_in_bucket="my_dataset/file_1.txt"
         )
 
-        persisted_dataset = Dataset.from_cloud(
+        cloud_dataset = Dataset.from_cloud(
             project_name=TEST_PROJECT_NAME,
             cloud_path=f"gs://{TEST_BUCKET_NAME}/my_dataset",
         )
 
-        self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/my_dataset")
-        self.assertEqual(persisted_dataset.name, "my_dataset")
-        self.assertEqual({file.name for file in persisted_dataset.files}, {"file_0.txt", "file_1.txt"})
+        self.assertEqual(cloud_dataset.path, f"gs://{TEST_BUCKET_NAME}/my_dataset")
+        self.assertEqual(cloud_dataset.name, "my_dataset")
+        self.assertEqual({file.name for file in cloud_dataset.files}, {"file_0.txt", "file_1.txt"})
 
-        for file in persisted_dataset:
+        for file in cloud_dataset:
             self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/my_dataset/{file.name}")
+
+        deserialised_dataset = Dataset.deserialise(cloud_dataset.serialise())
+
+        self.assertEqual(deserialised_dataset, cloud_dataset)
 
     def test_to_cloud(self):
         """Test that a dataset can be uploaded to the cloud via (`bucket_name`, `output_directory`) and via `gs_path`,

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -313,7 +313,9 @@ class DatasetTestCase(BaseTestCase):
                     self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}/{file.name}")
 
     def test_from_cloud_with_no_datafile_json_file(self):
-        """Test that any cloud directory can be accessed as a dataset, even if it has no `dataset.json` file in it."""
+        """Test that any cloud directory can be accessed as a dataset, even if it has no `dataset.json` file in it. Also
+        test that the cloud dataset doesn't lose any information during serialization.
+        """
         GoogleCloudStorageClient(TEST_PROJECT_NAME).upload_from_string(
             "[1, 2, 3]", bucket_name=TEST_BUCKET_NAME, path_in_bucket="my_dataset/file_0.txt"
         )
@@ -334,9 +336,12 @@ class DatasetTestCase(BaseTestCase):
         for file in cloud_dataset:
             self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/my_dataset/{file.name}")
 
+        # Test serialisation doesn't lose any information.
         deserialised_dataset = Dataset.deserialise(cloud_dataset.serialise())
-
-        self.assertEqual(deserialised_dataset, cloud_dataset)
+        self.assertEqual(deserialised_dataset.id, cloud_dataset.id)
+        self.assertEqual(deserialised_dataset.name, cloud_dataset.name)
+        self.assertEqual(deserialised_dataset.path, cloud_dataset.path)
+        self.assertEqual(deserialised_dataset.hash_value, cloud_dataset.hash_value)
 
     def test_to_cloud(self):
         """Test that a dataset can be uploaded to the cloud via (`bucket_name`, `output_directory`) and via `gs_path`,

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -189,3 +189,24 @@ class TestManifest(BaseTestCase):
                     self.assertEqual(dataset.path, f"gs://{TEST_BUCKET_NAME}/my-directory/{dataset.name}")
                     self.assertTrue(len(dataset.files), 2)
                     self.assertTrue(all(isinstance(file, Datafile) for file in dataset.files))
+
+    def test_instantiating_from_serialised_cloud_datasets_with_no_dataset_json_file(self):
+        """Test that a Manifest can be instantiated from a serialized cloud dataset with no `dataset.json` file. This
+        simulates what happens when such a cloud dataset is referred to in a manifest received by a child service.
+        """
+        GoogleCloudStorageClient(TEST_PROJECT_NAME).upload_from_string(
+            "[1, 2, 3]", bucket_name=TEST_BUCKET_NAME, path_in_bucket="my_dataset/file_0.txt"
+        )
+
+        GoogleCloudStorageClient(TEST_PROJECT_NAME).upload_from_string(
+            "[4, 5, 6]", bucket_name=TEST_BUCKET_NAME, path_in_bucket="my_dataset/file_1.txt"
+        )
+
+        serialised_cloud_dataset = Dataset.from_cloud(
+            project_name=TEST_PROJECT_NAME,
+            cloud_path=f"gs://{TEST_BUCKET_NAME}/my_dataset",
+        ).serialise()
+
+        manifest = Manifest(datasets=[serialised_cloud_dataset], keys={"my_dataset": 0})
+        self.assertEqual(manifest.datasets[0].path, f"gs://{TEST_BUCKET_NAME}/my_dataset")
+        self.assertEqual(len(manifest.datasets[0].files), 1)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -208,5 +208,6 @@ class TestManifest(BaseTestCase):
         ).serialise()
 
         manifest = Manifest(datasets=[serialised_cloud_dataset], keys={"my_dataset": 0})
+        self.assertEqual(len(manifest.datasets), 1)
         self.assertEqual(manifest.datasets[0].path, f"gs://{TEST_BUCKET_NAME}/my_dataset")
-        self.assertEqual(len(manifest.datasets[0].files), 1)
+        self.assertEqual(len(manifest.datasets[0].files), 2)


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Allow `Manifest` construction from any serialized cloud dataset

<!--- END AUTOGENERATED NOTES --->