### PR TITLE
Upload dataset metadata file when getting datasets with no existing metadata file

### DIFF
--- a/octue/definitions.py
+++ b/octue/definitions.py
@@ -7,8 +7,10 @@ FOLDER_DEFAULTS = {
 
 VALUES_FILENAME = "values.json"
 MANIFEST_FILENAME = "manifest.json"
-DATASET_FILENAME = "dataset.json"
 CHILDREN_FILENAME = "children.json"
+
+# Default JSON filenames for storing metadata about non-file objects in the cloud.
+DATASET_METADATA_FILENAME = "dataset_metadata.json"
 
 STRAND_FILENAME_MAP = {
     "configuration_values": VALUES_FILENAME,

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -127,22 +127,6 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         self._upload_metadata_file(project_name, cloud_path)
         return cloud_path
 
-    def _upload_metadata_file(self, project_name, cloud_path):
-        """Upload a metadata file representing the dataset to the given cloud location.
-
-        :param str project_name:
-        :param str cloud_path:
-        :return None:
-        """
-        serialised_dataset = self.serialise()
-        serialised_dataset["files"] = sorted(datafile.cloud_path for datafile in self.files)
-        del serialised_dataset["path"]
-
-        GoogleCloudStorageClient(project_name=project_name).upload_from_string(
-            string=json.dumps(serialised_dataset),
-            cloud_path=storage.path.join(cloud_path, definitions.DATASET_METADATA_FILENAME),
-        )
-
     @property
     def name(self):
         return self._name or os.path.split(os.path.abspath(os.path.split(self.path)[-1]))[-1]
@@ -226,3 +210,19 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
                 local_path = None
 
             datafile.download(local_path=local_path)
+
+    def _upload_metadata_file(self, project_name, cloud_path):
+        """Upload a metadata file representing the dataset to the given cloud location.
+
+        :param str project_name:
+        :param str cloud_path:
+        :return None:
+        """
+        serialised_dataset = self.serialise()
+        serialised_dataset["files"] = sorted(datafile.cloud_path for datafile in self.files)
+        del serialised_dataset["path"]
+
+        GoogleCloudStorageClient(project_name=project_name).upload_from_string(
+            string=json.dumps(serialised_dataset),
+            cloud_path=storage.path.join(cloud_path, definitions.DATASET_METADATA_FILENAME),
+        )

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -74,7 +74,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
             dataset_metadata = json.loads(
                 GoogleCloudStorageClient(project_name=project_name).download_as_string(
                     bucket_name=bucket_name,
-                    path_in_bucket=storage.path.join(path_to_dataset_directory, definitions.DATASET_FILENAME),
+                    path_in_bucket=storage.path.join(path_to_dataset_directory, definitions.DATASET_METADATA_FILENAME),
                 )
             )
 
@@ -140,7 +140,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
 
         GoogleCloudStorageClient(project_name=project_name).upload_from_string(
             string=json.dumps(serialised_dataset),
-            cloud_path=storage.path.join(cloud_path, definitions.DATASET_FILENAME),
+            cloud_path=storage.path.join(cloud_path, definitions.DATASET_METADATA_FILENAME),
         )
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.14",
+    version="0.3.15",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -367,19 +367,18 @@ class DatasetTestCase(BaseTestCase):
 
             bucket_name = TEST_BUCKET_NAME
             output_directory = "my_datasets"
-            gs_path = storage.path.generate_gs_path(bucket_name, output_directory)
+            cloud_path = storage.path.generate_gs_path(bucket_name, output_directory)
 
             for location_parameters in (
                 {"bucket_name": bucket_name, "output_directory": output_directory, "cloud_path": None},
-                {"bucket_name": None, "output_directory": None, "cloud_path": gs_path},
+                {"bucket_name": None, "output_directory": None, "cloud_path": cloud_path},
             ):
                 dataset.to_cloud(TEST_PROJECT_NAME, **location_parameters)
 
                 storage_client = GoogleCloudStorageClient(TEST_PROJECT_NAME)
 
                 persisted_file_0 = storage_client.download_as_string(
-                    bucket_name=TEST_BUCKET_NAME,
-                    path_in_bucket=storage.path.join(output_directory, dataset.name, "file_0.txt"),
+                    cloud_path=storage.path.join(cloud_path, dataset.name, "file_0.txt"),
                 )
 
                 self.assertEqual(persisted_file_0, "[1, 2, 3]")

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -348,7 +348,7 @@ class DatasetTestCase(BaseTestCase):
         # Test dataset metadata file has been uploaded.
         dataset_metadata = json.loads(
             cloud_storage_client.download_as_string(
-                cloud_path=storage.path.join(cloud_dataset.path, definitions.DATASET_FILENAME)
+                cloud_path=storage.path.join(cloud_dataset.path, definitions.DATASET_METADATA_FILENAME)
             )
         )
         del dataset_metadata["id"]
@@ -415,7 +415,9 @@ class DatasetTestCase(BaseTestCase):
                 persisted_dataset = json.loads(
                     storage_client.download_as_string(
                         bucket_name=TEST_BUCKET_NAME,
-                        path_in_bucket=storage.path.join(output_directory, dataset.name, "dataset.json"),
+                        path_in_bucket=storage.path.join(
+                            output_directory, dataset.name, definitions.DATASET_METADATA_FILENAME
+                        ),
                     )
                 )
 


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Upload dataset metadata file for cloud directory datasets when getting a dataset from a cloud directory with no existing metadata file

### Refactoring
- [x] Rename `dataset.json file` to `dataset_metadata.json`
- [x] Simplify `Dataset.from_cloud`

<!--- END AUTOGENERATED NOTES --->