### PR TITLE
Let FilterContainer.one method be used with no filters on empty containers

### DIFF
--- a/octue/resources/filter_containers.py
+++ b/octue/resources/filter_containers.py
@@ -89,6 +89,7 @@ class FilterContainer(ABC):
         """
         results = self.filter(**kwargs)
 
+        # If no filters are given, results will be `None`.
         if results is None:
             self._raise_if_not_exactly_one_item(self, **kwargs)
             return next(iter(self))
@@ -175,6 +176,7 @@ class FilterDict(FilterContainer, UserDict):
         """
         results = self.filter(**kwargs)
 
+        # If no filters are given, results will be `None`.
         if results is None:
             self._raise_if_not_exactly_one_item(self, **kwargs)
             return next(iter(self.items()))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.15",
+    version="0.3.16",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -65,8 +65,12 @@ class TestFilterSet(BaseTestCase):
             filterables.one(a__equals=3)
 
     def test_one(self):
-        """Test that the `one` method works and returns one result."""
+        """Test that the `one` method returns one result without mutating its `FilterContainer` instance."""
         filterables = FilterSet({FilterableThing(a=3, b=2), FilterableThing(a=3, b=99), FilterableThing(a=77)})
+        self.assertEqual(filterables.one(a__equals=77), FilterableThing(a=77))
+
+        # Test that `one` doesn't mutate the `FilterContainer` instance (i.e. `one` can be called again on the same
+        # instance and give the same result).
         self.assertEqual(filterables.one(a__equals=77), FilterableThing(a=77))
 
     def test_one_with_no_filter(self):

--- a/tests/resources/test_filter_containers.py
+++ b/tests/resources/test_filter_containers.py
@@ -69,6 +69,12 @@ class TestFilterSet(BaseTestCase):
         filterables = FilterSet({FilterableThing(a=3, b=2), FilterableThing(a=3, b=99), FilterableThing(a=77)})
         self.assertEqual(filterables.one(a__equals=77), FilterableThing(a=77))
 
+    def test_one_with_no_filter(self):
+        """Test that the `one` method can be used with no filters on a FilterSet with only one item to return that item."""
+        filterable_thing = FilterableThing(a=3, b=2)
+        filterables = FilterSet({filterable_thing})
+        self.assertEqual(filterables.one(), filterable_thing)
+
     def test_ordering_by_a_non_existent_attribute(self):
         """ Ensure an error is raised if ordering is attempted by a non-existent attribute. """
         filter_set = FilterSet([FilterableThing(age=5), FilterableThing(age=4), FilterableThing(age=3)])
@@ -240,6 +246,12 @@ class TestFilterDict(BaseTestCase):
     def test_one(self):
         """Test that the `one` method works and returns one result."""
         self.assertEqual(self.ANIMALS.one(age__equals=91), ("another_dog", self.ANIMALS["another_dog"]))
+
+    def test_one_with_no_filter(self):
+        """Test that the `one` method can be used with no filters on a FilterDict with only one item to return that item."""
+        filterable_thing = FilterableThing(a=3, b=2)
+        filterables = FilterDict({"my_thing": filterable_thing})
+        self.assertEqual(filterables.one(), ("my_thing", filterable_thing))
 
     def test_ordering_by_a_non_existent_attribute(self):
         """Ensure an error is raised if ordering is attempted by a non-existent attribute."""


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] Let `FilterContainer.one` be used with no filters on empty containers

<!--- END AUTOGENERATED NOTES --->