### PR TITLE
Clarify the interface for serialising Serialisable instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
           - '^hotfix/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^review/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^refactor/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
-          - '^release/(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+          - '^test/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/conventional-commits
     rev: 0.2.1

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -136,7 +136,7 @@ class Service(CoolNameable):
             if analysis.output_manifest is None:
                 serialised_output_manifest = None
             else:
-                serialised_output_manifest = analysis.output_manifest.serialise(to_string=True)
+                serialised_output_manifest = analysis.output_manifest.serialise()
 
             self.publisher.publish(
                 topic=topic.path,
@@ -239,7 +239,7 @@ class Service(CoolNameable):
         response_subscription.create(allow_existing=False)
 
         if input_manifest is not None:
-            input_manifest = input_manifest.serialise(to_string=True)
+            input_manifest = input_manifest.serialise()
 
         self.publisher.publish(
             topic=question_topic.path,

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -37,33 +37,6 @@ class Serialisable:
 
         :return str: JSON string containing a serialised primitive version of the resource
         """
-        return json.dumps(self.to_primitive(**kwargs), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
-
-    def to_primitive(self, **kwargs):
-        """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,
-        only public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these
-        exact attributes are included (these can include non-public attributes); conversely, if
-        `_EXCLUDE_SERIALISE_FIELDS` is specified and `_SERIALISE_FIELDS` is not, then all public attributes are
-        included apart from the excluded ones. By default, the conversion is carried out using the `OctueJSONEncoder`,
-        which will sort keys as well as format and indent automatically. Additional keyword arguments will be passed to
-        ``json.dumps()`` to enable full override of formatting options.
-
-        For example:
-        ```
-        class MyThing(Serialisable):
-            _SERIALISE_FIELDS = ("a",)
-            def __init__(self):
-                self.a = 1
-                self.b = 2
-                self._private = 3
-                self.__protected = 4
-
-        MyThing().to_primitive()
-        {"a": 1}
-        ```
-
-        :return dict:
-        """
         names_of_attributes_to_serialise = self._SERIALISE_FIELDS or (
             field_name
             for field_name in dir(self)
@@ -90,8 +63,34 @@ class Serialisable:
         #  primitives using their `serialise` method. A more performant method would be to implement an encoder which
         #  returns python primitives, not strings. The reason we do this is to validate outbound information the same
         #  way as we validate incoming.
-        string = json.dumps(self_as_primitive, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
-        return json.loads(string, cls=OctueJSONDecoder)
+        return json.dumps(self_as_primitive, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
+
+    def to_primitive(self, **kwargs):
+        """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,
+        only public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these
+        exact attributes are included (these can include non-public attributes); conversely, if
+        `_EXCLUDE_SERIALISE_FIELDS` is specified and `_SERIALISE_FIELDS` is not, then all public attributes are
+        included apart from the excluded ones. By default, the conversion is carried out using the `OctueJSONEncoder`,
+        which will sort keys as well as format and indent automatically. Additional keyword arguments will be passed to
+        ``json.dumps()`` to enable full override of formatting options.
+
+        For example:
+        ```
+        class MyThing(Serialisable):
+            _SERIALISE_FIELDS = ("a",)
+            def __init__(self):
+                self.a = 1
+                self.b = 2
+                self._private = 3
+                self.__protected = 4
+
+        MyThing().to_primitive()
+        {"a": 1}
+        ```
+
+        :return dict:
+        """
+        return json.loads(self.serialise(), cls=OctueJSONDecoder)
 
     def to_file(self, filename, **kwargs):
         """Write the object to a JSON file.

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -33,13 +33,13 @@ class Serialisable:
         return cls(**serialised_object)
 
     def serialise(self, **kwargs):
-        """Serialise to a JSON string of primitives. See `Serialisable.to_primitive` for more information.
+        """Serialise to a JSON string of primitives. See `Serialisable.to_primitives` for more information.
 
         :return str: JSON string containing a serialised primitive version of the resource
         """
-        return json.dumps(self.to_primitive(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
+        return json.dumps(self.to_primitives(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
 
-    def to_primitive(self, **kwargs):
+    def to_primitives(self, **kwargs):
         """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,
         only public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these
         exact attributes are included (these can include non-public attributes); conversely, if
@@ -58,7 +58,7 @@ class Serialisable:
                 self._private = 3
                 self.__protected = 4
 
-        MyThing().to_primitive()
+        MyThing().to_primitives()
         {"a": 1}
         ```
 

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -37,7 +37,7 @@ class Serialisable:
 
         :return str: JSON string containing a serialised primitive version of the resource
         """
-        return json.dumps(self.to_primitive(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
+        return json.dumps(self.to_primitive(**kwargs), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
 
     def to_primitive(self, **kwargs):
         """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -32,46 +32,35 @@ class Serialisable:
 
         return cls(**serialised_object)
 
-    def serialise(self, to_string=False, **kwargs):
-        """Serialise into a primitive dict or JSON string.
+    def serialise(self, **kwargs):
+        """Serialise to a JSON string of primitives. See `Serialisable.to_primitive` for more information.
 
-        Serialises all non-private and non-protected attributes except for 'logger', unless the subclass has a
-        `_serialise_fields` tuple of the attribute names to serialise. For example:
+        :return str: JSON string containing a serialised primitive version of the resource
+        """
+        return json.dumps(self.to_primitive(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
+
+    def to_primitive(self, **kwargs):
+        """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,
+        only public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these
+        exact attributes are included (these can include non-public attributes); conversely, if
+        `_EXCLUDE_SERIALISE_FIELDS` is specified and `_SERIALISE_FIELDS` is not, then all public attributes are
+        included apart from the excluded ones. By default, the conversion is carried out using the `OctueJSONEncoder`,
+        which will sort keys as well as format and indent automatically. Additional keyword arguments will be passed to
+        ``json.dumps()`` to enable full override of formatting options.
+
+        For example:
         ```
         class MyThing(Serialisable):
-            _serialise_fields = ("a",)
+            _SERIALISE_FIELDS = ("a",)
             def __init__(self):
                 self.a = 1
                 self.b = 2
+                self._private = 3
+                self.__protected = 4
 
-        MyThing().serialise()
+        MyThing().to_primitive()
         {"a": 1}
         ```
-
-        By default, serialises using the OctueJSONEncoder, and will sort keys as well as format and indent
-        automatically. Additional keyword arguments will be passed to ``json.dumps()`` to enable full override
-        of formatting options
-
-        :return: json string or dict containing a serialised/primitive version of the resource.
-        :rtype: str, dict
-        """
-        # TODO this conversion backward-and-forward is very inefficient but allows us to use the same encoder for
-        #  converting the object to a dict as to strings, which ensures that nested attributes are also cast to
-        #  primitive using their serialise() method. A more performant method would be to implement an encoder which
-        #  returns python primitives, not strings. The reason we do this is to validate outbound information the same
-        #  way as we validate incoming.
-        string = json.dumps(self.to_primitive(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
-
-        if to_string:
-            return string
-
-        return json.loads(string, cls=OctueJSONDecoder)
-
-    def to_primitive(self):
-        """Convert the instance into a JSON-compatible primitive python dictionary of its attributes. By default, only
-        public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these exact
-        attributes are included; conversely, if `_EXCLUDE_SERIALISE_FIELDS` is specified and `_SERIALISE_FIELDS` is
-        not, then all public attributes are included apart from the excluded ones.
 
         :return dict:
         """
@@ -96,13 +85,19 @@ class Serialisable:
             else:
                 self_as_primitive[name] = attribute
 
-        return self_as_primitive
+        # TODO this backward-and-forward conversion is very inefficient but allows us to use the same encoder for
+        #  converting the object to a dict as to strings, which ensures that nested attributes are also cast to
+        #  primitives using their `serialise` method. A more performant method would be to implement an encoder which
+        #  returns python primitives, not strings. The reason we do this is to validate outbound information the same
+        #  way as we validate incoming.
+        string = json.dumps(self_as_primitive, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
+        return json.loads(string, cls=OctueJSONDecoder)
 
-    def to_file(self, file_name, **kwargs):
+    def to_file(self, filename, **kwargs):
         """Write the object to a JSON file.
 
-        :parameter str file_name: file to write to, including relative or absolute path and .json extension
+        :param str filename: path of file to write to, including relative or absolute path and .json extension
         :return None:
         """
-        with open(file_name, "w") as fp:
-            fp.write(self.serialise(**kwargs, to_string=True))
+        with open(filename, "w") as f:
+            f.write(self.serialise(**kwargs))

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -33,7 +33,26 @@ class Serialisable:
         return cls(**serialised_object)
 
     def serialise(self, **kwargs):
-        """Serialise to a JSON string of primitives. See `Serialisable.to_primitive` for more information.
+        """Serialise to a JSON string of primitives. By default, only public attributes are included. If the class
+        variable `_SERIALISE_FIELDS` is specified, then only these exact attributes are included (these can include
+        non-public attributes); conversely, if `_EXCLUDE_SERIALISE_FIELDS` is specified and `_SERIALISE_FIELDS` is not,
+        then all public attributes are included apart from the excluded ones. By default, the conversion is carried out
+        using the `OctueJSONEncoder`, which will sort keys as well as format and indent automatically. Additional
+        keyword arguments will be passed to ``json.dumps()`` to enable full override of formatting options.
+
+        For example:
+        ```
+        class MyThing(Serialisable):
+            _SERIALISE_FIELDS = ("a",)
+            def __init__(self):
+                self.a = 1
+                self.b = 2
+                self._private = 3
+                self.__protected = 4
+
+        MyThing().to_primitive()
+        {"a": 1}
+        ```
 
         :return str: JSON string containing a serialised primitive version of the resource
         """
@@ -65,28 +84,9 @@ class Serialisable:
         #  way as we validate incoming.
         return json.dumps(self_as_primitive, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
 
-    def to_primitive(self, **kwargs):
-        """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,
-        only public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these
-        exact attributes are included (these can include non-public attributes); conversely, if
-        `_EXCLUDE_SERIALISE_FIELDS` is specified and `_SERIALISE_FIELDS` is not, then all public attributes are
-        included apart from the excluded ones. By default, the conversion is carried out using the `OctueJSONEncoder`,
-        which will sort keys as well as format and indent automatically. Additional keyword arguments will be passed to
-        ``json.dumps()`` to enable full override of formatting options.
-
-        For example:
-        ```
-        class MyThing(Serialisable):
-            _SERIALISE_FIELDS = ("a",)
-            def __init__(self):
-                self.a = 1
-                self.b = 2
-                self._private = 3
-                self.__protected = 4
-
-        MyThing().to_primitive()
-        {"a": 1}
-        ```
+    def to_primitive(self):
+        """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. The same rules
+        as described in `serialise` apply.
 
         :return dict:
         """

--- a/octue/mixins/serialisable.py
+++ b/octue/mixins/serialisable.py
@@ -33,13 +33,13 @@ class Serialisable:
         return cls(**serialised_object)
 
     def serialise(self, **kwargs):
-        """Serialise to a JSON string of primitives. See `Serialisable.to_primitives` for more information.
+        """Serialise to a JSON string of primitives. See `Serialisable.to_primitive` for more information.
 
         :return str: JSON string containing a serialised primitive version of the resource
         """
-        return json.dumps(self.to_primitives(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
+        return json.dumps(self.to_primitive(), cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
 
-    def to_primitives(self, **kwargs):
+    def to_primitive(self, **kwargs):
         """Convert the instance into a JSON-compatible python dictionary of its attributes as primitives. By default,
         only public attributes are included. If the class variable `_SERIALISE_FIELDS` is specified, then only these
         exact attributes are included (these can include non-public attributes); conversely, if
@@ -58,7 +58,7 @@ class Serialisable:
                 self._private = 3
                 self.__protected = 4
 
-        MyThing().to_primitives()
+        MyThing().to_primitive()
         {"a": 1}
         ```
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -218,7 +218,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         :param str cloud_path:
         :return None:
         """
-        serialised_dataset = self.serialise()
+        serialised_dataset = self.to_primitive()
         serialised_dataset["files"] = sorted(datafile.cloud_path for datafile in self.files)
         del serialised_dataset["path"]
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -218,7 +218,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         :param str cloud_path:
         :return None:
         """
-        serialised_dataset = self.to_primitive()
+        serialised_dataset = self.to_primitives()
         serialised_dataset["files"] = sorted(datafile.cloud_path for datafile in self.files)
         del serialised_dataset["path"]
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -218,7 +218,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         :param str cloud_path:
         :return None:
         """
-        serialised_dataset = self.to_primitives()
+        serialised_dataset = self.to_primitive()
         serialised_dataset["files"] = sorted(datafile.cloud_path for datafile in self.files)
         del serialised_dataset["path"]
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -114,7 +114,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
             else:
                 datasets.append(dataset.absolute_path)
 
-        serialised_manifest = self.serialise()
+        serialised_manifest = self.to_primitive()
         serialised_manifest["datasets"] = sorted(datasets)
         del serialised_manifest["path"]
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -114,7 +114,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
             else:
                 datasets.append(dataset.absolute_path)
 
-        serialised_manifest = self.to_primitive()
+        serialised_manifest = self.to_primitives()
         serialised_manifest["datasets"] = sorted(datasets)
         del serialised_manifest["path"]
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -114,7 +114,7 @@ class Manifest(Pathable, Serialisable, Loggable, Identifiable, Hashable):
             else:
                 datasets.append(dataset.absolute_path)
 
-        serialised_manifest = self.to_primitives()
+        serialised_manifest = self.to_primitive()
         serialised_manifest["datasets"] = sorted(datasets)
         del serialised_manifest["path"]
 

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -44,7 +44,7 @@ class TagDict(Serialisable, UserDict):
                     f"must not start with '_'."
                 )
 
-    def to_primitive(self, **kwargs):
+    def to_primitives(self, **kwargs):
         """Serialise a TagDict to a JSON dictionary or string.
 
         :param bool to_string:

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -44,11 +44,9 @@ class TagDict(Serialisable, UserDict):
                     f"must not start with '_'."
                 )
 
-    def to_primitive(self, **kwargs):
-        """Serialise a TagDict to a JSON dictionary or string.
+    def serialise(self, **kwargs):
+        """Serialise a TagDict to a JSON string.
 
-        :param bool to_string:
-        :return str|dict:
+        :return str:
         """
-        string = json.dumps(self.data, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
-        return json.loads(string)
+        return json.dumps(self.data, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -44,15 +44,11 @@ class TagDict(Serialisable, UserDict):
                     f"must not start with '_'."
                 )
 
-    def serialise(self, to_string=False, **kwargs):
+    def to_primitive(self, **kwargs):
         """Serialise a TagDict to a JSON dictionary or string.
 
         :param bool to_string:
         :return str|dict:
         """
         string = json.dumps(self.data, cls=OctueJSONEncoder, sort_keys=True, indent=4, **kwargs)
-
-        if to_string:
-            return string
-
         return json.loads(string)

--- a/octue/resources/tag.py
+++ b/octue/resources/tag.py
@@ -44,7 +44,7 @@ class TagDict(Serialisable, UserDict):
                     f"must not start with '_'."
                 )
 
-    def to_primitives(self, **kwargs):
+    def to_primitive(self, **kwargs):
         """Serialise a TagDict to a JSON dictionary or string.
 
         :param bool to_string:

--- a/octue/utils/encoders.py
+++ b/octue/utils/encoders.py
@@ -5,13 +5,13 @@ from twined.utils import TwinedEncoder
 
 
 class OctueJSONEncoder(TwinedEncoder):
-    """A JSON Encoder which allows objects having a `to_primitives` method to control their own conversion to primitives."""
+    """A JSON Encoder which allows objects having a `to_primitive` method to control their own conversion to primitives."""
 
     def default(self, obj):
 
-        # If the class defines a `to_primitives` method, use it.
-        if hasattr(obj, "to_primitives"):
-            return obj.to_primitives()
+        # If the class defines a `to_primitive` method, use it.
+        if hasattr(obj, "to_primitive"):
+            return obj.to_primitive()
 
         # Convert sets to sorted lists (JSON doesn't support sets).
         if isinstance(obj, set):

--- a/octue/utils/encoders.py
+++ b/octue/utils/encoders.py
@@ -5,13 +5,13 @@ from twined.utils import TwinedEncoder
 
 
 class OctueJSONEncoder(TwinedEncoder):
-    """A JSON Encoder which allows objects having a `to_primitive` method to control their own conversion to primitives."""
+    """A JSON Encoder which allows objects having a `to_primitives` method to control their own conversion to primitives."""
 
     def default(self, obj):
 
-        # If the class defines a `to_primitive` method, use it.
-        if hasattr(obj, "to_primitive"):
-            return obj.to_primitive()
+        # If the class defines a `to_primitives` method, use it.
+        if hasattr(obj, "to_primitives"):
+            return obj.to_primitives()
 
         # Convert sets to sorted lists (JSON doesn't support sets).
         if isinstance(obj, set):

--- a/octue/utils/encoders.py
+++ b/octue/utils/encoders.py
@@ -5,15 +5,15 @@ from twined.utils import TwinedEncoder
 
 
 class OctueJSONEncoder(TwinedEncoder):
-    """A JSON Encoder which allows objects having a `serialise()` method to control their own conversion to primitives."""
+    """A JSON Encoder which allows objects having a `to_primitive` method to control their own conversion to primitives."""
 
     def default(self, obj):
 
-        # If the class defines a serialise() method then use it
-        if hasattr(obj, "serialise"):
-            return obj.serialise()
+        # If the class defines a `to_primitive` method, use it.
+        if hasattr(obj, "to_primitive"):
+            return obj.to_primitive()
 
-        # Serialise sets as sorted list (JSON doesn't support sets).
+        # Convert sets to sorted lists (JSON doesn't support sets).
         if isinstance(obj, set):
             return {"_type": "set", "items": sorted(obj)}
 
@@ -23,5 +23,5 @@ class OctueJSONEncoder(TwinedEncoder):
         if isinstance(obj, datetime.datetime):
             return {"_type": "datetime", "value": obj.isoformat()}
 
-        # Otherwise let the base class default method raise the TypeError
+        # Otherwise let the base class default method raise the TypeError.
         return TwinedEncoder.default(self, obj)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.16",
+    version="0.3.17",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -245,7 +245,7 @@ class MockService(Service):
         # Ignore any errors from the answering service as they will be raised on the remote service in practice, not
         # locally as is done in this mock.
         if input_manifest is not None:
-            input_manifest = input_manifest.serialise(to_string=True)
+            input_manifest = input_manifest.serialise()
 
         try:
             self.children[service_id].answer(

--- a/tests/mixins/test_serialisable.py
+++ b/tests/mixins/test_serialisable.py
@@ -38,7 +38,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_returns_primitive_without_logger_or_protected_fields(self):
         """Ensures class instantiates with a UUID()"""
         resource = Inherit()
-        serialised = resource.serialise()
+        serialised = resource.to_primitive()
         self.assertTrue("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
         self.assertFalse("logger" in serialised.keys())
@@ -47,7 +47,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_serialise_only_attrs(self):
         """Restricts the id field, which would normally be serialised"""
         resource = InheritWithFieldsToSerialise()
-        serialised = resource.serialise()
+        serialised = resource.to_primitive()
         self.assertFalse("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
         self.assertFalse("logger" in serialised.keys())
@@ -56,7 +56,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_serialise_to_string(self):
         """Restricts the id field, which would normally be serialised"""
         resource = InheritWithFieldsToSerialise()
-        serialised = resource.serialise(to_string=True)
+        serialised = resource.serialise()
         self.assertIsInstance(serialised, str)
 
     def test_serialise_to_file(self):

--- a/tests/mixins/test_serialisable.py
+++ b/tests/mixins/test_serialisable.py
@@ -38,7 +38,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_returns_primitive_without_logger_or_protected_fields(self):
         """Ensures class instantiates with a UUID()"""
         resource = Inherit()
-        serialised = resource.to_primitive()
+        serialised = resource.to_primitives()
         self.assertTrue("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
         self.assertFalse("logger" in serialised.keys())
@@ -47,7 +47,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_serialise_only_attrs(self):
         """Restricts the id field, which would normally be serialised"""
         resource = InheritWithFieldsToSerialise()
-        serialised = resource.to_primitive()
+        serialised = resource.to_primitives()
         self.assertFalse("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
         self.assertFalse("logger" in serialised.keys())

--- a/tests/mixins/test_serialisable.py
+++ b/tests/mixins/test_serialisable.py
@@ -38,7 +38,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_returns_primitive_without_logger_or_protected_fields(self):
         """Ensures class instantiates with a UUID()"""
         resource = Inherit()
-        serialised = resource.to_primitives()
+        serialised = resource.to_primitive()
         self.assertTrue("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
         self.assertFalse("logger" in serialised.keys())
@@ -47,7 +47,7 @@ class SerialisableTestCase(BaseTestCase):
     def test_serialise_only_attrs(self):
         """Restricts the id field, which would normally be serialised"""
         resource = InheritWithFieldsToSerialise()
-        serialised = resource.to_primitives()
+        serialised = resource.to_primitive()
         self.assertFalse("id" in serialised.keys())
         self.assertTrue("field_to_serialise" in serialised.keys())
         self.assertFalse("logger" in serialised.keys())

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -724,3 +724,22 @@ class DatafileTestCase(BaseTestCase):
         datafile = Datafile(path="local_file.txt")
         self.assertIsNone(datafile.bucket_name)
         self.assertIsNone(datafile.path_in_bucket)
+
+    def test_datafiles_with_space_in_name_can_be_uploaded_downloaded_serialized_and_deserialized(self):
+        """Test that a datafile with a space in its name can be uploaded, downloaded, serialized, and deserialized."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            local_path = os.path.join(temporary_directory, "name with spaces.txt")
+
+            with open(local_path, "w") as f:
+                f.write("blah")
+
+            datafile = Datafile(path=local_path)
+
+            serialized_datafile = datafile.serialise()
+            deserialized_datafile = Datafile.deserialise(serialized_datafile)
+            self.assertEqual(deserialized_datafile.name, "name with spaces.txt")
+
+            datafile.to_cloud(project_name="blah", cloud_path=f"gs://{TEST_BUCKET_NAME}/name with spaces.txt")
+
+        downloaded_datafile = Datafile(project_name="blah", path=f"gs://{TEST_BUCKET_NAME}/name with spaces.txt")
+        self.assertEqual(downloaded_datafile.name, "name with spaces.txt")

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -135,7 +135,7 @@ class DatafileTestCase(BaseTestCase):
 
     def test_serialisable(self):
         """Ensure datafiles can be serialised to JSON."""
-        serialised_datafile = self.create_valid_datafile().to_primitives()
+        serialised_datafile = self.create_valid_datafile().to_primitive()
 
         expected_fields = {
             "id",
@@ -442,7 +442,7 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("hello")
 
         datafile = Datafile(path=temporary_file.name)
-        serialised_datafile = datafile.to_primitives()
+        serialised_datafile = datafile.to_primitive()
         deserialised_datafile = Datafile.deserialise(serialised_datafile)
 
         self.assertEqual(datafile.id, deserialised_datafile.id)
@@ -459,7 +459,7 @@ class DatafileTestCase(BaseTestCase):
 
         filename = os.path.split(temporary_file.name)[-1]
         datafile = Datafile(path=filename)
-        serialised_datafile = datafile.to_primitives()
+        serialised_datafile = datafile.to_primitive()
 
         pathable = Pathable(path=os.path.join(os.sep, "an", "absolute", "path"))
         deserialised_datafile = Datafile.deserialise(serialised_datafile, path_from=pathable)
@@ -475,7 +475,7 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("hello")
 
         datafile = Datafile(path=temporary_file.name)
-        serialised_datafile = datafile.to_primitives()
+        serialised_datafile = datafile.to_primitive()
 
         pathable = Pathable(path=os.path.join(os.sep, "an", "absolute", "path"))
         deserialised_datafile = Datafile.deserialise(serialised_datafile, path_from=pathable)
@@ -735,7 +735,7 @@ class DatafileTestCase(BaseTestCase):
 
             datafile = Datafile(path=local_path)
 
-            serialized_datafile = datafile.to_primitives()
+            serialized_datafile = datafile.to_primitive()
             deserialized_datafile = Datafile.deserialise(serialized_datafile)
             self.assertEqual(deserialized_datafile.name, "name with spaces.txt")
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -135,7 +135,7 @@ class DatafileTestCase(BaseTestCase):
 
     def test_serialisable(self):
         """Ensure datafiles can be serialised to JSON."""
-        serialised_datafile = self.create_valid_datafile().serialise()
+        serialised_datafile = self.create_valid_datafile().to_primitive()
 
         expected_fields = {
             "id",
@@ -442,7 +442,7 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("hello")
 
         datafile = Datafile(path=temporary_file.name)
-        serialised_datafile = datafile.serialise()
+        serialised_datafile = datafile.to_primitive()
         deserialised_datafile = Datafile.deserialise(serialised_datafile)
 
         self.assertEqual(datafile.id, deserialised_datafile.id)
@@ -459,7 +459,7 @@ class DatafileTestCase(BaseTestCase):
 
         filename = os.path.split(temporary_file.name)[-1]
         datafile = Datafile(path=filename)
-        serialised_datafile = datafile.serialise()
+        serialised_datafile = datafile.to_primitive()
 
         pathable = Pathable(path=os.path.join(os.sep, "an", "absolute", "path"))
         deserialised_datafile = Datafile.deserialise(serialised_datafile, path_from=pathable)
@@ -475,7 +475,7 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("hello")
 
         datafile = Datafile(path=temporary_file.name)
-        serialised_datafile = datafile.serialise()
+        serialised_datafile = datafile.to_primitive()
 
         pathable = Pathable(path=os.path.join(os.sep, "an", "absolute", "path"))
         deserialised_datafile = Datafile.deserialise(serialised_datafile, path_from=pathable)
@@ -735,7 +735,7 @@ class DatafileTestCase(BaseTestCase):
 
             datafile = Datafile(path=local_path)
 
-            serialized_datafile = datafile.serialise()
+            serialized_datafile = datafile.to_primitive()
             deserialized_datafile = Datafile.deserialise(serialized_datafile)
             self.assertEqual(deserialized_datafile.name, "name with spaces.txt")
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -135,7 +135,7 @@ class DatafileTestCase(BaseTestCase):
 
     def test_serialisable(self):
         """Ensure datafiles can be serialised to JSON."""
-        serialised_datafile = self.create_valid_datafile().to_primitive()
+        serialised_datafile = self.create_valid_datafile().to_primitives()
 
         expected_fields = {
             "id",
@@ -442,7 +442,7 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("hello")
 
         datafile = Datafile(path=temporary_file.name)
-        serialised_datafile = datafile.to_primitive()
+        serialised_datafile = datafile.to_primitives()
         deserialised_datafile = Datafile.deserialise(serialised_datafile)
 
         self.assertEqual(datafile.id, deserialised_datafile.id)
@@ -459,7 +459,7 @@ class DatafileTestCase(BaseTestCase):
 
         filename = os.path.split(temporary_file.name)[-1]
         datafile = Datafile(path=filename)
-        serialised_datafile = datafile.to_primitive()
+        serialised_datafile = datafile.to_primitives()
 
         pathable = Pathable(path=os.path.join(os.sep, "an", "absolute", "path"))
         deserialised_datafile = Datafile.deserialise(serialised_datafile, path_from=pathable)
@@ -475,7 +475,7 @@ class DatafileTestCase(BaseTestCase):
             temporary_file.write("hello")
 
         datafile = Datafile(path=temporary_file.name)
-        serialised_datafile = datafile.to_primitive()
+        serialised_datafile = datafile.to_primitives()
 
         pathable = Pathable(path=os.path.join(os.sep, "an", "absolute", "path"))
         deserialised_datafile = Datafile.deserialise(serialised_datafile, path_from=pathable)
@@ -735,7 +735,7 @@ class DatafileTestCase(BaseTestCase):
 
             datafile = Datafile(path=local_path)
 
-            serialized_datafile = datafile.to_primitive()
+            serialized_datafile = datafile.to_primitives()
             deserialized_datafile = Datafile.deserialise(serialized_datafile)
             self.assertEqual(deserialized_datafile.name, "name with spaces.txt")
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -242,7 +242,7 @@ class DatasetTestCase(BaseTestCase):
     def test_serialise(self):
         """Test that a dataset can be serialised."""
         dataset = self.create_valid_dataset()
-        self.assertEqual(len(dataset.serialise()["files"]), 2)
+        self.assertEqual(len(dataset.to_primitive()["files"]), 2)
 
     def test_exists_in_cloud(self):
         """Test whether all files of a dataset are in the cloud or not can be determined."""
@@ -339,7 +339,7 @@ class DatasetTestCase(BaseTestCase):
             self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/my_dataset/{file.name}")
 
         # Test serialisation doesn't lose any information.
-        deserialised_dataset = Dataset.deserialise(cloud_dataset.serialise())
+        deserialised_dataset = Dataset.deserialise(cloud_dataset.to_primitive())
         self.assertEqual(deserialised_dataset.id, cloud_dataset.id)
         self.assertEqual(deserialised_dataset.name, cloud_dataset.name)
         self.assertEqual(deserialised_dataset.path, cloud_dataset.path)
@@ -429,7 +429,7 @@ class DatasetTestCase(BaseTestCase):
                     ],
                 )
 
-                self.assertEqual(persisted_dataset["tags"], dataset.tags.serialise())
+                self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitive())
 
     def test_download_all_files(self):
         """Test that all files in a dataset can be downloaded with one command."""

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -242,7 +242,7 @@ class DatasetTestCase(BaseTestCase):
     def test_serialise(self):
         """Test that a dataset can be serialised."""
         dataset = self.create_valid_dataset()
-        self.assertEqual(len(dataset.to_primitive()["files"]), 2)
+        self.assertEqual(len(dataset.to_primitives()["files"]), 2)
 
     def test_exists_in_cloud(self):
         """Test whether all files of a dataset are in the cloud or not can be determined."""
@@ -339,7 +339,7 @@ class DatasetTestCase(BaseTestCase):
             self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/my_dataset/{file.name}")
 
         # Test serialisation doesn't lose any information.
-        deserialised_dataset = Dataset.deserialise(cloud_dataset.to_primitive())
+        deserialised_dataset = Dataset.deserialise(cloud_dataset.to_primitives())
         self.assertEqual(deserialised_dataset.id, cloud_dataset.id)
         self.assertEqual(deserialised_dataset.name, cloud_dataset.name)
         self.assertEqual(deserialised_dataset.path, cloud_dataset.path)
@@ -429,7 +429,7 @@ class DatasetTestCase(BaseTestCase):
                     ],
                 )
 
-                self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitive())
+                self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitives())
 
     def test_download_all_files(self):
         """Test that all files in a dataset can be downloaded with one command."""

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -242,7 +242,7 @@ class DatasetTestCase(BaseTestCase):
     def test_serialise(self):
         """Test that a dataset can be serialised."""
         dataset = self.create_valid_dataset()
-        self.assertEqual(len(dataset.to_primitives()["files"]), 2)
+        self.assertEqual(len(dataset.to_primitive()["files"]), 2)
 
     def test_exists_in_cloud(self):
         """Test whether all files of a dataset are in the cloud or not can be determined."""
@@ -339,7 +339,7 @@ class DatasetTestCase(BaseTestCase):
             self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/my_dataset/{file.name}")
 
         # Test serialisation doesn't lose any information.
-        deserialised_dataset = Dataset.deserialise(cloud_dataset.to_primitives())
+        deserialised_dataset = Dataset.deserialise(cloud_dataset.to_primitive())
         self.assertEqual(deserialised_dataset.id, cloud_dataset.id)
         self.assertEqual(deserialised_dataset.name, cloud_dataset.name)
         self.assertEqual(deserialised_dataset.path, cloud_dataset.path)
@@ -429,7 +429,7 @@ class DatasetTestCase(BaseTestCase):
                     ],
                 )
 
-                self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitives())
+                self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitive())
 
     def test_download_all_files(self):
         """Test that all files in a dataset can be downloaded with one command."""

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -40,7 +40,7 @@ class TestManifest(BaseTestCase):
     def test_deserialise(self):
         """Test that manifests can be deserialised."""
         manifest = self.create_valid_manifest()
-        serialised_manifest = manifest.serialise()
+        serialised_manifest = manifest.to_primitive()
         deserialised_manifest = Manifest.deserialise(serialised_manifest)
 
         self.assertEqual(manifest.name, deserialised_manifest.name)
@@ -205,7 +205,7 @@ class TestManifest(BaseTestCase):
         serialised_cloud_dataset = Dataset.from_cloud(
             project_name=TEST_PROJECT_NAME,
             cloud_path=f"gs://{TEST_BUCKET_NAME}/my_dataset",
-        ).serialise()
+        ).to_primitive()
 
         manifest = Manifest(datasets=[serialised_cloud_dataset], keys={"my_dataset": 0})
         self.assertEqual(len(manifest.datasets), 1)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -40,7 +40,7 @@ class TestManifest(BaseTestCase):
     def test_deserialise(self):
         """Test that manifests can be deserialised."""
         manifest = self.create_valid_manifest()
-        serialised_manifest = manifest.to_primitives()
+        serialised_manifest = manifest.to_primitive()
         deserialised_manifest = Manifest.deserialise(serialised_manifest)
 
         self.assertEqual(manifest.name, deserialised_manifest.name)
@@ -205,7 +205,7 @@ class TestManifest(BaseTestCase):
         serialised_cloud_dataset = Dataset.from_cloud(
             project_name=TEST_PROJECT_NAME,
             cloud_path=f"gs://{TEST_BUCKET_NAME}/my_dataset",
-        ).to_primitives()
+        ).to_primitive()
 
         manifest = Manifest(datasets=[serialised_cloud_dataset], keys={"my_dataset": 0})
         self.assertEqual(len(manifest.datasets), 1)

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -40,7 +40,7 @@ class TestManifest(BaseTestCase):
     def test_deserialise(self):
         """Test that manifests can be deserialised."""
         manifest = self.create_valid_manifest()
-        serialised_manifest = manifest.to_primitive()
+        serialised_manifest = manifest.to_primitives()
         deserialised_manifest = Manifest.deserialise(serialised_manifest)
 
         self.assertEqual(manifest.name, deserialised_manifest.name)
@@ -205,7 +205,7 @@ class TestManifest(BaseTestCase):
         serialised_cloud_dataset = Dataset.from_cloud(
             project_name=TEST_PROJECT_NAME,
             cloud_path=f"gs://{TEST_BUCKET_NAME}/my_dataset",
-        ).to_primitive()
+        ).to_primitives()
 
         manifest = Manifest(datasets=[serialised_cloud_dataset], keys={"my_dataset": 0})
         self.assertEqual(len(manifest.datasets), 1)


### PR DESCRIPTION
## Summary
Clarify the interface for serialising `Serialisable` instances. Serialising now clearly means converting instances to a string, while a new `to_primitive` method converts instances to a dictionary of python primitives.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Refactoring
- [x] Only allow `Serialisable.serialise` to serialise to strings
- [x] Factor new `Serialisable.to_primitive` method out from `Serialisable.serialise` and use it to replace previous usages of `Serialisable.serialise(to_string=False)`

### Operations
- [x] Allow `test` branch prefix and remove the old `release` prefix

### Testing
- [x] Test datafiles with spaces in name work as expected

<!--- END AUTOGENERATED NOTES --->