### PR TITLE
Ensure bullet points render in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 
 # Required by the python script for building documentation
 Sphinx>=2,<3
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==1.0.0
 sphinx-tabs==1.2.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx_rtd_theme"]
+extensions = ["sphinx_rtd_theme", "sphinx_tabs"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["sphinx_rtd_theme"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.17",
+    version="0.3.18",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary
Ensure bullet points render in docs. The problem may have been one of the things listed in [here](https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file). Note that some Chromium-based browsers still aren't rendering the bullet points, but Safari now is.

<!--- START AUTOGENERATED NOTES --->
## Contents

### Fixes
- [x] Explicitly add `sphinx-tabs` and `sphinx-rtd-theme` to `sphinx` extensions in `conf.py`

### Dependencies
- [x] Use latest `sphinx-rtd-theme` for docs

<!--- END AUTOGENERATED NOTES --->