### PR TITLE
Fix mkver.conf so suggested semantic version stays under 1.0.0

### DIFF
--- a/mkver.conf
+++ b/mkver.conf
@@ -25,7 +25,11 @@ patches: [
 commitMessageActions: [
   # Disable major version increments while package is still in beta (i.e. keep the version below 1.0.0).
   {
-    pattern: "BREAKING CHANGE|BREAKING-CHANGE"
+    pattern: "BREAKING CHANGE"
+    action: IncrementMinor
+  }
+  {
+    pattern: "BREAKING-CHANGE"
     action: IncrementMinor
   }
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.19",
+    version="0.3.20",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents

### Operations
- [x] Fix `mkver.conf` so the semantic version suggested by `git-mkver` stays under `1.0.0`

<!--- END AUTOGENERATED NOTES --->

Thanks to @idc101 [for this solution](https://github.com/idc101/git-mkver/issues/20)!