### PR TITLE
Add option to not show cloud directories as blobs in scandir

### DIFF
--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -211,7 +211,9 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         """
         for datafile in self.files:
             if local_directory:
-                local_path = os.path.abspath(os.path.join(local_directory, datafile.name))
+                local_path = os.path.abspath(
+                    os.path.join(local_directory, *datafile.cloud_path.split(self.name + "/")[1:])
+                )
             else:
                 local_path = None
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -61,7 +61,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         cloud_path=None,
         bucket_name=None,
         path_to_dataset_directory=None,
-        include_subdirectories=False,
+        recursive=False,
     ):
         """Instantiate a Dataset from Google Cloud storage. Either (`bucket_name` and `path_to_dataset_directory`) or
         `cloud_path` must be provided.
@@ -70,7 +70,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         :param str|None cloud_path: full path to dataset in cloud storage (e.g. `gs://bucket_name/path/to/dataset`)
         :param str|None bucket_name: name of bucket dataset is stored in
         :param str|None path_to_dataset_directory: path to dataset directory (containing dataset's files) in cloud (e.g. `path/to/dataset`)
-        :param bool include_subdirectories: if `True`, include in the dataset all files in the subdirectories recursively contained in the dataset directory
+        :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained in the dataset directory
         :return Dataset:
         """
         if cloud_path:
@@ -104,9 +104,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
                 path=storage.path.generate_gs_path(bucket_name, blob.name),
                 project_name=project_name,
             )
-            for blob in GoogleCloudStorageClient(project_name=project_name).scandir(
-                cloud_path, recursive=include_subdirectories
-            )
+            for blob in GoogleCloudStorageClient(project_name=project_name).scandir(cloud_path, recursive=recursive)
         )
 
         dataset = Dataset(path=cloud_path, files=datafiles)

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -211,9 +211,8 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         """
         for datafile in self.files:
             if local_directory:
-                local_path = os.path.abspath(
-                    os.path.join(local_directory, *datafile.cloud_path.split(self.name + "/")[1:])
-                )
+                path_relative_to_dataset = datafile.cloud_path.split(self.name + "/")[1]
+                local_path = os.path.abspath(os.path.join(local_directory, *path_relative_to_dataset.split("/")))
             else:
                 local_path = None
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -105,7 +105,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
                 project_name=project_name,
             )
             for blob in GoogleCloudStorageClient(project_name=project_name).scandir(
-                cloud_path, include_subdirectories=include_subdirectories
+                cloud_path, recursive=include_subdirectories
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.3.21",
+    version="0.4.0",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import unittest
 import uuid
+import warnings
 from tempfile import TemporaryDirectory, gettempdir
 
 from octue.cloud.emulators import GoogleCloudStorageEmulatorTestResultModifier
@@ -28,6 +29,11 @@ class BaseTestCase(unittest.TestCase):
         root_dir = os.path.dirname(os.path.abspath(__file__))
         self.data_path = os.path.join(root_dir, "data")
         self.templates_path = os.path.join(os.path.dirname(root_dir), "octue", "templates")
+
+        # Make unittest ignore excess ResourceWarnings so tests' console outputs are clearer. This has to be done even
+        # if these warnings are ignored elsewhere as unittest forces warnings to be displayed by default.
+        warnings.simplefilter("ignore", category=ResourceWarning)
+
         super().setUp()
 
     def callCli(self, args):

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -235,9 +235,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         )
 
         contents = list(
-            self.storage_client.scandir(
-                bucket_name=TEST_BUCKET_NAME, directory_path=directory_path, include_subdirectories=False
-            )
+            self.storage_client.scandir(bucket_name=TEST_BUCKET_NAME, directory_path=directory_path, recursive=False)
         )
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[0].name, storage.path.join(directory_path, self.FILENAME))

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -491,17 +491,16 @@ class TestDataset(BaseTestCase):
         """Test that all files in a dataset can be downloaded with one command."""
         storage_client = GoogleCloudStorageClient(project_name=TEST_PROJECT_NAME)
 
-        file_0_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "file_0.txt")
-        storage_client.upload_from_string(string=json.dumps([1, 2, 3]), cloud_path=file_0_path)
+        dataset_name = "another-dataset"
+        storage_client.upload_from_string(
+            string=json.dumps([1, 2, 3]), bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/file_0.txt"
+        )
+        storage_client.upload_from_string(
+            string=json.dumps([4, 5, 6]), bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/file_1.txt"
+        )
 
-        file_1_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "file_1.txt")
-        storage_client.upload_from_string(string=json.dumps([4, 5, 6]), cloud_path=file_1_path)
-
-        dataset = Dataset(
-            files={
-                Datafile(path=file_0_path, project_name=TEST_PROJECT_NAME, labels={"hello"}, tags={"a": "b"}),
-                Datafile(path=file_1_path, project_name=TEST_PROJECT_NAME, labels={"goodbye"}, tags={"a": "c"}),
-            },
+        dataset = Dataset.from_cloud(
+            project_name=TEST_PROJECT_NAME, cloud_path=f"gs://{TEST_BUCKET_NAME}/{dataset_name}"
         )
 
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -513,7 +512,7 @@ class TestDataset(BaseTestCase):
             with open(os.path.join(temporary_directory, "file_1.txt")) as f:
                 self.assertEqual(f.read(), "[4, 5, 6]")
 
-    def test_download_all_files_from_recursive_dataset(self):
+    def test_download_all_files_from_nested_dataset(self):
         """Test that all files in a nested dataset can be downloaded with one command."""
         self._create_nested_cloud_dataset("nested_dataset")
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -391,7 +391,7 @@ class DatasetTestCase(BaseTestCase):
         cloud_dataset = Dataset.from_cloud(
             project_name=TEST_PROJECT_NAME,
             cloud_path=f"gs://{TEST_BUCKET_NAME}/a_dataset",
-            include_subdirectories=True,
+            recursive=True,
         )
 
         self.assertEqual(cloud_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_dataset")


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Enhancements
- [x] **BREAKING CHANGE:** Add option to not show cloud directories as blobs in `GoogleCloudStorageClient.scandir` 

### Fixes
- [x] Ensure nested datasets' structures are preserved on download

### Refactoring
- [x] Clarify `Dataset.download_all_files`
- [x] **BREAKING CHANGE:** Rename `Dataset.from_cloud` parameter 

### Testing
- [x] Make unittest ignore `ResourceWarnings` for clearer test output

<!--- END AUTOGENERATED NOTES --->