### PR TITLE
Define Analysis attributes explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.4.1",
+    version="0.4.2",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,4 +1,4 @@
-from octue.resources.analysis import _HASH_FUNCTIONS, Analysis
+from octue.resources.analysis import HASH_FUNCTIONS, Analysis
 from twined import Twine
 from ..base import BaseTestCase
 
@@ -27,7 +27,7 @@ class AnalysisTestCase(BaseTestCase):
     def test_analysis_hash_attributes_are_none_when_no_relevant_strands(self):
         """Ensures that the hash attributes of Analysis instances are None if none of the relevant strands are provided"""
         analysis = Analysis(twine="{}")
-        for strand_name in _HASH_FUNCTIONS:
+        for strand_name in HASH_FUNCTIONS:
             self.assertIsNone(getattr(analysis, f"{strand_name}_hash"))
 
     def test_analysis_hash_attributes_are_populated_when_relevant_strands_are_present(self):
@@ -40,7 +40,7 @@ class AnalysisTestCase(BaseTestCase):
             input_manifest=self.create_valid_manifest(),
         )
 
-        for strand_name in _HASH_FUNCTIONS:
+        for strand_name in HASH_FUNCTIONS:
             hash_ = getattr(analysis, f"{strand_name}_hash")
             self.assertTrue(isinstance(hash_, str))
             self.assertTrue(len(hash_) == 8)


### PR DESCRIPTION
## Summary
Explicitly define `Analysis` attributes so that code introspection tools can more easily detect their existence. This is useful for developers and general transparency/readability of the class interface.

<!--- START AUTOGENERATED NOTES --->
## Contents

### Refactoring
- Define `Analysis` attributes explicitly in constructor rather than implicitly using a `for` loop and `setattr`

<!--- END AUTOGENERATED NOTES --->