### PR TITLE
Ensure MissingServiceID error is raised when appropriate

### DIFF
--- a/octue/cloud/deployment/google/cloud_run.py
+++ b/octue/cloud/deployment/google/cloud_run.py
@@ -61,6 +61,14 @@ def answer_question(project_name, question, credentials_environment_variable=Non
     """
     service_id = os.environ.get("SERVICE_ID")
 
+    if not service_id:
+        raise MissingServiceID(
+            "The ID for the deployed service is missing or empty - ensure SERVICE_ID is available as an environment "
+            "variable."
+        )
+
+    question_uuid = question["attributes"]["question_uuid"]
+
     service = Service(
         service_id=service_id,
         backend=GCPPubSubBackend(
@@ -68,15 +76,7 @@ def answer_question(project_name, question, credentials_environment_variable=Non
         ),
     )
 
-    question_uuid = question["attributes"]["question_uuid"]
-
     try:
-        if not service_id:
-            raise MissingServiceID(
-                "The ID for the deployed service is missing - ensure SERVICE_ID is available as an environment "
-                "variable."
-            )
-
         deployment_configuration = _get_deployment_configuration(DEPLOYMENT_CONFIGURATION_PATH)
 
         runner = Runner(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.4.6",
+    version="0.4.7",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/deployment/google/test_cloud_run.py
+++ b/tests/cloud/deployment/google/test_cloud_run.py
@@ -9,6 +9,7 @@ from unittest import TestCase, mock
 import twined.exceptions
 from octue.cloud.deployment.google import cloud_run
 from octue.cloud.pub_sub.service import Service
+from octue.exceptions import MissingServiceID
 from octue.resources.service_backends import GCPPubSubBackend
 from tests.cloud.pub_sub.mocks import MockTopic
 
@@ -54,6 +55,31 @@ class TestCloudRun(TestCase):
                 )
 
                 self.assertEqual(response.status_code, 204)
+
+    def test_error_raised_when_no_service_id_environment_variable(self):
+        """Test that a MissingServiceID error is raised if the SERVICE_ID environment variable is missing."""
+        with self.assertRaises(MissingServiceID):
+            cloud_run.answer_question(
+                project_name="a-project-name",
+                question={
+                    "data": {},
+                    "attributes": {"question_uuid": "8c859f87-b594-4297-883f-cd1c7718ef29"},
+                },
+                credentials_environment_variable="GOOGLE_APPLICATION_CREDENTIALS",
+            )
+
+    def test_error_raised_when_service_id_environment_variable_is_empty(self):
+        """Test that a MissingServiceID error is raised if the SERVICE_ID environment variable is empty."""
+        with mock.patch.dict(os.environ, {"SERVICE_ID": ""}):
+            with self.assertRaises(MissingServiceID):
+                cloud_run.answer_question(
+                    project_name="a-project-name",
+                    question={
+                        "data": {},
+                        "attributes": {"question_uuid": "8c859f87-b594-4297-883f-cd1c7718ef29"},
+                    },
+                    credentials_environment_variable="GOOGLE_APPLICATION_CREDENTIALS",
+                )
 
     def test_with_no_deployment_configuration_file(self):
         """Test that the Cloud Run `answer_question` function uses the default deployment values when a deployment


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Fixes
- Ensure `MissingServiceID` error is raised when the `SERVICE_ID` environment variable is empty or missing on deployed services

<!--- END AUTOGENERATED NOTES --->