### PR TITLE
Retry topic existence check if it initially fails

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -221,7 +221,8 @@ class Service(CoolNameable):
                 )
 
         question_topic = Topic(name=service_id, namespace=OCTUE_NAMESPACE, service=self)
-        if not question_topic.exists():
+
+        if not question_topic.exists(timeout=timeout):
             raise octue.exceptions.ServiceNotFound(f"Service with ID {service_id!r} cannot be found.")
 
         question_uuid = str(uuid.uuid4())

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import google.api_core.exceptions
 
 
@@ -57,16 +58,22 @@ class Topic:
         self.service.publisher.delete_topic(topic=self.path)
         logger.debug("%r deleted topic %r.", self.service, self.path)
 
-    def exists(self):
+    def exists(self, timeout=10):
         """Check if the topic exists on the Google Pub/Sub servers.
 
+        :param float timeout:
         :return bool:
         """
-        try:
-            self.service.publisher.get_topic(topic=self.path)
-        except google.api_core.exceptions.NotFound:
-            return False
-        return True
+        start_time = time.time()
+
+        while time.time() - start_time <= timeout:
+            try:
+                self.service.publisher.get_topic(topic=self.path)
+                return True
+            except google.api_core.exceptions.NotFound:
+                pass
+
+        return False
 
     def _log_creation(self):
         """Log the creation of the topic.

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -71,7 +71,7 @@ class Topic:
                 self.service.publisher.get_topic(topic=self.path)
                 return True
             except google.api_core.exceptions.NotFound:
-                pass
+                time.sleep(1)
 
         return False
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.4.8",
+    version="0.4.9",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -50,9 +50,10 @@ class MockTopic(Topic):
         except KeyError:
             pass
 
-    def exists(self):
+    def exists(self, timeout=10):
         """Check if the topic exists in the global messages dictionary.
 
+        :param float timeout:
         :return bool:
         """
         return get_service_id(self.path) in MESSAGES

--- a/tests/cloud/pub_sub/test_topic.py
+++ b/tests/cloud/pub_sub/test_topic.py
@@ -52,3 +52,7 @@ class TestTopic(BaseTestCase):
             side_effect=google.api_core.exceptions.NotFound(""),
         ):
             self.assertFalse(self.topic.exists())
+
+    def test_exists_returns_false_if_timeout_exceeded(self):
+        """Test `Topic.exists` returns `False` if the timeout is exceeded."""
+        self.assertFalse(self.topic.exists(timeout=0))

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import time
 import unittest
 import uuid
 
@@ -142,7 +141,7 @@ class TemplateAppsTestCase(BaseTestCase):
                     twine=os.path.join(parent_service_path, "twine.json"),
                     children=test_children_path,
                 )
-                time.sleep(5)
+
                 analysis = runner.run(
                     input_values=os.path.join(parent_service_path, "data", "input", "values.json"),
                 )


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#276](https://github.com/octue/octue-sdk-python/pull/276))

### Fixes
- Retry topic existence check if it initially fails by adding timeout parameter

<!--- END AUTOGENERATED NOTES --->