### PR TITLE
Stop high number of retries of publishing answers when asker has timed out

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -277,7 +277,6 @@ class Service(CoolNameable):
 
             finally:
                 subscription.delete()
-                subscription.topic.delete()
 
     def send_exception_to_asker(self, topic, timeout=30):
         """Serialise and send the exception being handled to the asker.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.4.9",
+    version="0.4.10",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/test_subscription.py
+++ b/tests/cloud/pub_sub/test_subscription.py
@@ -79,3 +79,5 @@ class TestSubscription(BaseTestCase):
         self.assertEqual(response._pb.ack_deadline_seconds, 60)
         self.assertEqual(response._pb.expiration_policy.ttl.seconds, THIRTY_ONE_DAYS)
         self.assertEqual(response._pb.message_retention_duration.seconds, SEVEN_DAYS)
+        self.assertEqual(response._pb.retry_policy.minimum_backoff.seconds, 10)
+        self.assertEqual(response._pb.retry_policy.maximum_backoff.seconds, 600)


### PR DESCRIPTION
## Summary

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#277](https://github.com/octue/octue-sdk-python/pull/277))

### Enhancements
- Make subscription retry policy exponential and allow customisation

### Fixes
- Stop deleting question topic when stopping waiting for answer

<!--- END AUTOGENERATED NOTES --->