### PR TITLE
Allow getting Google Cloud credentials as a dictionary

### DIFF
--- a/octue/cloud/credentials.py
+++ b/octue/cloud/credentials.py
@@ -33,29 +33,48 @@ class GCPCredentialsManager:
             )
             self.service_account_json = None
 
-    def get_credentials(self):
+    def get_credentials(self, as_dict=False):
         """Get the Google OAUTH2 service account credentials.
 
-        :return google.auth.service_account.Credentials:
+        :param bool as_dict: if `True`, return the credentials as a dictionary
+        :return str|google.auth.service_account.Credentials:
         """
         if self.service_account_json is None:
             return None
 
         # Check that the environment variable refers to a real file.
         if os.path.exists(self.service_account_json):
-            return self._get_credentials_from_file()
+            return self._get_credentials_from_file(as_dict=as_dict)
 
         # If it doesn't, assume that it's the credentials file as a JSON string.
-        return self._get_credentials_from_string()
+        return self._get_credentials_from_string(as_dict=as_dict)
 
-    def _get_credentials_from_file(self):
+    def _get_credentials_from_file(self, as_dict=False):
+        """Get the credentials from the JSON file specified in the environment variable's value.
+
+        :param bool as_dict: if `True`, return the credentials as a dictionary
+        :return str|google.auth.service_account.Credentials:
+        """
         with open(self.service_account_json) as f:
             credentials = json.load(f)
 
         logger.debug("GCP credentials read from file.")
+
+        if as_dict:
+            return credentials
+
         return service_account.Credentials.from_service_account_info(credentials)
 
-    def _get_credentials_from_string(self):
+    def _get_credentials_from_string(self, as_dict=False):
+        """Get the credentials directly from the JSON string that is the environment variable's value.
+
+        :param bool as_dict: if `True`, return the credentials as a dictionary
+        :return str|google.auth.service_account.Credentials:
+        """
         credentials = json.loads(self.service_account_json)
         logger.debug("GCP credentials loaded from string.")
+
+        if as_dict:
+            return credentials
+
         return service_account.Credentials.from_service_account_info(credentials)

--- a/octue/cloud/credentials.py
+++ b/octue/cloud/credentials.py
@@ -37,7 +37,7 @@ class GCPCredentialsManager:
         """Get the Google OAUTH2 service account credentials.
 
         :param bool as_dict: if `True`, return the credentials as a dictionary
-        :return str|google.auth.service_account.Credentials|None:
+        :return dict|google.auth.service_account.Credentials|None:
         """
         if self.service_account_json is None:
             return None
@@ -50,10 +50,10 @@ class GCPCredentialsManager:
         return self._get_credentials_from_string(as_dict=as_dict)
 
     def _get_credentials_from_file(self, as_dict=False):
-        """Get the credentials from the JSON file specified in the environment variable's value.
+        """Get the credentials from the JSON file whose path is specified in the environment variable's value.
 
         :param bool as_dict: if `True`, return the credentials as a dictionary
-        :return str|google.auth.service_account.Credentials:
+        :return dict|google.auth.service_account.Credentials:
         """
         with open(self.service_account_json) as f:
             credentials = json.load(f)
@@ -66,10 +66,10 @@ class GCPCredentialsManager:
         return service_account.Credentials.from_service_account_info(credentials)
 
     def _get_credentials_from_string(self, as_dict=False):
-        """Get the credentials directly from the JSON string that is the environment variable's value.
+        """Get the credentials directly from the JSON string specified in the environment variable's value.
 
         :param bool as_dict: if `True`, return the credentials as a dictionary
-        :return str|google.auth.service_account.Credentials:
+        :return dict|google.auth.service_account.Credentials:
         """
         credentials = json.loads(self.service_account_json)
         logger.debug("GCP credentials loaded from string.")

--- a/octue/cloud/credentials.py
+++ b/octue/cloud/credentials.py
@@ -13,7 +13,7 @@ class GCPCredentialsManager:
     JSON string of the contents of such a service account file, from the given environment variable and instantiates
     a Google Cloud credentials object.
 
-    :param str environment_variable_name:
+    :param str|None environment_variable_name:
     :return None:
     """
 
@@ -37,7 +37,7 @@ class GCPCredentialsManager:
         """Get the Google OAUTH2 service account credentials.
 
         :param bool as_dict: if `True`, return the credentials as a dictionary
-        :return str|google.auth.service_account.Credentials:
+        :return str|google.auth.service_account.Credentials|None:
         """
         if self.service_account_json is None:
             return None

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.4.10",
+    version="0.4.11",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/test_credentials.py
+++ b/tests/cloud/test_credentials.py
@@ -1,3 +1,7 @@
+import json
+import os
+import tempfile
+from unittest.mock import patch
 import google.oauth2.service_account
 
 from octue.cloud.credentials import GCPCredentialsManager
@@ -6,11 +10,32 @@ from tests.base import BaseTestCase
 
 class TestGCPCredentialsManager(BaseTestCase):
     def test_warning_issued_if_no_environment_variable(self):
-        """ Ensure a warning is issued if the given environment variable can't be found. """
+        """Ensure a warning is issued if the given environment variable can't be found."""
         with self.assertWarns(Warning):
             GCPCredentialsManager(environment_variable_name="heeby_jeeby-11111-33103")
 
     def test_credentials_can_be_loaded_from_file(self):
-        """ Test that credentials can be loaded from the file at the path specified by the environment variable. """
+        """Test that credentials can be loaded from the file at the path specified by the environment variable."""
         credentials = GCPCredentialsManager().get_credentials()
         self.assertEqual(type(credentials), google.oauth2.service_account.Credentials)
+
+    def test_credentials_can_be_loaded_as_dictionary_from_string(self):
+        """Test that credentials can be loaded as a dictionary from a string-valued environment variable."""
+        with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": '{"blah": "nah"}'}):
+            credentials = GCPCredentialsManager().get_credentials(as_dict=True)
+            self.assertEqual(credentials, {"blah": "nah"})
+
+    def test_credentials_can_be_loaded_as_dictionary_from_file(self):
+        """Test that credentials can be loaded as a dictionary from a file."""
+        with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
+
+            with open(temporary_file.name, "w") as f:
+                json.dump({"blah": "nah"}, f)
+
+            with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": temporary_file.name}):
+                credentials = GCPCredentialsManager().get_credentials(as_dict=True)
+                self.assertEqual(credentials, {"blah": "nah"})
+
+    def test_credentials_are_none_when_environment_variable_name_is_none(self):
+        """Test that credentials are `None` when the given environment variable name is `None`."""
+        self.assertIsNone(GCPCredentialsManager(environment_variable_name=None).get_credentials())


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#278](https://github.com/octue/octue-sdk-python/pull/278))

### Enhancements
- Allow getting of Google Cloud credentials as a dictionary

### Operations
- Increase version number

### Testing
- Add more tests for GCPCredentialsManager

### Other
- Update docstrings

<!--- END AUTOGENERATED NOTES --->