### PR TITLE
Add question monitoring ability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
           - '^test/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/conventional-commits
-    rev: 0.2.1
+    rev: 0.5.0
     hooks:
       - id: check-commit-message-is-conventional
         stages: [commit-msg]

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -28,7 +28,12 @@ class OrderedMessageHandler:
     """
 
     def __init__(
-        self, subscriber, subscription, monitoring_callback=None, service_name="REMOTE", message_handlers=None
+        self,
+        subscriber,
+        subscription,
+        monitoring_callback=None,
+        service_name="REMOTE",
+        message_handlers=None,
     ):
         self.subscriber = subscriber
         self.subscription = subscription
@@ -175,7 +180,7 @@ class OrderedMessageHandler:
         :param dict message:
         :return None:
         """
-        logger.info("%r received a monitoring update.", self.subscription.topic.service)
+        logger.debug("%r received a monitoring update.", self.subscription.topic.service)
 
         if self.monitoring_callback is not None:
             self.monitoring_callback(json.loads(message["data"]))

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -21,7 +21,7 @@ class OrderedMessageHandler:
 
     :param google.pubsub_v1.services.subscriber.client.SubscriberClient subscriber: a Google Pub/Sub subscriber
     :param octue.cloud.pub_sub.subscription.Subscription subscription: the subscription messages are pulled from
-    :param callable|None monitoring_callback: a function to handle monitoring update messages
+    :param callable|None monitoring_callback: a function to handle monitoring updates (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive
     :param str service_name: an arbitrary name to refer to the service subscribed to by (used for labelling its remote log messages)
     :param dict|None message_handlers: a mapping of message handler names to callables that handle each type of message
     :return None:
@@ -178,7 +178,7 @@ class OrderedMessageHandler:
         logger.info("%r received a monitoring update.", self.subscription.topic.service)
 
         if self.monitoring_callback is not None:
-            self.monitoring_callback(message["data"])
+            self.monitoring_callback(json.loads(message["data"]))
 
     def _handle_log_message(self, message):
         """Deserialise the message into a log record and pass it to the local log handlers, adding [<service-name>] to

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -130,7 +130,7 @@ class Service(CoolNameable):
                 input_values=data["input_values"],
                 input_manifest=data["input_manifest"],
                 analysis_log_handler=analysis_log_handler,
-                monitoring_function=functools.partial(self.send_monitoring_update_to_asker, topic=topic),
+                monitoring_update_function=functools.partial(self.send_monitoring_update_to_asker, topic=topic),
             )
 
             if analysis.output_manifest is None:
@@ -266,7 +266,7 @@ class Service(CoolNameable):
         the answer is received.
 
         :param octue.cloud.pub_sub.subscription.Subscription subscription: the subscription for the question's answer
-        :param callable|None monitoring_callback: a function to handle monitoring updates (e.g. send them to an endpoint for plotting or displaying)
+        :param callable|None monitoring_callback: a function to handle monitoring updates (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive
         :param str service_name: an arbitrary name to refer to the service subscribed to by (used for labelling its remote log messages)
         :param float|None timeout: how long in seconds to wait for an answer before raising a `TimeoutError`
         :param float delivery_acknowledgement_timeout: how long in seconds to wait for a delivery acknowledgement before resending the question

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -340,7 +340,7 @@ class Service(CoolNameable):
         :param float timeout: time in seconds to retry sending the update
         :return None:
         """
-        logger.info("%r sending monitoring update.", self)
+        logger.debug("%r sending monitoring update.", self)
 
         self.publisher.publish(
             topic=topic.path,

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -271,12 +271,19 @@ class Service(CoolNameable):
         return response_subscription, question_uuid
 
     def wait_for_answer(
-        self, subscription, service_name="REMOTE", timeout=60, delivery_acknowledgement_timeout=30, retry_interval=5
+        self,
+        subscription,
+        monitoring_callback=None,
+        service_name="REMOTE",
+        timeout=60,
+        delivery_acknowledgement_timeout=30,
+        retry_interval=5,
     ):
         """Wait for an answer to a question on the given subscription, deleting the subscription and its topic once
         the answer is received.
 
         :param octue.cloud.pub_sub.subscription.Subscription subscription: the subscription for the question's answer
+        :param callable|None monitoring_callback: a function to handle monitoring updates (e.g. send them to an endpoint for plotting or displaying)
         :param str service_name: an arbitrary name to refer to the service subscribed to by (used for labelling its remote log messages)
         :param float|None timeout: how long in seconds to wait for an answer before raising a `TimeoutError`
         :param float delivery_acknowledgement_timeout: how long in seconds to wait for a delivery acknowledgement before resending the question
@@ -289,6 +296,7 @@ class Service(CoolNameable):
         message_handler = OrderedMessageHandler(
             subscriber=subscriber,
             subscription=subscription,
+            monitoring_callback=monitoring_callback,
             service_name=service_name,
         )
 

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -391,13 +391,15 @@ class Service(CoolNameable):
         :return (dict, str, bool):
         """
         try:
-            # Parse Google Cloud Pub/Sub question format.
+            # Parse and acknowledge question from Google Cloud Pub/Sub.
             data = json.loads(question.data.decode())
             question.ack()
-            logger.info("%r received a question.", self)
         except Exception:
-            # Parse Google Cloud Run question format.
+            # Parse question from Google Cloud Run. We can't acknowledge the it here as it's not possible with the
+            # information given.
             data = json.loads(base64.b64decode(question["data"]).decode("utf-8").strip())
+
+        logger.info("%r received a question.", self)
 
         question_uuid = get_nested_attribute(question, "attributes.question_uuid")
         forward_logs = bool(int(get_nested_attribute(question, "attributes.forward_logs")))

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -98,5 +98,5 @@ class CloudLocationNotSpecified(OctueSDKException):
     """
 
 
-class InvalidMonitorUpdate(OctueSDKException):
-    """Raise if a monitor update fails validation against the `monitors_schema` section of the Twine."""
+class InvalidMonitorMessage(OctueSDKException):
+    """Raise if a monitor message fails validation against the "monitor_message_schema" field of the Twine."""

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -96,3 +96,7 @@ class CloudLocationNotSpecified(OctueSDKException):
     """Raise when attempting to interact with a cloud resource implicitly but the implicit details of its location are
     missing.
     """
+
+
+class InvalidMonitorUpdate(OctueSDKException):
+    """Raise if a monitor update fails validation against the `monitors_schema` section of the Twine."""

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -41,7 +41,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
     Analyses are instantiated at the top level of your app/service/twin code and you can import the instantiated
     object from there (see the templates for examples)
 
-    :param twined.Twine twine: Twine instance or json source
+    :param twined.Twine|str twine: Twine instance or json source
     :param callable|None monitoring_update_function: a function that sends monitoring updates to the parent that requested the analysis
     :param any configuration_values: see Runner.run() for definition
     :param octue.resources.manifest.Manifest configuration_manifest: see Runner.run() for definition
@@ -100,6 +100,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
 
         if self._monitoring_update_function is None:
             module_logger.warning("Attempted to send a monitoring update but no monitoring function is specified.")
+            return
 
         self._monitoring_update_function(data)
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -91,6 +91,8 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
         :param any data:
         :return None:
         """
+        self.twine.validate_monitor_values(source=data)
+
         if self._monitoring_update_function is not None:
             self._monitoring_update_function(data)
             return

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -95,7 +95,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
         try:
             self.twine.validate_monitor_values(source=data)
         except twined.exceptions.InvalidValuesContents:
-            self.logger.warning("Attempted to send a monitoring update but schema validation failed.")
+            module_logger.warning("Attempted to send a monitoring update but schema validation failed.")
             return
 
         if self._monitoring_update_function is None:

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -3,6 +3,7 @@ import logging
 
 import twined.exceptions
 from octue.definitions import OUTPUT_STRANDS
+from octue.exceptions import InvalidMonitorUpdate
 from octue.mixins import Hashable, Identifiable, Labelable, Loggable, Serialisable, Taggable
 from octue.resources.manifest import Manifest
 from octue.utils.encoders import OctueJSONEncoder
@@ -94,9 +95,8 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
         """
         try:
             self.twine.validate_monitor_values(source=data)
-        except twined.exceptions.InvalidValuesContents:
-            module_logger.warning("Attempted to send a monitoring update but schema validation failed.")
-            return
+        except twined.exceptions.InvalidValuesContents as e:
+            raise InvalidMonitorUpdate(e)
 
         if self._monitoring_update_function is None:
             module_logger.warning("Attempted to send a monitoring update but no monitoring function is specified.")

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -90,7 +90,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
     def send_monitoring_update(self, data):
         """Send a monitoring update to the parent that requested the analysis.
 
-        :param any data:
+        :param any data: any JSON-compatible data structure
         :return None:
         """
         try:

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -74,6 +74,7 @@ class Runner:
         input_manifest=None,
         analysis_log_level=logging.INFO,
         analysis_log_handler=None,
+        monitoring_update_function=None,
     ):
         """Run an analysis
 
@@ -82,6 +83,7 @@ class Runner:
         :param Union[str, octue.resources.manifest.Manifest, None] input_manifest: The input_manifest strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
         :param str analysis_log_level: the level below which to ignore log messages
         :param logging.Handler|None analysis_log_handler: the logging.Handler instance which will be used to handle logs for this analysis run. Handlers can be created as per the logging cookbook https://docs.python.org/3/howto/logging-cookbook.html but should use the format defined above in LOG_FORMAT.
+        :param callable|None monitoring_update_function: a function that sends monitoring updates to the parent that requested the analysis
         :return: None
         """
         if hasattr(self.twine, "credentials"):
@@ -138,8 +140,9 @@ class Runner:
 
         analysis = Analysis(
             id=analysis_id,
-            logger=analysis_logger,
             twine=self.twine,
+            monitoring_update_function=monitoring_update_function,
+            logger=analysis_logger,
             skip_checks=self.skip_checks,
             **self.configuration,
             **inputs,

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -74,7 +74,7 @@ class Runner:
         input_manifest=None,
         analysis_log_level=logging.INFO,
         analysis_log_handler=None,
-        monitoring_update_function=None,
+        handle_monitor_message=None,
     ):
         """Run an analysis.
 
@@ -83,7 +83,7 @@ class Runner:
         :param Union[str, octue.resources.manifest.Manifest, None] input_manifest: The input_manifest strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
         :param str analysis_log_level: the level below which to ignore log messages
         :param logging.Handler|None analysis_log_handler: the logging.Handler instance which will be used to handle logs for this analysis run. Handlers can be created as per the logging cookbook https://docs.python.org/3/howto/logging-cookbook.html but should use the format defined above in LOG_FORMAT.
-        :param callable|None monitoring_update_function: a function that sends monitoring updates to the parent that requested the analysis
+        :param callable|None handle_monitor_message: a function that sends monitor messages to the parent that requested the analysis
         :return None:
         """
         if hasattr(self.twine, "credentials"):
@@ -109,7 +109,7 @@ class Runner:
                 for child in inputs["children"]
             }
 
-        outputs_and_monitors = self.twine.prepare("monitors", "output_values", "output_manifest", cls=CLASS_MAP)
+        outputs_and_monitors = self.twine.prepare("monitor_message", "output_values", "output_manifest", cls=CLASS_MAP)
 
         # TODO this is hacky, we need to rearchitect the twined validation so we can do this kind of thing in there
         outputs_and_monitors["output_manifest"] = self._update_manifest_path(
@@ -141,7 +141,7 @@ class Runner:
         analysis = Analysis(
             id=analysis_id,
             twine=self.twine,
-            monitoring_update_function=monitoring_update_function,
+            handle_monitor_message=handle_monitor_message,
             logger=analysis_logger,
             skip_checks=self.skip_checks,
             **self.configuration,

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -76,7 +76,7 @@ class Runner:
         analysis_log_handler=None,
         monitoring_update_function=None,
     ):
-        """Run an analysis
+        """Run an analysis.
 
         :param str|None analysis_id: UUID of analysis
         :param Union[str, dict, None] input_values: the input_values strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
@@ -84,7 +84,7 @@ class Runner:
         :param str analysis_log_level: the level below which to ignore log messages
         :param logging.Handler|None analysis_log_handler: the logging.Handler instance which will be used to handle logs for this analysis run. Handlers can be created as per the logging cookbook https://docs.python.org/3/howto/logging-cookbook.html but should use the format defined above in LOG_FORMAT.
         :param callable|None monitoring_update_function: a function that sends monitoring updates to the parent that requested the analysis
-        :return: None
+        :return None:
         """
         if hasattr(self.twine, "credentials"):
             self._populate_environment_with_google_cloud_secrets()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.5.0",
+    version="0.6.0",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "google-crc32c>=1.1.2",
         "gunicorn",
         "python-dateutil>=2.8.1",
-        "twined>=0.0.20",
+        "twined @ https://github.com/octue/twined/archive/feature/validate-monitors.zip",
     ],
     url="https://www.github.com/octue/octue-sdk-python",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "google-crc32c>=1.1.2",
         "gunicorn",
         "python-dateutil>=2.8.1",
-        "twined @ https://github.com/octue/twined/archive/feature/validate-monitors.zip",
+        "twined==0.1.0",
     ],
     url="https://www.github.com/octue/octue-sdk-python",
     license="MIT",

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -349,14 +349,23 @@ class TestService(BaseTestCase):
 
         def create_run_function_with_monitoring():
             def mock_app(analysis):
-                analysis.send_monitoring_update({"blah": "my first monitoring update"})
-                analysis.send_monitoring_update({"lorem": "my second monitoring update"})
+                analysis.send_monitoring_update({"status": "my first monitoring update"})
+                analysis.send_monitoring_update({"status": "my second monitoring update"})
 
             twine = """
                 {
                     "input_values_schema": {
                         "type": "object",
                         "required": []
+                    },
+                    "monitors_schema": {
+                        "type": "object",
+                        "properties": {
+                            "status": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["status"]
                     }
                 }
             """
@@ -377,7 +386,7 @@ class TestService(BaseTestCase):
                     parent.wait_for_answer(subscription, monitoring_callback=lambda data: monitoring_data.append(data))
 
         self.assertEqual(
-            monitoring_data, [{"blah": "my first monitoring update"}, {"lorem": "my second monitoring update"}]
+            monitoring_data, [{"status": "my first monitoring update"}, {"status": "my second monitoring update"}]
         )
 
     def test_ask_with_input_manifest(self):

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,3 +1,5 @@
+import logging
+
 from octue.resources.analysis import HASH_FUNCTIONS, Analysis
 from twined import Twine
 from ..base import BaseTestCase
@@ -44,3 +46,17 @@ class AnalysisTestCase(BaseTestCase):
             hash_ = getattr(analysis, f"{strand_name}_hash")
             self.assertTrue(isinstance(hash_, str))
             self.assertTrue(len(hash_) == 8)
+
+    def test_warning_raised_if_attempting_to_send_a_monitoring_update_but_no_monitoring_callback_is_provided(self):
+        """Test that a warning is raised if attempting to send a monitoring update but no monitoring callback is
+        provided.
+        """
+        analysis = Analysis(twine='{"monitors_schema": {}}')
+
+        with self.assertLogs(level=logging.WARNING) as logging_context:
+            analysis.send_monitoring_update(data=[])
+
+        self.assertIn(
+            "Attempted to send a monitoring update but no monitoring function is specified.",
+            logging_context.output[0],
+        )

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -51,12 +51,12 @@ class AnalysisTestCase(BaseTestCase):
         """Test that a warning is raised if attempting to send a monitoring update but no monitoring callback is
         provided.
         """
-        analysis = Analysis(twine='{"monitors_schema": {}}')
+        analysis = Analysis(twine='{"monitor_message_schema": {}}')
 
         with self.assertLogs(level=logging.WARNING) as logging_context:
-            analysis.send_monitoring_update(data=[])
+            analysis.send_monitor_message(data=[])
 
         self.assertIn(
-            "Attempted to send a monitoring update but no monitoring function is specified.",
+            "Attempted to send a monitor message but no handler is specified.",
             logging_context.output[0],
         )

--- a/tests/resources/test_child.py
+++ b/tests/resources/test_child.py
@@ -12,7 +12,7 @@ class TestChild(BaseTestCase):
         """Test that a child can be asked multiple questions."""
         backend = GCPPubSubBackend(project_name="blah")
 
-        def run_function(analysis_id, input_values, input_manifest, analysis_log_handler):
+        def run_function(analysis_id, input_values, input_manifest, analysis_log_handler, monitoring_update_function):
             return MockAnalysis(output_values=input_values)
 
         responding_service = MockService(backend=backend, service_id=str(uuid.uuid4()), run_function=run_function)

--- a/tests/resources/test_child.py
+++ b/tests/resources/test_child.py
@@ -12,7 +12,7 @@ class TestChild(BaseTestCase):
         """Test that a child can be asked multiple questions."""
         backend = GCPPubSubBackend(project_name="blah")
 
-        def run_function(analysis_id, input_values, input_manifest, analysis_log_handler, monitoring_update_function):
+        def run_function(analysis_id, input_values, input_manifest, analysis_log_handler, handle_monitor_message):
             return MockAnalysis(output_values=input_values)
 
         responding_service = MockService(backend=backend, service_id=str(uuid.uuid4()), run_function=run_function)


### PR DESCRIPTION
## Summary
Add the ability for parents to monitor the progress of their children's analyses.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents (#281)

### New features
- Add ability to validate (against the schema in `twine.json`) and send monitoring updates from a child to its parent
- Allow parents to provide a callback function that handles monitoring updates for e.g. plotting or other visualisation

### Fixes
- Log receipt of questions in Google Cloud Run

### Operations
- Use latest conventional commits pre-commit hook

### Refactoring
- Rename `Service.parse_question` to `Service._parse_question`
- Rename `Service.send_delivery_acknowledgement_to_asker` to `Service._send_delivery_acknowledgement`

<!--- STOP AUTOGENERATED NOTES --->

### Quality Checklist
- [x] New features are fully tested (No matter how much Coverage Karma you have)
- [ ] [v0.2 onward] New features are included in the documentation