### PR TITLE
Allow datafiles to represent HDF5 files

### DIFF
--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from urllib.parse import urlparse
 import google.api_core.exceptions
+import h5py
 import pkg_resources
 from google_crc32c import Checksum
 
@@ -680,7 +681,11 @@ class _DatafileContextManager:
         if "w" in self.mode:
             os.makedirs(os.path.split(self.datafile.local_path)[0], exist_ok=True)
 
-        self._fp = open(self.datafile.local_path, self.mode, **self.kwargs)
+        if self.datafile.extension == "hdf5":
+            self._fp = h5py.File(self.datafile.local_path, self.mode, **self.kwargs)
+        else:
+            self._fp = open(self.datafile.local_path, self.mode, **self.kwargs)
+
         return self._fp
 
     def __exit__(self, *args):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.6.1",
+    version="0.6.2",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",
@@ -28,6 +28,7 @@ setup(
         "google-cloud-storage>=1.35.1",
         "google-crc32c>=1.1.2",
         "gunicorn",
+        "h5py==3.6.0",
         "python-dateutil>=2.8.1",
         "twined==0.1.0",
     ],

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -757,8 +757,8 @@ class DatafileTestCase(BaseTestCase):
 
     def test_creating_new_hdf5_datafile(self):
         """Test that a new HDF5 datafile can be created and written to."""
-        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=False) as temporary_file:
-            datafile = Datafile(path=temporary_file.name)
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            datafile = Datafile(path=os.path.join(temporary_directory, "my-file.hdf5"))
 
             with datafile.open("w") as f:
                 f["dataset"] = range(10)
@@ -768,9 +768,11 @@ class DatafileTestCase(BaseTestCase):
 
     def test_creating_datafile_from_existing_hdf5_file(self):
         """Test that a datafile can be created from an existing HDF5 file."""
-        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=False) as temporary_file:
-            with h5py.File(temporary_file.name, "w") as f:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            path = os.path.join(temporary_directory, "my-file.hdf5")
+
+            with h5py.File(path, "w") as f:
                 f["dataset"] = range(10)
 
-            with Datafile(path=temporary_file.name) as (datafile, f):
+            with Datafile(path=path) as (datafile, f):
                 self.assertEqual(list(f["dataset"]), list(range(10)))


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#286](https://github.com/octue/octue-sdk-python/pull/286))

### Enhancements
- Allow datafiles to represent HDF5 files

<!--- END AUTOGENERATED NOTES --->