### PR TITLE
Make `h5py` dependency optional

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
           - 'sphinx-tabs==1.2.1'
           - 'scipy~=1.5.2'
           - 'jsonschema~=3.2.0'
+          - 'docutils==0.12'
 
   - repo: https://github.com/windpioneers/pre-commit-hooks
     rev: 0.0.5

--- a/docs/source/datafile.rst
+++ b/docs/source/datafile.rst
@@ -15,6 +15,14 @@ easily check where a datafile exists by accessing the following properties:
     datafile.exists_in_cloud
     >>> True
 
+.. warning::
+    If you want to represent HDF5 files with a ``Datafile``, you must include the extra requirements provided by the
+    ``hdf5`` key at installation i.e.
+
+    .. code-block:: shell
+
+        pip install octue[hdf5]
+
 A datafile has the following main attributes:
 
 - ``local_path`` - the absolute local path of the file, or ``None`` if it only exists in the cloud

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,4 +37,4 @@ stringcase==1.2.0
 # Current library
 #    Installs any dependencies in setup.py
 # ------------------------------------------------------------------------------
--e .
+-e .[hdf5]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.6.4",
+    version="0.6.5",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",
@@ -28,10 +28,10 @@ setup(
         "google-cloud-storage>=1.35.1",
         "google-crc32c>=1.1.2",
         "gunicorn",
-        "h5py==3.6.0",
         "python-dateutil>=2.8.1",
         "twined==0.1.0",
     ],
+    extras_require={"hdf5": ["h5py==3.6.0"]},
     url="https://www.github.com/octue/octue-sdk-python",
     license="MIT",
     author="Thomas Clark (github: thclark)",


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#288](https://github.com/octue/octue-sdk-python/pull/288))

### Dependencies
- Make `h5py` dependency optional
- Use working version of `docutils` in `pre-commit-config.yaml`

<!--- END AUTOGENERATED NOTES --->