### PR TITLE
Allow monitor message handler to be given to Child

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -266,7 +266,7 @@ class Service(CoolNameable):
         the answer is received.
 
         :param octue.cloud.pub_sub.subscription.Subscription subscription: the subscription for the question's answer
-        :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive
+        :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive as an argument (note that this could be an array or object)
         :param str service_name: an arbitrary name to refer to the service subscribed to by (used for labelling its remote log messages)
         :param float|None timeout: how long in seconds to wait for an answer before raising a `TimeoutError`
         :param float delivery_acknowledgement_timeout: how long in seconds to wait for a delivery acknowledgement before resending the question

--- a/octue/resources/child.py
+++ b/octue/resources/child.py
@@ -23,16 +23,30 @@ class Child:
         backend = service_backends.get_backend(backend_type_name)(**backend)
         self._service = BACKEND_TO_SERVICE_MAPPING[backend_type_name](backend=backend)
 
-    def ask(self, input_values=None, input_manifest=None, subscribe_to_logs=True, timeout=20):
+    def ask(
+        self,
+        input_values=None,
+        input_manifest=None,
+        subscribe_to_logs=True,
+        handle_monitor_message=None,
+        timeout=20,
+    ):
         """Ask the child a question (i.e. send it some input value and/or a manifest and wait for it to run an analysis
         on them and return the output values). The input values given must adhere to the Twine file of the child.
 
         :param any input_values: the input values of the question
         :param octue.resources.manifest.Manifest|None input_manifest: the input manifest of the question
         :param bool subscribe_to_logs: if `True`, subscribe to logs from the remote service and handle them with the local log handlers
+        :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive as an argument (note that this could be an array or object)
         :param float timeout: time in seconds to wait for an answer before raising a timeout error
         :raise TimeoutError: if the timeout is exceeded while waiting for an answer
         :return dict: dictionary containing the keys "output_values" and "output_manifest"
         """
-        subscription, _ = self._service.ask(self.id, input_values, input_manifest, subscribe_to_logs)
-        return self._service.wait_for_answer(subscription=subscription, service_name=self.name, timeout=timeout)
+        subscription, _ = self._service.ask(self.id, input_values, input_manifest, subscribe_to_logs, timeout=timeout)
+
+        return self._service.wait_for_answer(
+            subscription=subscription,
+            handle_monitor_message=handle_monitor_message,
+            service_name=self.name,
+            timeout=timeout,
+        )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.6.5",
+    version="0.6.6",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary

<!--- START AUTOGENERATED NOTES --->
## Contents ([#289](https://github.com/octue/octue-sdk-python/pull/289))

### Enhancements
- Allow monitor message handler to be given to Child

<!--- END AUTOGENERATED NOTES --->