### PR TITLE
Preserve directory structure in cloud when uploading datasets

### DIFF
--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -146,9 +146,12 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
             cloud_path = storage.path.generate_gs_path(bucket_name, output_directory, self.name)
 
         for datafile in self.files:
+
+            relative_path = datafile.path.split(self.path)[-1].strip("/")
+
             datafile.to_cloud(
                 project_name,
-                cloud_path=storage.path.join(cloud_path, datafile.name),
+                cloud_path=storage.path.join(cloud_path, relative_path),
             )
 
         self._upload_metadata_file(project_name, cloud_path)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.6.8",
+    version="0.6.9",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,0 +1,18 @@
+import os
+
+from octue.resources.dataset import Dataset
+
+
+def create_dataset_with_two_files(dataset_directory_path):
+    """Create a dataset in the given directory containing two files.
+
+    :param str dataset_directory_path:
+    :return octue.resources.dataset.Dataset:
+    """
+    paths = [os.path.join(dataset_directory_path, filename) for filename in ("file_0.txt", "file_1.txt")]
+
+    for path, data in zip(paths, range(len(paths))):
+        with open(path, "w") as f:
+            f.write(str(data))
+
+    return Dataset.from_local_directory(dataset_directory_path)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -11,6 +11,7 @@ from octue.resources import Datafile, Dataset
 from octue.resources.filter_containers import FilterSet
 from tests import TEST_BUCKET_NAME, TEST_PROJECT_NAME
 from tests.base import BaseTestCase
+from tests.resources import create_dataset_with_two_files
 
 
 class TestDataset(BaseTestCase):
@@ -301,48 +302,31 @@ class TestDataset(BaseTestCase):
 
     def test_from_cloud(self):
         """Test that a Dataset in cloud storage can be accessed via (`bucket_name`, `output_directory`) and via
-        `gs_path`.
+        `cloud_path`.
         """
         with tempfile.TemporaryDirectory() as temporary_directory:
-            file_0_path = os.path.join(temporary_directory, "file_0.txt")
-            file_1_path = os.path.join(temporary_directory, "file_1.txt")
-
-            with open(file_0_path, "w") as f:
-                f.write("[1, 2, 3]")
-
-            with open(file_1_path, "w") as f:
-                f.write("[4, 5, 6]")
-
-            dataset = Dataset(
-                name="dataset_0",
-                files={
-                    Datafile(path=file_0_path, labels={"hello"}, tags={"a": "b"}),
-                    Datafile(path=file_1_path, labels={"goodbye"}, tags={"a": "b"}),
-                },
-                tags={"a": "b", "c": 1},
-            )
+            dataset = create_dataset_with_two_files(temporary_directory)
+            dataset.tags = {"a": "b", "c": 1}
 
             dataset.to_cloud(
-                project_name=TEST_PROJECT_NAME, bucket_name=TEST_BUCKET_NAME, output_directory="a_directory"
+                project_name=TEST_PROJECT_NAME,
+                bucket_name=TEST_BUCKET_NAME,
+                output_directory="a_directory",
             )
 
-            bucket_name = TEST_BUCKET_NAME
             path_to_dataset_directory = storage.path.join("a_directory", dataset.name)
-            gs_path = f"gs://{bucket_name}/{path_to_dataset_directory}"
+            gs_path = f"gs://{TEST_BUCKET_NAME}/{path_to_dataset_directory}"
 
             for location_parameters in (
                 {
-                    "bucket_name": bucket_name,
+                    "bucket_name": TEST_BUCKET_NAME,
                     "path_to_dataset_directory": path_to_dataset_directory,
                     "cloud_path": None,
                 },
                 {"bucket_name": None, "path_to_dataset_directory": None, "cloud_path": gs_path},
             ):
 
-                persisted_dataset = Dataset.from_cloud(
-                    project_name=TEST_PROJECT_NAME,
-                    **location_parameters,
-                )
+                persisted_dataset = Dataset.from_cloud(project_name=TEST_PROJECT_NAME, **location_parameters)
 
                 self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}")
                 self.assertEqual(persisted_dataset.id, dataset.id)
@@ -449,29 +433,15 @@ class TestDataset(BaseTestCase):
         `cloud_path`, including all its files and a serialised JSON file of the Datafile instance.
         """
         with tempfile.TemporaryDirectory() as temporary_directory:
-            file_0_path = os.path.join(temporary_directory, "file_0.txt")
-            file_1_path = os.path.join(temporary_directory, "file_1.txt")
+            dataset_directory_name = os.path.split(temporary_directory)[-1]
+            dataset = create_dataset_with_two_files(temporary_directory)
+            dataset.tags = {"a": "b", "c": 1}
 
-            with open(file_0_path, "w") as f:
-                f.write("[1, 2, 3]")
-
-            with open(file_1_path, "w") as f:
-                f.write("[4, 5, 6]")
-
-            dataset = Dataset(
-                files={
-                    Datafile(path=file_0_path, labels={"hello"}),
-                    Datafile(path=file_1_path, labels={"goodbye"}),
-                },
-                tags={"a": "b", "c": 1},
-            )
-
-            bucket_name = TEST_BUCKET_NAME
             output_directory = "my_datasets"
-            cloud_path = storage.path.generate_gs_path(bucket_name, output_directory)
+            cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, output_directory)
 
             for location_parameters in (
-                {"bucket_name": bucket_name, "output_directory": output_directory, "cloud_path": None},
+                {"bucket_name": TEST_BUCKET_NAME, "output_directory": output_directory, "cloud_path": None},
                 {"bucket_name": None, "output_directory": None, "cloud_path": cloud_path},
             ):
                 dataset.to_cloud(TEST_PROJECT_NAME, **location_parameters)
@@ -482,13 +452,13 @@ class TestDataset(BaseTestCase):
                     cloud_path=storage.path.join(cloud_path, dataset.name, "file_0.txt"),
                 )
 
-                self.assertEqual(persisted_file_0, "[1, 2, 3]")
+                self.assertEqual(persisted_file_0, "0")
 
                 persisted_file_1 = storage_client.download_as_string(
                     bucket_name=TEST_BUCKET_NAME,
                     path_in_bucket=storage.path.join(output_directory, dataset.name, "file_1.txt"),
                 )
-                self.assertEqual(persisted_file_1, "[4, 5, 6]")
+                self.assertEqual(persisted_file_1, "1")
 
                 persisted_dataset = json.loads(
                     storage_client.download_as_string(
@@ -502,8 +472,8 @@ class TestDataset(BaseTestCase):
                 self.assertEqual(
                     persisted_dataset["files"],
                     [
-                        "gs://octue-test-bucket/my_datasets/octue-sdk-python/file_0.txt",
-                        "gs://octue-test-bucket/my_datasets/octue-sdk-python/file_1.txt",
+                        f"gs://octue-test-bucket/my_datasets/{dataset_directory_name}/file_0.txt",
+                        f"gs://octue-test-bucket/my_datasets/{dataset_directory_name}/file_1.txt",
                     ],
                 )
 


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#301](https://github.com/octue/octue-sdk-python/pull/301))

### Fixes
- Preserve directory structure on dataset cloud upload
<!--- END AUTOGENERATED NOTES --->