### PR TITLE
Create cloud path properly during dataset cloud upload

### DIFF
--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -147,11 +147,11 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
 
         for datafile in self.files:
 
-            relative_path = datafile.path.split(self.path)[-1].strip("/")
+            datafile_path_relative_to_dataset = datafile.path.split(self.path)[-1].strip("/")
 
             datafile.to_cloud(
                 project_name,
-                cloud_path=storage.path.join(cloud_path, relative_path),
+                cloud_path=storage.path.join(cloud_path, *datafile_path_relative_to_dataset.split(os.path.sep)),
             )
 
         self._upload_metadata_file(project_name, cloud_path)

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -493,7 +493,9 @@ class TestDataset(BaseTestCase):
         uploaded_dataset = Dataset.from_cloud(project_name=TEST_PROJECT_NAME, cloud_path=upload_path)
 
         # Check that the paths relative to the dataset directory are the same in the cloud as they are locally.
-        local_datafile_relative_paths = {path.split(temporary_directory)[-1].strip("/") for path in local_paths}
+        local_datafile_relative_paths = {
+            path.split(temporary_directory)[-1].strip(os.path.sep).replace(os.path.sep, "/") for path in local_paths
+        }
 
         cloud_datafile_relative_paths = {
             storage.path.split_bucket_name_from_gs_path(datafile.path)[-1].split("my-dataset/")[-1]


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#302](https://github.com/octue/octue-sdk-python/pull/302))

### Fixes
- Create cloud path in an OS-agnostice way during dataset cloud upload

### Testing
- Make test OS-agnostic

<!--- END AUTOGENERATED NOTES --->