### PR TITLE
Use ThreadPool to speed up uploading files from a dataset

### DIFF
--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -145,14 +145,30 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
         if not cloud_path:
             cloud_path = storage.path.generate_gs_path(bucket_name, output_directory, self.name)
 
+        files_and_paths = []
+
         for datafile in self.files:
-
-            datafile_path_relative_to_dataset = datafile.path.split(self.path)[-1].strip("/")
-
-            datafile.to_cloud(
-                project_name,
-                cloud_path=storage.path.join(cloud_path, *datafile_path_relative_to_dataset.split(os.path.sep)),
+            datafile_path_relative_to_dataset = datafile.path.split(self.path)[-1].strip(os.path.sep).strip("/")
+            files_and_paths.append(
+                (
+                    datafile,
+                    storage.path.join(cloud_path, *datafile_path_relative_to_dataset.split(os.path.sep)),
+                )
             )
+
+        def upload(iterable_element):
+            """Upload a datafile to the given cloud path.
+
+            :param tuple(octue.resources.datafile.Datafile, str) iterable_element:
+            :return None:
+            """
+            datafile = iterable_element[0]
+            cloud_path = iterable_element[1]
+            datafile.to_cloud(project_name, cloud_path=cloud_path)
+
+        # Use multiple threads to significantly speed up file uploads by reducing latency.
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            executor.map(upload, files_and_paths)
 
         self._upload_metadata_file(project_name, cloud_path)
         return cloud_path

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -288,7 +288,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Loggable, Identifiabl
             return datafile.download(local_path=local_path)
 
         # Use multiple threads to significantly speed up files downloads by reducing latency.
-        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             executor.map(download, files_and_paths)
 
     def _upload_metadata_file(self, project_name, cloud_path):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.6.9",
+    version="0.6.10",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary
Multi-thread uploads of multiple files from dataset to cloud storage. 

When uploading 100 files, the time taken was:
- 15.5s with the new approach
- 50.9s with the old approach

This is a 3.3x speed up that is likely to increase with the number of files in the dataset and the number of threads available.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#303](https://github.com/octue/octue-sdk-python/pull/303))

### Enhancements
- Use `ThreadPool` to upload files from a dataset to the cloud
- Lift 10-worker limit for dataset file downloads

### Fixes
- Ensure datafile paths relative to their dataset are constructed correctly on non-Linux-based OSs
<!--- END AUTOGENERATED NOTES --->