### PR TITLE
Fix analysis logging

### DIFF
--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -23,3 +23,13 @@ Here are some example logs handled by ``octue`` produced when running the child 
     [2021-07-10 20:03:37,849 | INFO | octue.cloud.pub_sub.service] <Service('prophetic-dolphin')> responded to question '437c58d4-4ffe-438b-b57b-2292ece0d2e7'.
     [2021-07-10 20:03:40,401 | INFO | octue.cloud.pub_sub.service] <Service('pragmatic-griffin')> received an answer to question '437c58d4-4ffe-438b-b57b-2292ece0d2e7'.
     [2021-07-10 20:03:44,613 | INFO | octue.runner | analysis-102ee7d5-4b94-4f8a-9dcd-36dbd00662ec] The wind speeds and elevations at [{'longitude': 0, 'latitude': 0}, {'longitude': 1, 'latitude': 1}] are [3296, 1909] and [89, 82].
+
+
+Adding additional metadata to the log context
+--------------––-----------------------------
+
+You can also provide environment variables to add the following metadata to the log context:
+
+- ``INCLUDE_LINE_NUMBER_LOG_METADATA`` - include the line number
+- ``INCLUDE_PROCESS_NAME_LOG_METADATA`` - include the process name
+- ``INCLUDE_THREAD_NAME_LOG_METADATA`` - include the thread name

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -25,11 +25,11 @@ Here are some example logs handled by ``octue`` produced when running the child 
     [2021-07-10 20:03:44,613 | INFO | octue.runner | analysis-102ee7d5-4b94-4f8a-9dcd-36dbd00662ec] The wind speeds and elevations at [{'longitude': 0, 'latitude': 0}, {'longitude': 1, 'latitude': 1}] are [3296, 1909] and [89, 82].
 
 
-Adding additional metadata to the log context
---------------––-----------------------------
+Adding additional log record attributes to the logging context
+--------------––----------------------------------------------
 
-You can also provide environment variables to add the following metadata to the log context:
+You can add certain log record attributes to the logging context by providing the following environment variables:
 
-- ``INCLUDE_LINE_NUMBER_LOG_METADATA`` - include the line number
-- ``INCLUDE_PROCESS_NAME_LOG_METADATA`` - include the process name
-- ``INCLUDE_THREAD_NAME_LOG_METADATA`` - include the thread name
+- ``INCLUDE_LINE_NUMBER_IN_LOGS`` - include the line number
+- ``INCLUDE_PROCESS_NAME_IN_LOGS`` - include the process name
+- ``INCLUDE_THREAD_NAME_IN_LOGS`` - include the thread name

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from .log_handlers import apply_log_handler, get_formatter
+from .log_handlers import apply_log_handler, create_octue_formatter, get_metadata_schema
 from .runner import Runner
 
 
@@ -11,4 +11,4 @@ if int(os.environ.get("USE_OCTUE_LOG_HANDLER", "0")) == 1:
     # Use the default log handler from this package if `USE_OCTUE_LOG_HANDLER` is 1. The default value for this is 0
     # because `octue` is a package that is primarily imported - the importer may not want to use this log handler if
     # they have their own.
-    apply_log_handler(logger_name=None, formatter=get_formatter())
+    apply_log_handler(logger_name=None, formatter=create_octue_formatter(logging_metadata_schema=get_metadata_schema()))

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from .log_handlers import apply_log_handler, create_octue_formatter, get_metadata_schema
+from .log_handlers import apply_log_handler, create_octue_formatter, get_metadata_schema_for_current_compute_platform
 from .runner import Runner
 
 
@@ -11,4 +11,5 @@ if int(os.environ.get("USE_OCTUE_LOG_HANDLER", "0")) == 1:
     # Use the default log handler from this package if `USE_OCTUE_LOG_HANDLER` is 1. The default value for this is 0
     # because `octue` is a package that is primarily imported - the importer may not want to use this log handler if
     # they have their own.
-    apply_log_handler(logger_name=None, formatter=create_octue_formatter(logging_metadata_schema=get_metadata_schema()))
+    logging_metadata_schema = get_metadata_schema_for_current_compute_platform()
+    apply_log_handler(logger_name=None, formatter=create_octue_formatter(logging_metadata_schema))

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -13,7 +13,7 @@ if int(os.environ.get("USE_OCTUE_LOG_HANDLER", "0")) == 1:
     # they have their own.
     apply_log_handler(
         logger_name=None,  # Apply to the root logger.
-        include_line_number=os.environ.get("INCLUDE_LINE_NUMBER_LOG_METADATA", False),
-        include_process_name=os.environ.get("INCLUDE_PROCESS_NAME_LOG_METADATA", False),
-        include_thread_name=os.environ.get("INCLUDE_THREAD_NAME_LOG_METADATA", False),
+        include_line_number=bool(int(os.environ.get("INCLUDE_LINE_NUMBER_LOG_METADATA", 0))),
+        include_process_name=bool(int(os.environ.get("INCLUDE_PROCESS_NAME_LOG_METADATA", 0))),
+        include_thread_name=bool(int(os.environ.get("INCLUDE_THREAD_NAME_LOG_METADATA", 0))),
     )

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from .log_handlers import apply_log_handler, create_octue_formatter, get_metadata_schema_for_current_compute_platform
+from .log_handlers import apply_log_handler
 from .runner import Runner
 
 
@@ -11,5 +11,4 @@ if int(os.environ.get("USE_OCTUE_LOG_HANDLER", "0")) == 1:
     # Use the default log handler from this package if `USE_OCTUE_LOG_HANDLER` is 1. The default value for this is 0
     # because `octue` is a package that is primarily imported - the importer may not want to use this log handler if
     # they have their own.
-    logging_metadata_schema = get_metadata_schema_for_current_compute_platform()
-    apply_log_handler(logger_name=None, formatter=create_octue_formatter(logging_metadata_schema))
+    apply_log_handler(logger_name=None)

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -13,7 +13,7 @@ if int(os.environ.get("USE_OCTUE_LOG_HANDLER", "0")) == 1:
     # they have their own.
     apply_log_handler(
         logger_name=None,  # Apply to the root logger.
-        include_line_number=bool(int(os.environ.get("INCLUDE_LINE_NUMBER_LOG_METADATA", 0))),
-        include_process_name=bool(int(os.environ.get("INCLUDE_PROCESS_NAME_LOG_METADATA", 0))),
-        include_thread_name=bool(int(os.environ.get("INCLUDE_THREAD_NAME_LOG_METADATA", 0))),
+        include_line_number=bool(int(os.environ.get("INCLUDE_LINE_NUMBER_IN_LOGS", 0))),
+        include_process_name=bool(int(os.environ.get("INCLUDE_PROCESS_NAME_IN_LOGS", 0))),
+        include_thread_name=bool(int(os.environ.get("INCLUDE_THREAD_NAME_IN_LOGS", 0))),
     )

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -11,4 +11,9 @@ if int(os.environ.get("USE_OCTUE_LOG_HANDLER", "0")) == 1:
     # Use the default log handler from this package if `USE_OCTUE_LOG_HANDLER` is 1. The default value for this is 0
     # because `octue` is a package that is primarily imported - the importer may not want to use this log handler if
     # they have their own.
-    apply_log_handler(logger_name=None)
+    apply_log_handler(
+        logger_name=None,  # Apply to the root logger.
+        include_line_number=os.environ.get("INCLUDE_LINE_NUMBER_LOG_METADATA", False),
+        include_process_name=os.environ.get("INCLUDE_PROCESS_NAME_LOG_METADATA", False),
+        include_thread_name=os.environ.get("INCLUDE_THREAD_NAME_LOG_METADATA", False),
+    )

--- a/octue/cloud/deployment/google/cloud_run.py
+++ b/octue/cloud/deployment/google/cloud_run.py
@@ -29,7 +29,7 @@ def index():
         return _log_bad_request_and_return_400_response("No Pub/Sub message received.")
 
     # Acknowledge questions that are redelivered to stop further redelivery and redundant processing.
-    if envelope["deliveryAttempt"] > 1:
+    if envelope.get("deliveryAttempt", 0) > 1:
         logger.info(
             "This question has already been received by the service. It will now be acknowledged to prevent further "
             "redundant redelivery."

--- a/octue/essentials/monitor_messages.py
+++ b/octue/essentials/monitor_messages.py
@@ -1,7 +1,11 @@
 """A module containing helper functions for sending monitor messages that conform to the Octue essential monitor
 message schema https://refs.schema.octue.com/octue/essential-monitors/0.0.2.json
 """
+import logging
 from datetime import datetime, timezone
+
+
+logger = logging.getLogger(__name__)
 
 
 def send_status_text(analysis, text, service_name):
@@ -15,7 +19,7 @@ def send_status_text(analysis, text, service_name):
     analysis.send_monitor_message(
         {"service": service_name, "status_text": text, "date_time": datetime.now(timezone.utc).isoformat()}
     )
-    analysis.logger.info(text)
+    logger.info(text)
 
 
 def send_estimated_seconds_remaining(analysis, estimated_seconds_remaining, service_name):

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -17,7 +17,7 @@ def create_formatter(logging_metadata):
 
 
 # Logging format for analysis runs. All handlers should use this logging format, to make logs consistently parseable
-LOGGING_METADATA_WITH_TIMESTAMP = ("%(asctime)s", "%(levelname)s", "%(name)s")
+LOGGING_METADATA_WITH_TIMESTAMP = ["%(asctime)s", "%(levelname)s", "%(name)s"]
 FORMATTER_WITH_TIMESTAMP = create_formatter(LOGGING_METADATA_WITH_TIMESTAMP)
 FORMATTER_WITHOUT_TIMESTAMP = create_formatter(LOGGING_METADATA_WITH_TIMESTAMP[1:])
 
@@ -29,7 +29,7 @@ def apply_log_handler(logger_name=None, handler=None, log_level=logging.INFO, fo
     :param logging.Handler handler: The handler to use. If None, default console handler will be attached.
     :param int log_level: ignore log messages below this level
     :param logging.Formatter|None formatter: if this is `None`, the default `FORMATTER_WITH_TIMESTAMP` is used
-    :return logging.Logger:
+    :return logging.Handler:
     """
     handler = handler or logging.StreamHandler()
     handler.setFormatter(formatter or FORMATTER_WITH_TIMESTAMP)
@@ -51,7 +51,7 @@ def apply_log_handler(logger_name=None, handler=None, log_level=logging.INFO, fo
             local_logger.removeHandler(temporary_handler)
             break
 
-    return logger
+    return handler
 
 
 def get_remote_handler(logger_uri, formatter=None):
@@ -84,3 +84,10 @@ def get_formatter():
         return FORMATTER_WITHOUT_TIMESTAMP
     else:
         return FORMATTER_WITH_TIMESTAMP
+
+
+def get_metadata_schema():
+    if os.environ.get("COMPUTE_PROVIDER", "UNKNOWN") == "GOOGLE_CLOUD_RUN":
+        return LOGGING_METADATA_WITH_TIMESTAMP[1:]
+
+    return LOGGING_METADATA_WITH_TIMESTAMP

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -73,7 +73,7 @@ def get_remote_handler(logger_uri, formatter=None):
     return handler
 
 
-def get_metadata_schema():
+def get_metadata_schema_for_current_compute_platform():
     """Get the correct metadata schema for the environment. If the environment is Google Cloud Run, use a log handler
     with a formatter that doesn't include the timestamp in the log message context to avoid the date appearing twice in
     the Google Cloud Run logs (Google adds its own timestamp to log messages).

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -27,7 +27,7 @@ def apply_log_handler(logger_name=None, handler=None, log_level=logging.INFO, fo
 
     :param str|None logger_name: if this is `None`, the root logger is used
     :param logging.Handler handler: The handler to use. If None, default console handler will be attached.
-    :param int log_level: ignore log messages below this level
+    :param int|str log_level: ignore log messages below this level
     :param logging.Formatter|None formatter: if this is `None`, the default `FORMATTER_WITH_TIMESTAMP` is used
     :return logging.Handler:
     """

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -18,8 +18,8 @@ def create_octue_formatter(logging_metadata_schema):
 
 # Logging format for analysis runs. All handlers should use this logging format, to make logs consistently parseable
 LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP = ["%(asctime)s", "%(levelname)s", "%(name)s"]
+LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP = LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP[1:]
 FORMATTER_WITH_TIMESTAMP = create_octue_formatter(LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP)
-FORMATTER_WITHOUT_TIMESTAMP = create_octue_formatter(LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP[1:])
 
 
 def apply_log_handler(logger_name=None, handler=None, log_level=logging.INFO, formatter=None):

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -26,7 +26,7 @@ def apply_log_handler(logger_name=None, handler=None, log_level=logging.INFO, fo
     """Apply a log handler with the given formatter to the logger with the given name.
 
     :param str|None logger_name: if this is `None`, the root logger is used
-    :param logging.Handler handler: The handler to use. If None, default console handler will be attached.
+    :param logging.Handler handler: The handler to use. If `None`, the default `StreamHandler` will be attached.
     :param int|str log_level: ignore log messages below this level
     :param logging.Formatter|None formatter: if this is `None`, the default `FORMATTER_WITH_TIMESTAMP` is used
     :return logging.Handler:

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -4,7 +4,7 @@ import os
 from urllib.parse import urlparse
 
 
-def create_formatter(logging_metadata):
+def create_octue_formatter(logging_metadata):
     """Create a log formatter from the given logging metadata that delimits the context fields with space-padded
     pipes and encapsulates the whole context in square brackets before adding the message at the end. e.g. if the
     logging metadata was `("%(asctime)s", "%(levelname)s", "%(name)s")`, the formatter would format log messages as e.g.
@@ -18,8 +18,8 @@ def create_formatter(logging_metadata):
 
 # Logging format for analysis runs. All handlers should use this logging format, to make logs consistently parseable
 LOGGING_METADATA_WITH_TIMESTAMP = ["%(asctime)s", "%(levelname)s", "%(name)s"]
-FORMATTER_WITH_TIMESTAMP = create_formatter(LOGGING_METADATA_WITH_TIMESTAMP)
-FORMATTER_WITHOUT_TIMESTAMP = create_formatter(LOGGING_METADATA_WITH_TIMESTAMP[1:])
+FORMATTER_WITH_TIMESTAMP = create_octue_formatter(LOGGING_METADATA_WITH_TIMESTAMP)
+FORMATTER_WITHOUT_TIMESTAMP = create_octue_formatter(LOGGING_METADATA_WITH_TIMESTAMP[1:])
 
 
 def apply_log_handler(logger_name=None, handler=None, log_level=logging.INFO, formatter=None):

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -11,7 +11,7 @@ from octue.utils.folders import get_file_name_from_strand
 from twined import ALL_STRANDS, Twine
 
 
-module_logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 HASH_FUNCTIONS = {
@@ -99,7 +99,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
             raise InvalidMonitorMessage(e)
 
         if self._handle_monitor_message is None:
-            module_logger.warning("Attempted to send a monitor message but no handler is specified.")
+            logger.warning("Attempted to send a monitor message but no handler is specified.")
             return
 
         self._handle_monitor_message(data)
@@ -118,7 +118,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
         serialised_strands = {}
 
         for output_strand in OUTPUT_STRANDS:
-            self.logger.debug("Serialising %r", output_strand)
+            logger.debug("Serialising %r", output_strand)
 
             attribute = getattr(self, output_strand)
             if attribute is not None:
@@ -126,7 +126,7 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
 
             serialised_strands[output_strand] = attribute
 
-        self.logger.debug("Validating serialised output json against twine")
+        logger.debug("Validating serialised output json against twine")
         self.twine.validate(**serialised_strands)
 
         # Optionally write the serialised strands to disk.
@@ -137,13 +137,13 @@ class Analysis(Identifiable, Loggable, Serialisable, Labelable, Taggable):
                     filename = get_file_name_from_strand(output_strand, output_dir)
                     with open(filename, "w") as fp:
                         fp.write(serialised_strands[output_strand])
-                    self.logger.debug("Wrote %r to file %r", output_strand, filename)
+                    logger.debug("Wrote %r to file %r", output_strand, filename)
 
         # Optionally write the manifest to Google Cloud storage.
         if upload_to_cloud:
             if hasattr(self, "output_manifest"):
                 self.output_manifest.to_cloud(project_name, bucket_name, output_dir)
-                self.logger.debug(
+                logger.debug(
                     "Wrote %r to cloud storage at project %r in bucket %r.",
                     self.output_manifest,
                     project_name,

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -6,7 +6,11 @@ import google.api_core.exceptions
 from google.cloud import secretmanager
 
 from octue.cloud.credentials import GCPCredentialsManager
-from octue.log_handlers import apply_log_handler, create_octue_formatter, get_metadata_schema
+from octue.log_handlers import (
+    apply_log_handler,
+    create_octue_formatter,
+    get_metadata_schema_for_current_compute_platform,
+)
 from octue.resources import Child
 from octue.resources.analysis import CLASS_MAP, Analysis
 from octue.utils import gen_uuid
@@ -318,7 +322,7 @@ class AnalysisLogHandlerSwitcher:
         self.initial_handlers = list(self.logger.handlers)
         self._remove_log_handlers()
 
-        logging_metadata = get_metadata_schema() + [f"analysis-{self.analysis_id}"]
+        logging_metadata = get_metadata_schema_for_current_compute_platform() + [f"analysis-{self.analysis_id}"]
         formatter = create_octue_formatter(logging_metadata_schema=logging_metadata)
 
         apply_log_handler(formatter=formatter, log_level=self.analysis_log_level)

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -322,18 +322,19 @@ class AnalysisLogHandlerSwitcher:
         self.initial_handlers = list(self.logger.handlers)
         self._remove_log_handlers()
 
+        # Add the analysis ID to the logging metadata.
         logging_metadata = get_metadata_schema_for_current_compute_platform() + [f"analysis-{self.analysis_id}"]
         formatter = create_octue_formatter(logging_metadata_schema=logging_metadata)
 
+        # Apply a local console `StreamHandler` to the logger.
         apply_log_handler(formatter=formatter, log_level=self.analysis_log_level)
 
-        if self.extra_log_handlers:
-            for extra_handler in self.extra_log_handlers:
-                apply_log_handler(
-                    handler=extra_handler,
-                    log_level=self.analysis_log_level,
-                    formatter=formatter,
-                )
+        if not self.extra_log_handlers:
+            return
+
+        # Apply any other given handlers to the logger.
+        for extra_handler in self.extra_log_handlers:
+            apply_log_handler(handler=extra_handler, log_level=self.analysis_log_level, formatter=formatter)
 
     def __exit__(self, *args):
         """Remove the new handlers from the logger and re-add the initial handlers.

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -307,7 +307,7 @@ class AnalysisLogHandlerSwitcher:
         self._remove_log_handlers()
 
         logging_metadata = get_metadata_schema() + [f"analysis-{self.analysis_id}"]
-        formatter = create_octue_formatter(logging_metadata=logging_metadata)
+        formatter = create_octue_formatter(logging_metadata_schema=logging_metadata)
 
         apply_log_handler(formatter=formatter, log_level=self.analysis_log_level)
 

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -6,11 +6,7 @@ import google.api_core.exceptions
 from google.cloud import secretmanager
 
 from octue.cloud.credentials import GCPCredentialsManager
-from octue.log_handlers import (
-    apply_log_handler,
-    create_octue_formatter,
-    get_metadata_schema_for_current_compute_platform,
-)
+from octue.log_handlers import apply_log_handler, create_octue_formatter, get_log_record_attributes_for_environment
 from octue.resources import Child
 from octue.resources.analysis import CLASS_MAP, Analysis
 from octue.utils import gen_uuid
@@ -325,8 +321,8 @@ class AnalysisLogHandlerSwitcher:
         self._remove_log_handlers()
 
         # Add the analysis ID to the logging metadata.
-        logging_metadata = get_metadata_schema_for_current_compute_platform() + [f"analysis-{self.analysis_id}"]
-        formatter = create_octue_formatter(logging_metadata_schema=logging_metadata)
+        log_record_attributes = get_log_record_attributes_for_environment() + [f"analysis-{self.analysis_id}"]
+        formatter = create_octue_formatter(log_record_attributes=log_record_attributes)
 
         # Apply a local console `StreamHandler` to the logger.
         apply_log_handler(formatter=formatter, log_level=self.analysis_log_level)

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -6,7 +6,7 @@ import google.api_core.exceptions
 from google.cloud import secretmanager
 
 from octue.cloud.credentials import GCPCredentialsManager
-from octue.log_handlers import apply_log_handler, create_formatter, get_metadata_schema
+from octue.log_handlers import apply_log_handler, create_octue_formatter, get_metadata_schema
 from octue.resources import Child
 from octue.resources.analysis import CLASS_MAP, Analysis
 from octue.utils import gen_uuid
@@ -307,7 +307,7 @@ class AnalysisLogHandlerSwitcher:
         self._remove_log_handlers()
 
         logging_metadata = get_metadata_schema() + [f"analysis-{self.analysis_id}"]
-        formatter = create_formatter(logging_metadata=logging_metadata)
+        formatter = create_octue_formatter(logging_metadata=logging_metadata)
 
         apply_log_handler(formatter=formatter, log_level=self.analysis_log_level)
 

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -123,6 +123,8 @@ class Runner:
 
         analysis_id = str(analysis_id) if analysis_id else gen_uuid()
 
+        # Temporarily replace the root logger's handlers with a `StreamHandler` and the analysis log handler that
+        # include the analysis ID in the logging metadata.
         with AnalysisLogHandlerSwitcher(
             analysis_id=analysis_id,
             logger=logging.getLogger(),

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -290,6 +290,18 @@ class AppFrom:
 
 
 class AnalysisLogHandlerSwitcher:
+    """A context manager that, in its context, takes the given logger, removes its handlers, and adds a local handler
+    and any other handlers provided to it. A formatter is applied to the handlers that includes the given analysis ID
+    in the logging metadata. On leaving the context, the logger's initial handlers are restored to it and any that were
+    added to it in the context are removed.
+
+    :param str analysis_id:
+    :param logger.Logger logger:
+    :param str analysis_log_level:
+    :param list(logger.Logger) extra_log_handlers:
+    :return None:
+    """
+
     def __init__(self, analysis_id, logger, analysis_log_level, extra_log_handlers=None):
         self.logger = logger
         self.analysis_id = analysis_id
@@ -330,5 +342,9 @@ class AnalysisLogHandlerSwitcher:
             self.logger.addHandler(handler)
 
     def _remove_log_handlers(self):
+        """Remove all handlers from the logger.
+
+        :return None:
+        """
         for handler in list(self.logger.handlers):
             self.logger.removeHandler(handler)

--- a/octue/templates/template-child-services/parent_service/app.py
+++ b/octue/templates/template-child-services/parent_service/app.py
@@ -1,3 +1,9 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 def run(analysis, *args, **kwargs):
     """Your main entrypoint to run the application
 
@@ -28,12 +34,12 @@ def run(analysis, *args, **kwargs):
         - ``credentials``, a dict of Credential objects
 
     """
-    analysis.logger.info("Hello! The child services template app is running!")
+    logger.info("Hello! The child services template app is running!")
 
     elevations = analysis.children["elevation"].ask(input_values=analysis.input_values, timeout=20)["output_values"]
     wind_speeds = analysis.children["wind_speed"].ask(input_values=analysis.input_values, timeout=20)["output_values"]
 
-    analysis.logger.info(
+    logger.info(
         "The wind speeds and elevations at %s are %s and %s.",
         analysis.input_values["locations"],
         elevations,

--- a/octue/templates/template-python-fractal/app.py
+++ b/octue/templates/template-python-fractal/app.py
@@ -1,4 +1,9 @@
+import logging
+
 from fractal import fractal
+
+
+logger = logging.getLogger(__name__)
 
 
 def run(analysis, *args, **kwargs):
@@ -32,21 +37,21 @@ def run(analysis, *args, **kwargs):
 
     """
     # You can use the attached logger to record debug statements, general information, warnings or errors
-    # analysis.logger.info("The input directory is %s", analysis.input_dir)
-    # analysis.logger.info("The output directory is %s", analysis.output_dir)
-    # analysis.logger.info("The tmp directory, where you can store temporary files or caches, is %s", analysis.tmp_dir)
+    # logger.info("The input directory is %s", analysis.input_dir)
+    # logger.info("The output directory is %s", analysis.output_dir)
+    # logger.info("The tmp directory, where you can store temporary files or caches, is %s", analysis.tmp_dir)
 
     # Print statements will get logged...
     print("Hello! The app is running!")  # noqa: T001
 
     # ... but we encourage you to use the attached logger, which handles sending logs to remote services and allows them
     # to be viewed with twined server
-    analysis.logger.info(
+    logger.info(
         "The logger can be used for capturing different 'levels' of statement - for debug, info, warnings or errors."
     )
 
     # You can access any of the configuration or input values, anywhere in your code, from the analysis object
-    analysis.logger.info("The maximum number of iterations will be %s", analysis.configuration_values)
+    logger.info("The maximum number of iterations will be %s", analysis.configuration_values)
 
     # Run the code
     fractal(analysis)

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -1,6 +1,10 @@
+import logging
 from cleaner import clean, read_csv_files, read_dat_file
 
 from octue.resources import Datafile
+
+
+logger = logging.getLogger(__name__)
 
 
 def run(analysis, *args, **kwargs):
@@ -18,12 +22,12 @@ def run(analysis, *args, **kwargs):
     - Add them to the output manifest
     """
     # You can use the attached logger to record debug statements, general information, warnings or errors
-    analysis.logger.info("Starting clean up of files in %s", analysis.input_manifest.absolute_path)
+    logger.info("Starting clean up of files in %s", analysis.input_manifest.absolute_path)
 
     # Get the configuration value for our time averaging window (or if not present, use the default specified in
     # the twine)
     time_window = (analysis.configuration_values.get("time_window", 600),)
-    analysis.logger.info("Averaging window set to %ss", time_window)
+    logger.info("Averaging window set to %ss", time_window)
 
     # Get the input dataset which will be read in
     input_dataset = analysis.input_manifest.get_dataset("raw_met_mast_data")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.6.10",
+    version="0.6.11",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/deployment/google/test_cloud_run.py
+++ b/tests/cloud/deployment/google/test_cloud_run.py
@@ -19,7 +19,7 @@ cloud_run.app.testing = True
 
 class TestCloudRun(TestCase):
     # This is the service ID of the example service deployed to Google Cloud Run.
-    EXAMPLE_SERVICE_ID = "octue.services.009ea106-dc37-4521-a8cc-3e0836064334"
+    EXAMPLE_SERVICE_ID = "octue.services.afbf37e3-7650-4e79-bc8e-37c0c26eae13"
 
     def test_post_to_index_with_no_payload_results_in_400_error(self):
         """Test that a 400 (bad request) error code is returned if no payload is sent to the Flask endpoint."""

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 import uuid
 from unittest.mock import patch
@@ -22,6 +23,9 @@ from tests.cloud.pub_sub.mocks import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 BACKEND = GCPPubSubBackend(
     project_name=TEST_PROJECT_NAME, credentials_environment_variable="GOOGLE_APPLICATION_CREDENTIALS"
 )
@@ -34,10 +38,10 @@ def create_run_function():
     """
 
     def mock_app(analysis):
-        analysis.logger.info("Starting analysis.")
+        logger.info("Starting analysis.")
         analysis.output_values = "Hello! It worked!"
         analysis.output_manifest = None
-        analysis.logger.info("Finished analysis.")
+        logger.info("Finished analysis.")
 
     twine = """
         {

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -5,8 +5,8 @@ import sys
 from unittest import mock
 
 from octue.log_handlers import (
-    LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP,
-    LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP,
+    LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP,
+    LOG_RECORD_ATTRIBUTES_WITHOUT_TIMESTAMP,
     get_remote_handler,
 )
 from tests.base import BaseTestCase
@@ -22,7 +22,7 @@ class TestLogging(BaseTestCase):
                 importlib.reload(sys.modules["octue"])
 
         create_octue_formatter.assert_called_with(
-            logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP,
+            log_record_attributes=LOG_RECORD_ATTRIBUTES_WITHOUT_TIMESTAMP,
             include_line_number=False,
             include_process_name=False,
             include_thread_name=False,
@@ -37,7 +37,7 @@ class TestLogging(BaseTestCase):
                 importlib.reload(sys.modules["octue"])
 
         create_octue_formatter.assert_called_with(
-            logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP,
+            log_record_attributes=LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP,
             include_line_number=False,
             include_process_name=False,
             include_thread_name=False,

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -21,7 +21,12 @@ class TestLogging(BaseTestCase):
             with mock.patch("octue.log_handlers.create_octue_formatter") as create_octue_formatter:
                 importlib.reload(sys.modules["octue"])
 
-        create_octue_formatter.assert_called_with(logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP)
+        create_octue_formatter.assert_called_with(
+            logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP,
+            include_line_number=False,
+            include_process_name=False,
+            include_thread_name=False,
+        )
 
     def test_metadata_schema_with_timestamp_used_if_compute_provider_is_not_google_cloud_run(self):
         """Test that the formatter without a timestamp is used for logging if the `COMPUTE_PROVIDER` environment
@@ -31,7 +36,12 @@ class TestLogging(BaseTestCase):
             with mock.patch("octue.log_handlers.create_octue_formatter") as create_octue_formatter:
                 importlib.reload(sys.modules["octue"])
 
-        create_octue_formatter.assert_called_with(logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP)
+        create_octue_formatter.assert_called_with(
+            logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP,
+            include_line_number=False,
+            include_process_name=False,
+            include_thread_name=False,
+        )
 
     def test_octue_log_handler_not_used_if_use_octue_log_handler_environment_variable_not_present_or_0(self):
         """Test that the default octue log handler is not used if the `USE_OCTUE_LOG_HANDLER` environment variable is

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -13,7 +13,7 @@ from tests.base import BaseTestCase
 
 
 class TestLogging(BaseTestCase):
-    def test_metadata_schema_without_timestamp_used_if_compute_provider_is_google_cloud_run(self):
+    def test_log_record_attributes_without_timestamp_used_if_compute_provider_is_google_cloud_run(self):
         """Test that the formatter without a timestamp is used for logging if the `COMPUTE_PROVIDER` environment
         variable is present and equal to "GOOGLE_CLOUD_RUN", and `USE_OCTUE_LOG_HANDLER` is equal to "1".
         """
@@ -28,9 +28,9 @@ class TestLogging(BaseTestCase):
             include_thread_name=False,
         )
 
-    def test_metadata_schema_with_timestamp_used_if_compute_provider_is_not_google_cloud_run(self):
+    def test_log_record_attributes_with_timestamp_used_if_compute_provider_is_not_google_cloud_run(self):
         """Test that the formatter without a timestamp is used for logging if the `COMPUTE_PROVIDER` environment
-        variable is present and equal to "GOOGLE_CLOUD_RUN", and `USE_OCTUE_LOG_HANDLER` is equal to "1".
+        variable is present and not equal to "GOOGLE_CLOUD_RUN", and `USE_OCTUE_LOG_HANDLER` is equal to "1".
         """
         with mock.patch.dict(os.environ, USE_OCTUE_LOG_HANDLER="1", COMPUTE_PROVIDER="BLAH"):
             with mock.patch("octue.log_handlers.create_octue_formatter") as create_octue_formatter:
@@ -69,16 +69,16 @@ class TestLogging(BaseTestCase):
 
         mock_apply_log_handler.assert_called()
 
-    def test_extra_log_metadata_is_included_if_relevant_environment_variables_provided(self):
-        """Test that the expected extra log metadata is included in the log context if the relevant environment
-        variables are provided.
+    def test_extra_log_record_attributes_are_included_if_relevant_environment_variables_provided(self):
+        """Test that the expected extra log record attributes are included in the log context if the relevant
+        environment variables are provided.
         """
         with mock.patch.dict(
             os.environ,
             USE_OCTUE_LOG_HANDLER="1",
-            INCLUDE_LINE_NUMBER_LOG_METADATA="1",
-            INCLUDE_PROCESS_NAME_LOG_METADATA="1",
-            INCLUDE_THREAD_NAME_LOG_METADATA="1",
+            INCLUDE_LINE_NUMBER_IN_LOGS="1",
+            INCLUDE_PROCESS_NAME_IN_LOGS="1",
+            INCLUDE_THREAD_NAME_IN_LOGS="1",
         ):
             with mock.patch("octue.log_handlers.apply_log_handler") as mock_apply_log_handler:
                 importlib.reload(sys.modules["octue"])

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -69,6 +69,27 @@ class TestLogging(BaseTestCase):
 
         mock_apply_log_handler.assert_called()
 
+    def test_extra_log_metadata_is_included_if_relevant_environment_variables_provided(self):
+        """Test that the expected extra log metadata is included in the log context if the relevant environment
+        variables are provided.
+        """
+        with mock.patch.dict(
+            os.environ,
+            USE_OCTUE_LOG_HANDLER="1",
+            INCLUDE_LINE_NUMBER_LOG_METADATA="1",
+            INCLUDE_PROCESS_NAME_LOG_METADATA="1",
+            INCLUDE_THREAD_NAME_LOG_METADATA="1",
+        ):
+            with mock.patch("octue.log_handlers.apply_log_handler") as mock_apply_log_handler:
+                importlib.reload(sys.modules["octue"])
+
+                mock_apply_log_handler.assert_called_with(
+                    logger_name=None,
+                    include_line_number=True,
+                    include_process_name=True,
+                    include_thread_name=True,
+                )
+
 
 class TestGetRemoteHandler(BaseTestCase):
     def test_get_remote_handler_parses_ws_properly(self):

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -4,30 +4,34 @@ import os
 import sys
 from unittest import mock
 
-from octue.log_handlers import FORMATTER_WITH_TIMESTAMP, FORMATTER_WITHOUT_TIMESTAMP, get_remote_handler
+from octue.log_handlers import (
+    LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP,
+    LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP,
+    get_remote_handler,
+)
 from tests.base import BaseTestCase
 
 
 class TestLogging(BaseTestCase):
-    def test_formatter_without_timestamp_used_if_compute_provider_is_google_cloud_run(self):
+    def test_metadata_schema_without_timestamp_used_if_compute_provider_is_google_cloud_run(self):
         """Test that the formatter without a timestamp is used for logging if the `COMPUTE_PROVIDER` environment
         variable is present and equal to "GOOGLE_CLOUD_RUN", and `USE_OCTUE_LOG_HANDLER` is equal to "1".
         """
         with mock.patch.dict(os.environ, USE_OCTUE_LOG_HANDLER="1", COMPUTE_PROVIDER="GOOGLE_CLOUD_RUN"):
-            with mock.patch("octue.log_handlers.apply_log_handler") as mock_apply_log_handler:
+            with mock.patch("octue.log_handlers.create_octue_formatter") as create_octue_formatter:
                 importlib.reload(sys.modules["octue"])
 
-        mock_apply_log_handler.assert_called_with(logger_name=None, formatter=FORMATTER_WITHOUT_TIMESTAMP)
+        create_octue_formatter.assert_called_with(logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITHOUT_TIMESTAMP)
 
-    def test_formatter_with_timestamp_used_if_compute_provider_is_not_google_cloud_run(self):
+    def test_metadata_schema_with_timestamp_used_if_compute_provider_is_not_google_cloud_run(self):
         """Test that the formatter without a timestamp is used for logging if the `COMPUTE_PROVIDER` environment
         variable is present and equal to "GOOGLE_CLOUD_RUN", and `USE_OCTUE_LOG_HANDLER` is equal to "1".
         """
         with mock.patch.dict(os.environ, USE_OCTUE_LOG_HANDLER="1", COMPUTE_PROVIDER="BLAH"):
-            with mock.patch("octue.log_handlers.apply_log_handler") as mock_apply_log_handler:
+            with mock.patch("octue.log_handlers.create_octue_formatter") as create_octue_formatter:
                 importlib.reload(sys.modules["octue"])
 
-        mock_apply_log_handler.assert_called_with(logger_name=None, formatter=FORMATTER_WITH_TIMESTAMP)
+        create_octue_formatter.assert_called_with(logging_metadata_schema=LOGGING_METADATA_SCHEMA_WITH_TIMESTAMP)
 
     def test_octue_log_handler_not_used_if_use_octue_log_handler_environment_variable_not_present_or_0(self):
         """Test that the default octue log handler is not used if the `USE_OCTUE_LOG_HANDLER` environment variable is


### PR DESCRIPTION
## Summary
Ensure the root logger includes the analysis ID in the logging context for the duration of the analysis.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#304](https://github.com/octue/octue-sdk-python/pull/304))

### Enhancements
- Swap root log handlers for handlers that include the analysis ID in the logging context for duration of analysis
- Allow easy addition of line number, process name, and thread name to logging context via new environment variables

### Fixes
- Ensure analysis logging includes log messages from any packages or modules used during the analysis
- Ensure the name of the module from which the log message is emitted is correct for log messages emitted during the analysis
- Fix Pub/Sub delivery attempt key error

### Refactoring
- Rename `create_formatter` to `create_octue_formatter`

### Testing
- Update example service ID

<!--- END AUTOGENERATED NOTES --->