### PR TITLE
Allow kwargs to be passed to Dataset.from_local_directory

### DIFF
--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -51,11 +51,12 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         return len(self.files)
 
     @classmethod
-    def from_local_directory(cls, path_to_directory, recursive=False):
+    def from_local_directory(cls, path_to_directory, recursive=False, **kwargs):
         """Instantiate a Dataset from the files in the given local directory.
 
         :param str path_to_directory: path to a local directory
         :param bool recursive: if `True`, include all files in the directory's subdirectories recursively
+        :param kwargs: other keyword arguments for the `Dataset` instantiation
         :return Dataset:
         """
         datafiles = FilterSet()
@@ -68,7 +69,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
 
                 datafiles.add(Datafile(path=os.path.join(directory_path, filename)))
 
-        return Dataset(path=path_to_directory, files=datafiles)
+        return Dataset(path=path_to_directory, files=datafiles, **kwargs)
 
     @classmethod
     def from_cloud(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.8.1",
+    version="0.8.2",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -529,10 +529,13 @@ class TestDataset(BaseTestCase):
                 self.assertEqual(f.read(), "['blah', 'b', 'c']")
 
     def test_from_local_directory(self):
-        """Test that a dataset can be instantiated from a local nested directory ignoring its subdirectories."""
+        """Test that a dataset can be instantiated from a local nested directory ignoring its subdirectories and that
+        extra keyword arguments can be provided for the dataset instantiation.
+        """
         with tempfile.TemporaryDirectory() as temporary_directory:
             paths = self._create_files_and_nested_subdirectories(temporary_directory)
-            dataset = Dataset.from_local_directory(temporary_directory, recursive=False)
+            dataset = Dataset.from_local_directory(temporary_directory, recursive=False, name="my-dataset")
+            self.assertEqual(dataset.name, "my-dataset")
 
             # Check that just the top-level files from the directory are present in the dataset.
             datafile_paths = {datafile.path for datafile in dataset.files}


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#309](https://github.com/octue/octue-sdk-python/pull/309))

### Enhancements
- Allow kwargs to be passed to `Dataset.from_local_directory` (in response to [this issue](https://github.com/windpioneers/power-loss/pull/163#discussion_r782973746))

<!--- END AUTOGENERATED NOTES --->