### PR TITLE
Add line between built-in and third-party imports

### DIFF
--- a/octue/cli.py
+++ b/octue/cli.py
@@ -1,6 +1,7 @@
 import functools
 import os
 import sys
+
 import click
 import pkg_resources
 
@@ -233,7 +234,7 @@ def deploy():
 @deploy.command()
 @click.option(
     "--octue-configuration-path",
-    type=click.Path(),
+    type=click.Path(exists=True, dir_okay=False),
     default="octue.yaml",
     show_default=True,
     help="Path to an octue.yaml file.",

--- a/octue/cloud/credentials.py
+++ b/octue/cloud/credentials.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import warnings
+
 from google.oauth2 import service_account
 
 

--- a/octue/cloud/deployment/google/cloud_run/flask_app.py
+++ b/octue/cloud/deployment/google/cloud_run/flask_app.py
@@ -1,4 +1,5 @@
 import logging
+
 from flask import Flask, request
 
 from octue.cloud.deployment.google.answer_pub_sub_question import answer_question

--- a/octue/cloud/deployment/google/dataflow/deploy.py
+++ b/octue/cloud/deployment/google/dataflow/deploy.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 import apache_beam
 from apache_beam.options.pipeline_options import PipelineOptions
 

--- a/octue/cloud/deployment/google/deployer.py
+++ b/octue/cloud/deployment/google/deployer.py
@@ -1,6 +1,7 @@
 import subprocess
 import tempfile
 import uuid
+
 import yaml
 
 from octue.cloud.pub_sub.service import OCTUE_NAMESPACE, Service

--- a/octue/cloud/emulators.py
+++ b/octue/cloud/emulators.py
@@ -2,6 +2,7 @@ import logging
 import os
 import socket
 from contextlib import closing
+
 from gcp_storage_emulator.server import create_server
 
 

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+
 from google.api_core import retry
 
 import octue.exceptions

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -8,6 +8,7 @@ import sys
 import time
 import traceback as tb
 import uuid
+
 from google.cloud import pubsub_v1
 
 import octue.exceptions

--- a/octue/cloud/pub_sub/subscription.py
+++ b/octue/cloud/pub_sub/subscription.py
@@ -1,4 +1,5 @@
 import logging
+
 import google.api_core.exceptions
 from google.cloud.pubsub_v1 import SubscriberClient
 from google.cloud.pubsub_v1.types import ExpirationPolicy, FieldMask, RetryPolicy

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -1,5 +1,6 @@
 import logging
 import time
+
 import google.api_core.exceptions
 
 

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import os
+
 from google.cloud import storage
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google_crc32c import Checksum

--- a/octue/mixins/hashable.py
+++ b/octue/mixins/hashable.py
@@ -1,6 +1,7 @@
 import base64
 import collections.abc
 import datetime
+
 from google_crc32c import Checksum
 
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tempfile
 from urllib.parse import urlparse
+
 import google.api_core.exceptions
 
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import json
 import os
+
 import google.api_core.exceptions
 
 from octue import definitions

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -6,6 +6,7 @@ from octue.cloud.storage import GoogleCloudStorageClient
 from octue.exceptions import InvalidInputException, InvalidManifestException
 from octue.mixins import Hashable, Identifiable, Pathable, Serialisable
 from octue.resources.datafile import CLOUD_STORAGE_PROTOCOL
+
 from .dataset import Dataset
 
 

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -2,6 +2,7 @@ import importlib
 import logging
 import os
 import sys
+
 import google.api_core.exceptions
 from google.cloud import secretmanager
 

--- a/octue/templates/template-child-services/elevation_service/setup.py
+++ b/octue/templates/template-child-services/elevation_service/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 

--- a/octue/templates/template-child-services/parent_service/setup.py
+++ b/octue/templates/template-child-services/parent_service/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 

--- a/octue/templates/template-child-services/wind_speed_service/setup.py
+++ b/octue/templates/template-child-services/wind_speed_service/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 

--- a/octue/templates/template-python-fractal/fractal/fractal.py
+++ b/octue/templates/template-python-fractal/fractal/fractal.py
@@ -2,6 +2,7 @@ import json
 
 from octue.resources import Datafile
 from octue.utils.encoders import OctueJSONEncoder
+
 from .mandelbrot import mandelbrot
 
 

--- a/octue/templates/template-python-fractal/setup.py
+++ b/octue/templates/template-python-fractal/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -1,4 +1,5 @@
 import logging
+
 from cleaner import clean, read_csv_files, read_dat_file
 
 from octue.resources import Datafile

--- a/octue/templates/template-using-manifests/cleaner/clean.py
+++ b/octue/templates/template-using-manifests/cleaner/clean.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime, timezone
+
 from stringcase import snakecase
 
 

--- a/octue/templates/template-using-manifests/setup.py
+++ b/octue/templates/template-using-manifests/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import setup
 
 

--- a/octue/utils/decoders.py
+++ b/octue/utils/decoders.py
@@ -1,5 +1,6 @@
 import json
 from json import JSONDecoder
+
 import dateutil.parser
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,9 @@ ignore = F405, E501, W503, E203, E731
 [isort]
 line_length=120
 default_section = THIRDPARTY
-known_third_party = requests, click, jsonschema
-known_first_party = octue,app,fractal,test, twined
+known_third_party = requests,click,jsonschema
+known_first_party = octue,app,fractal,test,tests,twined
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-no_lines_before = THIRDPARTY, LOCALFOLDER
 lines_after_imports=2
 # These are necessary for `isort` to create import statements that are
 # compatible with `black`. Changing these will break auto-formatting.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.0",
+    version="0.9.1",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",

--- a/tests/cloud/deployment/google/test_deployer.py
+++ b/tests/cloud/deployment/google/test_deployer.py
@@ -2,6 +2,7 @@ import copy
 import os
 import tempfile
 from unittest.mock import Mock, patch
+
 import yaml
 
 from octue.cloud.deployment.google.deployer import DEFAULT_DOCKERFILE_URL, CloudRunDeployer

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 import google.api_core.exceptions
 
 from octue.cloud.pub_sub import Subscription, Topic

--- a/tests/cloud/pub_sub/test_subscription.py
+++ b/tests/cloud/pub_sub/test_subscription.py
@@ -1,5 +1,6 @@
 import os
 from unittest.mock import patch
+
 import google.api_core.exceptions
 from google.cloud.pubsub_v1 import SubscriberClient
 

--- a/tests/cloud/pub_sub/test_topic.py
+++ b/tests/cloud/pub_sub/test_topic.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 import google.api_core.exceptions
 
 from octue.cloud.pub_sub.service import Service

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from unittest.mock import patch
+
 import google.api_core.exceptions
 import google.cloud.exceptions
 

--- a/tests/cloud/test_credentials.py
+++ b/tests/cloud/test_credentials.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from unittest.mock import patch
+
 import google.oauth2.service_account
 
 from octue.cloud.credentials import GCPCredentialsManager

--- a/tests/mixins/test_base.py
+++ b/tests/mixins/test_base.py
@@ -1,4 +1,5 @@
 from octue.mixins import MixinBase
+
 from ..base import BaseTestCase
 
 

--- a/tests/mixins/test_hashable.py
+++ b/tests/mixins/test_hashable.py
@@ -1,5 +1,6 @@
 from octue.mixins import Hashable
 from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
+
 from ..base import BaseTestCase
 
 

--- a/tests/mixins/test_identifiable.py
+++ b/tests/mixins/test_identifiable.py
@@ -2,6 +2,7 @@ import uuid
 
 from octue import exceptions
 from octue.mixins import Identifiable
+
 from ..base import BaseTestCase
 
 

--- a/tests/mixins/test_labellable.py
+++ b/tests/mixins/test_labellable.py
@@ -1,6 +1,7 @@
 from octue import exceptions
 from octue.mixins import Labelable
 from octue.resources.label import Label, LabelSet
+
 from ..base import BaseTestCase
 
 

--- a/tests/mixins/test_pathable.py
+++ b/tests/mixins/test_pathable.py
@@ -2,6 +2,7 @@ import os
 
 from octue.exceptions import InvalidInputException
 from octue.mixins import MixinBase, Pathable
+
 from ..base import BaseTestCase
 
 

--- a/tests/mixins/test_serialisable.py
+++ b/tests/mixins/test_serialisable.py
@@ -4,6 +4,7 @@ import os
 from tempfile import TemporaryDirectory
 
 from octue.mixins import Serialisable
+
 from ..base import BaseTestCase
 
 

--- a/tests/mixins/test_taggable.py
+++ b/tests/mixins/test_taggable.py
@@ -1,6 +1,7 @@
 from octue import exceptions
 from octue.mixins import Taggable
 from octue.resources.tag import TagDict
+
 from ..base import BaseTestCase
 
 

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -2,6 +2,7 @@ import logging
 
 from octue.resources.analysis import HASH_FUNCTIONS, Analysis
 from twined import Twine
+
 from ..base import BaseTestCase
 
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -5,6 +5,7 @@ import tempfile
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import patch
+
 import h5py
 import pkg_resources
 
@@ -16,6 +17,7 @@ from octue.resources.datafile import Datafile
 from octue.resources.label import LabelSet
 from octue.resources.tag import TagDict
 from tests import TEST_BUCKET_NAME, TEST_PROJECT_NAME
+
 from ..base import BaseTestCase
 
 

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -9,6 +9,7 @@ import uuid
 
 from octue import Runner
 from octue.utils.processes import ProcessesContextManager
+
 from ..base import BaseTestCase
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import uuid
 from unittest import mock
+
 from click.testing import CliRunner
 
 from octue import REPOSITORY_ROOT

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,11 @@ class TestDeployCommand(BaseTestCase):
         """Test that a deployment error is raised if attempting to update a deployed service without providing the
         service ID.
         """
-        result = CliRunner().invoke(octue_cli, ["deploy", "cloud-run", "--update"])
+        with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
+            result = CliRunner().invoke(
+                octue_cli,
+                ["deploy", "cloud-run", f"--octue-configuration-path={temporary_file.name}", "--update"],
+            )
         self.assertEqual(result.exit_code, 1)
         self.assertIsInstance(result.exception, DeploymentError)
 


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#313](https://github.com/octue/octue-sdk-python/pull/313))

### Enhancements
- Raise more succinct error if `octue.yaml` file cannot be found in CLI command

### Style
- Add line between built-in, third-party, and relative imports

<!--- END AUTOGENERATED NOTES --->