### PR TITLE
Add missing arguments to Dataflow deployer

### DIFF
--- a/octue/cli.py
+++ b/octue/cli.py
@@ -5,7 +5,12 @@ import sys
 import click
 import pkg_resources
 
-from octue.cloud.deployment.google.dataflow.deploy import DEFAULT_IMAGE_URI, deploy_streaming_pipeline
+from octue.cloud.deployment.google.dataflow.deploy import (
+    DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION,
+    DEFAULT_IMAGE_URI,
+    DEFAULT_SETUP_FILE_PATH,
+    deploy_streaming_pipeline,
+)
 from octue.cloud.deployment.google.deployer import CloudRunDeployer
 from octue.cloud.pub_sub.service import Service
 from octue.definitions import CHILDREN_FILENAME, FOLDER_DEFAULTS, MANIFEST_FILENAME, VALUES_FILENAME
@@ -268,13 +273,36 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
     help="One of the valid apache-beam runners to use to execute the pipeline.",
 )
 @click.option(
+    "--setup-file-path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=DEFAULT_SETUP_FILE_PATH,
+    show_default=True,
+    help="The path to a python `setup.py` file to use for the service.",
+)
+@click.option(
     "--image-uri",
     type=str,
     default=DEFAULT_IMAGE_URI,
     show_default=True,
     help="The URI of the apache-beam-based Docker image to use for the service.",
 )
-def dataflow(service_name, service_id, project_name, region, runner, image_uri):
+@click.option(
+    "--temporary-files-location",
+    type=str,
+    default=DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION,
+    show_default=True,
+    help="The Google Cloud Storage path to save temporary files from the service at.",
+)
+def dataflow(
+    service_name,
+    service_id,
+    project_name,
+    region,
+    runner,
+    setup_file_path,
+    image_uri,
+    temporary_files_location,
+):
     """Deploy an app as a Google Dataflow streaming service.
 
     SERVICE_NAME - the name to give the service
@@ -291,7 +319,9 @@ def dataflow(service_name, service_id, project_name, region, runner, image_uri):
         service_id=service_id,
         region=region,
         runner=runner,
+        setup_file_path=os.path.abspath(setup_file_path),
         image_uri=image_uri,
+        temporary_files_location=temporary_files_location,
     )
 
 

--- a/octue/cloud/deployment/google/dataflow/deploy.py
+++ b/octue/cloud/deployment/google/dataflow/deploy.py
@@ -12,8 +12,9 @@ from octue.cloud.pub_sub import Topic
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_SETUP_FILE_PATH = os.path.join(REPOSITORY_ROOT, "setup.py")
 DEFAULT_IMAGE_URI = "eu.gcr.io/octue-amy/octue-sdk-python:latest"
-DATAFLOW_TEMPORARY_FILES_LOCATION = "gs://octue-sdk-python-dataflow-temporary-data/temp"
+DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION = "gs://octue-sdk-python-dataflow-temporary-data/temp"
 
 
 def deploy_streaming_pipeline(
@@ -22,7 +23,9 @@ def deploy_streaming_pipeline(
     project_name,
     region,
     runner="DataflowRunner",
+    setup_file_path=DEFAULT_SETUP_FILE_PATH,
     image_uri=DEFAULT_IMAGE_URI,
+    temporary_files_location=DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION,
     extra_options=None,
 ):
     """Deploy a streaming Dataflow pipeline to Google Cloud.
@@ -32,18 +35,20 @@ def deploy_streaming_pipeline(
     :param str project_name: the name of the project to deploy the pipeline to
     :param str region: the region to deploy the pipeline to
     :param str runner: the name of an apache-beam runner to use to execute the pipeline
-    :param str|None image_uri: the URI of the apache-beam-based Docker image to use for the pipeline
+    :param str setup_file_path: path to the python `setup.py` file to use for the service
+    :param str image_uri: the URI of the apache-beam-based Docker image to use for the pipeline
+    :param str temporary_files_location: a Google Cloud Storage path to save temporary files from the service at
     :param iter|None extra_options: any further arguments in command-line-option format to be passed to Apache Beam as pipeline options
     :return None:
     """
     beam_args = [
         f"--project={project_name}",
         f"--region={region}",
-        f"--temp_location={DATAFLOW_TEMPORARY_FILES_LOCATION}",
+        f"--temp_location={temporary_files_location}",
         f"--job_name={service_name}",
         f"--runner={runner}",
         "--dataflow_service_options=enable_prime",
-        f"--setup_file={os.path.join(REPOSITORY_ROOT, 'setup.py')}",
+        f"--setup_file={setup_file_path}",
         *(extra_options or []),
     ]
 

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -227,6 +227,7 @@ class Service(CoolNameable):
         )
         response_subscription.create(allow_existing=True)
 
+        serialised_input_manifest = None
         if input_manifest is not None:
             serialised_input_manifest = input_manifest.serialise()
 

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -228,11 +228,11 @@ class Service(CoolNameable):
         response_subscription.create(allow_existing=True)
 
         if input_manifest is not None:
-            input_manifest = input_manifest.serialise()
+            serialised_input_manifest = input_manifest.serialise()
 
         self.publisher.publish(
             topic=question_topic.path,
-            data=json.dumps({"input_values": input_values, "input_manifest": input_manifest}).encode(),
+            data=json.dumps({"input_values": input_values, "input_manifest": serialised_input_manifest}).encode(),
             question_uuid=question_uuid,
             forward_logs=str(int(subscribe_to_logs)),
         )

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -101,6 +101,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
                 GoogleCloudStorageClient(project_name=project_name).download_as_string(
                     bucket_name=bucket_name,
                     path_in_bucket=storage.path.join(path_to_dataset_directory, definitions.DATASET_METADATA_FILENAME),
+                    timeout=120,
                 )
             )
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.1",
+    version="0.9.2",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 
 from octue import REPOSITORY_ROOT
 from octue.cli import octue_cli
-from octue.cloud.deployment.google.dataflow.deploy import DATAFLOW_TEMPORARY_FILES_LOCATION
+from octue.cloud.deployment.google.dataflow.deploy import DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION
 from octue.exceptions import DeploymentError
 from tests import TESTS_DIR
 from tests.base import BaseTestCase
@@ -151,7 +151,7 @@ class TestDeployCommand(BaseTestCase):
 
         self.assertEqual(pipeline_options["project"], "my-project")
         self.assertEqual(pipeline_options["region"], "my-region")
-        self.assertEqual(pipeline_options["temp_location"], DATAFLOW_TEMPORARY_FILES_LOCATION)
+        self.assertEqual(pipeline_options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
         self.assertEqual(pipeline_options["job_name"], "my-service")
         self.assertEqual(pipeline_options["runner"], "MyApacheBeamRunner")
         self.assertEqual(pipeline_options["dataflow_service_options"], ["enable_prime"])


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#314](https://github.com/octue/octue-sdk-python/pull/314))

### Enhancements
- Increase timeout for loading dataset metadata

### Fixes
- Add setup file and temporary files location arguments to Dataflow deployer and CLI command
- Store unserialised input manifest in `Service._current_question`

<!--- END AUTOGENERATED NOTES --->