### PR TITLE
Add Dataflow deployment to generated build trigger

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.DS_store
+.git
+.idea
+__pycache__
+env
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8.12-slim
+
+RUN apt-get update && apt-get install -y git
+
+COPY setup.py setup.py
+
+COPY . .
+
+RUN pip3 install --upgrade pip && pip3 install -e .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,27 @@
+steps:
+  - id: Build
+    name: gcr.io/cloud-builders/docker
+    args:
+      - "-c"
+      - >-
+        docker build '-t'
+        '$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY_NAME:$TAG_NAME'
+        . '-f' Dockerfile
+    entrypoint: bash
+
+  - id: Push
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY_NAME:$TAG_NAME"
+
+images:
+  - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY_NAME:$TAG_NAME"
+timeout: 2400s
+options:
+  substitutionOption: ALLOW_LOOSE
+substitutions:
+  _GCR_HOSTNAME: eu.gcr.io
+  _REPOSITORY_NAME: octue-sdk-python
+tags:
+  - octue-sdk-python

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -272,17 +272,17 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
 @click.option("--no-cache", is_flag=True, help="If provided, don't use the Docker cache when building the image.")
 @click.option("--update", is_flag=True, help="If provided, allow updates to an existing service.")
 @click.option(
-    "--skip-build-trigger",
+    "--dataflow-job-only",
     is_flag=True,
-    help="If provided, skip creating and running the build trigger and just deploy the Dataflow job.",
+    help="If provided, skip creating and running the build trigger and just deploy a pre-built image to Dataflow",
 )
-def dataflow(octue_configuration_path, service_id, no_cache, update, skip_build_trigger):
+def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_job_only):
     """Deploy an app as a Google Dataflow streaming job."""
     if update and not service_id:
         raise DeploymentError("If updating a service, you must also provide the `--service-id` argument.")
 
     deployer = DataflowDeployer(octue_configuration_path, service_id=service_id)
-    deployer.deploy(no_cache=no_cache, update=update, skip_build_trigger=skip_build_trigger)
+    deployer.deploy(no_cache=no_cache, update=update, dataflow_job_only=dataflow_job_only)
 
 
 def set_unavailable_strand_paths_to_none(twine, strands):

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -271,13 +271,18 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
 )
 @click.option("--no-cache", is_flag=True, help="If provided, don't use the Docker cache when building the image.")
 @click.option("--update", is_flag=True, help="If provided, allow updates to an existing service.")
-def dataflow(octue_configuration_path, service_id, no_cache, update):
-    """Deploy an app as a Google Dataflow streaming service."""
+@click.option(
+    "--skip-build-trigger",
+    is_flag=True,
+    help="If provided, skip creating and running the build trigger and just deploy the Dataflow job.",
+)
+def dataflow(octue_configuration_path, service_id, no_cache, update, skip_build_trigger):
+    """Deploy an app as a Google Dataflow streaming job."""
     if update and not service_id:
         raise DeploymentError("If updating a service, you must also provide the `--service-id` argument.")
 
     deployer = DataflowDeployer(octue_configuration_path, service_id=service_id)
-    deployer.deploy(no_cache=no_cache, update=update)
+    deployer.deploy(no_cache=no_cache, update=update, skip_build_trigger=skip_build_trigger)
 
 
 def set_unavailable_strand_paths_to_none(twine, strands):

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -174,7 +174,7 @@ class BaseDeployer:
         that, if a `cloudbuild.yaml` file is provided instead of generated, the correct image URI from this file is
         used in later steps.
 
-        :return str: the build ID
+        :return None:
         """
         with ProgressMessage("Running build trigger", 3, self.TOTAL_NUMBER_OF_STAGES):
             build_command = [
@@ -192,7 +192,7 @@ class BaseDeployer:
             process = self._run_command(build_command)
             metadata = json.loads(process.stdout.decode())["metadata"]
             self.image_uri = metadata["build"]["images"][0]
-            return metadata["build"]["id"]
+            self._wait_for_build_to_finish(metadata["build"]["id"])
 
     def _wait_for_build_to_finish(self, build_id, check_period=20):
         """Wait for the build with the given ID to finish.
@@ -214,7 +214,7 @@ class BaseDeployer:
             process = self._run_command(get_build_command)
             status = json.loads(process.stdout.decode())["status"]
 
-            if status not in {"WORKING", "SUCCESS"}:
+            if status not in {"QUEUED", "WORKING", "SUCCESS"}:
                 raise DeploymentError(f"The build status is {status!r}.")
 
             if status == "SUCCESS":

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -48,10 +48,7 @@ class CloudRunDeployer(BaseDeployer):
         """
         self._generate_cloud_build_configuration(no_cache=no_cache)
         self._create_build_trigger(update=update)
-
-        build_id = self._run_build_trigger()
-        self._wait_for_build_to_finish(build_id)
-
+        self._run_build_trigger()
         self._allow_unauthenticated_messages()
         self._create_eventarc_run_trigger(update=update)
 

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -112,6 +112,18 @@ class DataflowDeployer(BaseDeployer):
                         "name": "gcr.io/cloud-builders/docker",
                         "args": ["push", self.image_uri],
                     },
+                    {
+                        "id": "Deploy Dataflow job",
+                        "name": "eu.gcr.io/octue-amy/octue-sdk-python/deployer:latest",
+                        "args": [
+                            "octue-app",
+                            "deploy",
+                            "dataflow",
+                            f"--service-id={self.service_id}",
+                            "--update",
+                            "--skip-build-trigger",
+                        ],
+                    },
                 ],
                 "images": [self.image_uri],
             }

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -63,7 +63,6 @@ class DataflowDeployer(BaseDeployer):
         self._generate_cloud_build_configuration(no_cache=no_cache)
         self._create_build_trigger(update=update)
         self._run_build_trigger()
-        self._deploy_streaming_dataflow_job(update=update)
         print(self.success_message)
 
     def _generate_cloud_build_configuration(self, no_cache=False):

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -59,6 +59,7 @@ class DataflowDeployer(BaseDeployer):
         if dataflow_job_only:
             self._deploy_streaming_dataflow_job(update=update)
             print(self.success_message)
+            return
 
         self._generate_cloud_build_configuration(no_cache=no_cache)
         self._create_build_trigger(update=update)

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -54,10 +54,7 @@ class DataflowDeployer(BaseDeployer):
         """
         self._generate_cloud_build_configuration(no_cache=no_cache)
         self._create_build_trigger(update=update)
-
-        build_id = self._run_build_trigger()
-        self._wait_for_build_to_finish(build_id)
-
+        self._run_build_trigger()
         self._deploy_streaming_dataflow_job(update=update)
 
         print(f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {self.service_id!r}.")

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -10,6 +10,8 @@ DEFAULT_DATAFLOW_DOCKERFILE_URL = (
     "https://raw.githubusercontent.com/octue/octue-sdk-python/main/octue/cloud/deployment/google/dataflow/Dockerfile"
 )
 
+OCTUE_SDK_PYTHON_IMAGE_URI = "eu.gcr.io/octue-amy/octue-sdk-python:0.9.3-slim"
+
 
 class DataflowDeployer(BaseDeployer):
     """A tool for using an `octue.yaml` file in a repository to build and deploy the repository's `octue` app to Google
@@ -114,7 +116,7 @@ class DataflowDeployer(BaseDeployer):
                     },
                     {
                         "id": "Deploy Dataflow job",
-                        "name": "eu.gcr.io/octue-amy/octue-sdk-python/deployer:latest",
+                        "name": OCTUE_SDK_PYTHON_IMAGE_URI,
                         "args": [
                             "octue-app",
                             "deploy",

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -44,7 +44,7 @@ class DataflowDeployer(BaseDeployer):
         )
         self.setup_file_path = self._octue_configuration.get("setup_file_path", DEFAULT_SETUP_FILE_PATH)
 
-    def deploy(self, no_cache=False, update=False):
+    def deploy(self, no_cache=False, update=False, skip_build_trigger=False):
         """Create a Google Cloud Build configuration from the `octue.yaml file, create a build trigger, run it, and
         deploy the app as a Google Dataflow streaming job.
 
@@ -52,6 +52,10 @@ class DataflowDeployer(BaseDeployer):
         :param bool update: if `True`, allow the build trigger to already exist and just build and deploy a new image based on an updated `octue.yaml` file
         :return str: the service's UUID
         """
+        if skip_build_trigger:
+            self._deploy_streaming_dataflow_job(update=update)
+            return self.service_id
+
         self._generate_cloud_build_configuration(no_cache=no_cache)
         self._create_build_trigger(update=update)
         self._run_build_trigger()

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -17,11 +17,11 @@ class Topic:
     :return None:
     """
 
-    def __init__(self, name, namespace, service):
-        if name.startswith(namespace):
-            self.name = name
-        else:
+    def __init__(self, name, service, namespace=""):
+        if namespace and not name.startswith(namespace):
             self.name = f"{namespace}.{name}"
+        else:
+            self.name = name
 
         self.service = service
         self.path = self.generate_topic_path(service.backend.project_name, self.name)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.2",
+    version="0.9.3",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",


### PR DESCRIPTION
## Summary
When deploying a service to Dataflow, add future automated Dataflow deployment to the build trigger. This removes the need to manually re-deploy a service to Dataflow using `octue-app dataflow deploy` each time the build trigger is run.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#318](https://github.com/octue/octue-sdk-python/pull/318))

### Enhancements
- Add Cloud Build step to `DataflowDeployer` to deploy a job to Dataflow
- Stop deploying jobs to Dataflow directly from local machine by default in `DataflowDeployer`
- Add option to `deploy dataflow` CLI command to skip creating and running the build trigger and only deploy the Dataflow job
- Allow `Topic` to be instantiated without a namespace

### Fixes
- Make `BaseDeployer` wait for queued builds instead of raising an error
- Ensure `DataflowDeployer._deploy_streaming_dataflow_job` creates jobs if they don't exist when the `update` parameter is `True`
- Ensure the Dataflow service topic exists before deploying a job

### Refactoring
- Combine `BaseDeployer._run_build_trigger` and `BaseDeployer._wait_for_build_to_finish`

### Operations
- Add `.dockerignore` file
- Add `Dockerfile` and `cloudbuild.yaml` for the `octue` package

<!--- END AUTOGENERATED NOTES --->