### PR TITLE
Fix Dataflow deployment

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,27 +1,32 @@
 steps:
+  - id: Log in to Docker
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker login --username=$$USERNAME --password=$$PASSWORD']
+    secretEnv: ['USERNAME', 'PASSWORD']
+
   - id: Build
     name: gcr.io/cloud-builders/docker
-    args:
-      - "-c"
-      - >-
-        docker build '-t'
-        '$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY_NAME:$TAG_NAME'
-        . '-f' Dockerfile
     entrypoint: bash
+    args: ['-c', 'docker build -t octue/octue-sdk-python:$TAG_NAME .']
 
   - id: Push
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY_NAME:$TAG_NAME"
+    name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: ['-c', 'docker push octue/octue-sdk-python:$TAG_NAME']
 
 images:
-  - "$_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY_NAME:$TAG_NAME"
+  - ${_REPOSITORY_NAME}:$TAG_NAME
 timeout: 2400s
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:
-  _GCR_HOSTNAME: eu.gcr.io
-  _REPOSITORY_NAME: octue-sdk-python
+  _REPOSITORY_NAME: octue/octue-sdk-python
 tags:
   - octue-sdk-python
+availableSecrets:
+  secretManager:
+   - versionName: projects/octue-amy/secrets/DOCKER_HUB_ACCESS_TOKEN/versions/1
+     env: 'PASSWORD'
+   - versionName: projects/octue-amy/secrets/DOCKER_HUB_USERNAME/versions/1
+     env: 'USERNAME'

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -276,13 +276,20 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
     is_flag=True,
     help="If provided, skip creating and running the build trigger and just deploy a pre-built image to Dataflow",
 )
-def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_job_only):
+@click.option("--image-uri-template", type=str, default=None, help="The `cloudbuild.yaml` template for the image URI.")
+@click.option("--image-uri", type=str, default=None, help="The actual image URI to use when creating the Dataflow job.")
+def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_job_only, image_uri_template, image_uri):
     """Deploy an app as a Google Dataflow streaming job."""
     if update and not service_id:
         raise DeploymentError("If updating a service, you must also provide the `--service-id` argument.")
 
-    deployer = DataflowDeployer(octue_configuration_path, service_id=service_id)
-    deployer.deploy(no_cache=no_cache, update=update, dataflow_job_only=dataflow_job_only)
+    deployer = DataflowDeployer(octue_configuration_path, service_id=service_id, image_uri_template=image_uri_template)
+
+    if dataflow_job_only:
+        deployer.create_streaming_dataflow_job(image_uri=image_uri, update=update)
+        return
+
+    deployer.deploy(no_cache=no_cache, update=update)
 
 
 def set_unavailable_strand_paths_to_none(twine, strands):

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -58,7 +58,7 @@ class BaseDeployer:
         self.build_trigger_description = None
         self.generated_cloud_build_configuration = None
         self.service_id = service_id or str(uuid.uuid4())
-        self.required_environment_variables = [f"SERVICE_ID={self.service_id}", f"SERVICE_NAME={self.name}"]
+        self.required_environment_variables = {"SERVICE_ID": self.service_id, "SERVICE_NAME": self.name}
 
         if image_uri_template:
             self._image_uri_provided = True

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -87,7 +87,7 @@ class CloudRunDeployer(BaseDeployer):
 
             environment_variables = ",".join(
                 [f"{variable['name']}={variable['value']}" for variable in self.environment_variables]
-                + self.required_environment_variables
+                + [f"{name}={value}" for name, value in self.required_environment_variables.items()]
             )
 
             self.generated_cloud_build_configuration = {

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -34,8 +34,8 @@ class CloudRunDeployer(BaseDeployer):
 
     TOTAL_NUMBER_OF_STAGES = 5
 
-    def __init__(self, octue_configuration_path, service_id=None):
-        super().__init__(octue_configuration_path, service_id)
+    def __init__(self, octue_configuration_path, service_id=None, image_uri_template=None):
+        super().__init__(octue_configuration_path, service_id, image_uri_template)
         self.build_trigger_description = f"Build the {self.name!r} service and deploy it to Cloud Run."
 
     def deploy(self, no_cache=False, update=False):
@@ -71,8 +71,11 @@ class CloudRunDeployer(BaseDeployer):
             1,
             self.TOTAL_NUMBER_OF_STAGES,
         ) as progress_message:
+
             if self.provided_cloud_build_configuration_path:
-                progress_message.finish_message = "skipped - using cloudbuild.yaml file from repository."
+                progress_message.finish_message = (
+                    f"skipped - using {self._octue_configuration['cloud_build_configuration_path']!r} from repository."
+                )
                 return
 
             get_dockerfile_step, dockerfile_path = self._create_get_dockerfile_step(DEFAULT_CLOUD_RUN_DOCKERFILE_URL)
@@ -93,12 +96,12 @@ class CloudRunDeployer(BaseDeployer):
                     {
                         "id": "Build image",
                         "name": "gcr.io/cloud-builders/docker",
-                        "args": ["build", *cache_option, "-t", self.image_uri, ".", "-f", dockerfile_path],
+                        "args": ["build", *cache_option, "-t", self.image_uri_template, ".", "-f", dockerfile_path],
                     },
                     {
                         "id": "Push image",
                         "name": "gcr.io/cloud-builders/docker",
-                        "args": ["push", self.image_uri],
+                        "args": ["push", self.image_uri_template],
                     },
                     {
                         "id": "Deploy image to Google Cloud Run",
@@ -110,7 +113,7 @@ class CloudRunDeployer(BaseDeployer):
                             "update",
                             self.name,
                             "--platform=managed",
-                            f"--image={self.image_uri}",
+                            f"--image={self.image_uri_template}",
                             f"--region={self.region}",
                             f"--memory={self.memory}",
                             f"--cpu={self.cpus}",
@@ -123,7 +126,7 @@ class CloudRunDeployer(BaseDeployer):
                         ],
                     },
                 ],
-                "images": [self.image_uri],
+                "images": [self.image_uri_template],
             }
 
     def _allow_unauthenticated_messages(self):

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -10,7 +10,7 @@ DEFAULT_DATAFLOW_DOCKERFILE_URL = (
     "https://raw.githubusercontent.com/octue/octue-sdk-python/main/octue/cloud/deployment/google/dataflow/Dockerfile"
 )
 
-OCTUE_SDK_PYTHON_IMAGE_URI = "octue/octue-sdk-python:0.9.3-slim"
+OCTUE_SDK_PYTHON_IMAGE_URI = "octue/octue-sdk-python:0.9.4-slim"
 
 
 class DataflowDeployer(BaseDeployer):
@@ -34,7 +34,7 @@ class DataflowDeployer(BaseDeployer):
     :return None:
     """
 
-    TOTAL_NUMBER_OF_STAGES = 4
+    TOTAL_NUMBER_OF_STAGES = 3
 
     def __init__(self, octue_configuration_path, service_id=None, image_uri_template=None):
         super().__init__(octue_configuration_path, service_id, image_uri_template)
@@ -67,7 +67,7 @@ class DataflowDeployer(BaseDeployer):
         :param bool update: if `True`, update the identically-named existing job
         :return None:
         """
-        with ProgressMessage("Deploying streaming Dataflow job", 4, self.TOTAL_NUMBER_OF_STAGES) as progress_message:
+        with ProgressMessage("Deploying streaming Dataflow job", 1, 1) as progress_message:
             if update:
                 progress_message.finish_message = "update triggered."
 

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -134,7 +134,10 @@ class DataflowDeployer(BaseDeployer):
                         "args": [
                             "build",
                             *cache_option,
-                            *[f"--build-arg={variable}" for variable in self.required_environment_variables],
+                            *[
+                                f"--build-arg={name}={value}"
+                                for name, value in self.required_environment_variables.items()
+                            ],
                             "-t",
                             self.image_uri_template,
                             ".",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.3",
+    version="0.9.4",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#319](https://github.com/octue/octue-sdk-python/pull/319))

### Fixes
- Push `octue-sdk-python` image to public Docker Hub repository in `cloudbuild.yaml`
- Use latest `octue-sdk-python` image in generated Cloud Build step in `DataflowDeployer`
- Use the image URI template in `cloudbuild.yaml` file generation instead of a static image name
- Split deploying a Dataflow job from creating and triggering a build trigger in `DataflowDeployer`

### Refactoring
- Store required environment variables in dictionary in `BaseDeployer`

<!--- END AUTOGENERATED NOTES --->