### PR TITLE
Add extra options to `octue.yaml` for Dataflow deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: octue/octue-sdk-python:${{ env.PACKAGE_VERSION }}-slim
+          tags: octue/octue-sdk-python:${{ env.PACKAGE_VERSION }}-slim,octue/octue-sdk-python:${{ env.PACKAGE_VERSION }}-slim:latest

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -74,10 +74,7 @@ class BaseDeployer:
         self.provided_cloud_build_configuration_path = self._octue_configuration.get("cloud_build_configuration_path")
         self.minimum_instances = self._octue_configuration.get("minimum_instances", 0)
         self.maximum_instances = self._octue_configuration.get("maximum_instances", 10)
-        self.concurrency = self._octue_configuration.get("concurrency", 10)
         self.branch_pattern = self._octue_configuration.get("branch_pattern", "^main$")
-        self.memory = self._octue_configuration.get("memory", "128Mi")
-        self.cpus = self._octue_configuration.get("cpus", 1)
         self.environment_variables = self._octue_configuration.get("environment_variables", [])
 
     @abstractmethod

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -72,7 +72,6 @@ class BaseDeployer:
         # Optional configuration file entries.
         self.dockerfile_path = self._octue_configuration.get("dockerfile_path")
         self.provided_cloud_build_configuration_path = self._octue_configuration.get("cloud_build_configuration_path")
-        self.minimum_instances = self._octue_configuration.get("minimum_instances", 0)
         self.maximum_instances = self._octue_configuration.get("maximum_instances", 10)
         self.branch_pattern = self._octue_configuration.get("branch_pattern", "^main$")
         self.environment_variables = self._octue_configuration.get("environment_variables", [])

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -42,6 +42,7 @@ class CloudRunDeployer(BaseDeployer):
         self.concurrency = self._octue_configuration.get("concurrency", 10)
         self.memory = self._octue_configuration.get("memory", "128Mi")
         self.cpus = self._octue_configuration.get("cpus", 1)
+        self.minimum_instances = self._octue_configuration.get("minimum_instances", 0)
 
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml` file, create a build trigger, and run the

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -38,6 +38,11 @@ class CloudRunDeployer(BaseDeployer):
         super().__init__(octue_configuration_path, service_id, image_uri_template)
         self.build_trigger_description = f"Build the {self.name!r} service and deploy it to Cloud Run."
 
+        # Optional configuration file entries.
+        self.concurrency = self._octue_configuration.get("concurrency", 10)
+        self.memory = self._octue_configuration.get("memory", "128Mi")
+        self.cpus = self._octue_configuration.get("cpus", 1)
+
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml` file, create a build trigger, and run the
         trigger. This deploys the app as a Google Cloud Run service and creates an Eventarc Pub/Sub run trigger for it.

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -1,3 +1,5 @@
+import pkg_resources
+
 from octue.cloud.deployment.google.base_deployer import BaseDeployer, ProgressMessage
 from octue.cloud.deployment.google.dataflow.pipeline import (
     DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION,
@@ -10,7 +12,7 @@ DEFAULT_DATAFLOW_DOCKERFILE_URL = (
     "https://raw.githubusercontent.com/octue/octue-sdk-python/main/octue/cloud/deployment/google/dataflow/Dockerfile"
 )
 
-OCTUE_SDK_PYTHON_IMAGE_URI = "octue/octue-sdk-python:0.9.4-slim"
+OCTUE_SDK_PYTHON_IMAGE_URI = f"octue/octue-sdk-python:{pkg_resources.get_distribution('octue').version}-slim"
 
 
 class DataflowDeployer(BaseDeployer):

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -85,6 +85,7 @@ class DataflowDeployer(BaseDeployer):
                 "temporary_files_location": self.temporary_files_location,
                 "service_account_email": self.service_account_email,
                 "worker_machine_type": self.worker_machine_type,
+                "maximum_instances": self.maximum_instances,
                 "update": update,
             }
 

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -48,6 +48,8 @@ class DataflowDeployer(BaseDeployer):
             "temporary_files_location", DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION
         )
         self.setup_file_path = self._octue_configuration.get("setup_file_path", DEFAULT_SETUP_FILE_PATH)
+        self.service_account_email = self._octue_configuration.get("service_account_email")
+        self.worker_machine_type = self._octue_configuration.get("worker_machine_type")
 
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml file, create a build trigger, run it, and
@@ -81,6 +83,8 @@ class DataflowDeployer(BaseDeployer):
                 "setup_file_path": self.setup_file_path,
                 "image_uri": image_uri,
                 "temporary_files_location": self.temporary_files_location,
+                "service_account_email": self.service_account_email,
+                "worker_machine_type": self.worker_machine_type,
                 "update": update,
             }
 

--- a/octue/cloud/deployment/google/dataflow/pipeline.py
+++ b/octue/cloud/deployment/google/dataflow/pipeline.py
@@ -32,6 +32,7 @@ def create_streaming_job(
     temporary_files_location=DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION,
     service_account_email=None,
     worker_machine_type=None,
+    maximum_instances=None,
     update=False,
     extra_options=None,
 ):
@@ -45,8 +46,9 @@ def create_streaming_job(
     :param str runner: the name of an `apache-beam` runner to use to execute the job
     :param str setup_file_path: path to the python `setup.py` file to use for the job
     :param str temporary_files_location: a Google Cloud Storage path to save temporary files from the job at
-    :param str service_account_email: the email of the service account to run the Dataflow VMs as
-    :param str worker_machine_type: the machine type to create Dataflow worker VMs as. See https://cloud.google.com/compute/docs/machine-types for a list of valid options. If not set, the Dataflow service will choose a reasonable default.
+    :param str|None service_account_email: the email of the service account to run the Dataflow VMs as
+    :param str|None worker_machine_type: the machine type to create Dataflow worker VMs as. See https://cloud.google.com/compute/docs/machine-types for a list of valid options. If not set, the Dataflow service will choose a reasonable default.
+    :param int|None maximum_instances: the maximum number of workers to use when executing the Dataflow job
     :param bool update: if `True`, update the existing job with the same name
     :param iter|None extra_options: any further arguments in command-line-option format to be passed to Apache Beam as pipeline options
     :raise DeploymentError: if a Dataflow job with the service name already exists
@@ -70,6 +72,9 @@ def create_streaming_job(
 
     if worker_machine_type:
         beam_args.append(f"--worker_machine_type={worker_machine_type}")
+
+    if maximum_instances:
+        beam_args.append(f"--max_num_workers={maximum_instances}")
 
     if update:
         beam_args.append("--update")

--- a/octue/cloud/deployment/google/dataflow/pipeline.py
+++ b/octue/cloud/deployment/google/dataflow/pipeline.py
@@ -27,7 +27,6 @@ def create_streaming_job(
     project_name,
     region,
     image_uri,
-    runner="DataflowRunner",
     setup_file_path=DEFAULT_SETUP_FILE_PATH,
     temporary_files_location=DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION,
     service_account_email=None,
@@ -43,7 +42,6 @@ def create_streaming_job(
     :param str project_name: the name of the project to deploy the job to
     :param str region: the region to deploy the job to
     :param str image_uri: the URI of the `apache-beam`-based Docker image to use for the job
-    :param str runner: the name of an `apache-beam` runner to use to execute the job
     :param str setup_file_path: path to the python `setup.py` file to use for the job
     :param str temporary_files_location: a Google Cloud Storage path to save temporary files from the job at
     :param str|None service_account_email: the email of the service account to run the Dataflow VMs as
@@ -59,7 +57,6 @@ def create_streaming_job(
         "region": region,
         "temp_location": temporary_files_location,
         "job_name": service_name,
-        "runner": runner,
         "sdk_container_image": image_uri,
         "setup_file": os.path.abspath(setup_file_path),
         "update": update,

--- a/octue/cloud/deployment/google/dataflow/pipeline.py
+++ b/octue/cloud/deployment/google/dataflow/pipeline.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import apache_beam
-from apache_beam.options.pipeline_options import WorkerOptions
+from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.runners.dataflow.dataflow_runner import DataflowRunner
 from apache_beam.runners.dataflow.internal.apiclient import DataflowJobAlreadyExistsError
 
@@ -74,7 +74,7 @@ def create_streaming_job(
     if maximum_instances:
         pipeline_options["max_num_workers"] = maximum_instances
 
-    pipeline_options = WorkerOptions.from_dictionary(pipeline_options)
+    pipeline_options = PipelineOptions.from_dictionary(pipeline_options)
     pipeline = apache_beam.Pipeline(options=pipeline_options)
 
     service_topic = Topic(name=service_id, service=Service(backend=GCPPubSubBackend(project_name=project_name)))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.5",
+    version="0.9.6",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#322](https://github.com/octue/octue-sdk-python/pull/322))

### Enhancements
- Allow service account, machine type, and maximum instances options in `octue.yaml` for Dataflow deployments

### Fixes
- Always use latest `octue-sdk-python` image in `DataflowDeployer`

### Refactoring
- Move Cloud-Run-only optional `octue.yaml` file options out of `BaseDeployer` and into `CloudRunDeployer`
- Create pipeline options from a dictionary
- Remove `runner` parameter from `create_streaming_job`

### Operations 
- Tag latest image as `latest` in docker workflow

<!--- END AUTOGENERATED NOTES --->