### PR TITLE
Ignore codecov upload failure in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   release:


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#325](https://github.com/octue/octue-sdk-python/pull/325))

### Operations
- Ignore codecov upload failure in release workflow

<!--- END AUTOGENERATED NOTES --->