### PR TITLE
Add secrets to octue configuration and put services under services key

### DIFF
--- a/octue/cli.py
+++ b/octue/cli.py
@@ -276,14 +276,13 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
     is_flag=True,
     help="If provided, skip creating and running the build trigger and just deploy a pre-built image to Dataflow",
 )
-@click.option("--image-uri-template", type=str, default=None, help="The `cloudbuild.yaml` template for the image URI.")
 @click.option("--image-uri", type=str, default=None, help="The actual image URI to use when creating the Dataflow job.")
-def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_job_only, image_uri_template, image_uri):
+def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_job_only, image_uri):
     """Deploy an app as a Google Dataflow streaming job."""
     if update and not service_id:
         raise DeploymentError("If updating a service, you must also provide the `--service-id` argument.")
 
-    deployer = DataflowDeployer(octue_configuration_path, service_id=service_id, image_uri_template=image_uri_template)
+    deployer = DataflowDeployer(octue_configuration_path, service_id=service_id)
 
     if dataflow_job_only:
         deployer.create_streaming_dataflow_job(image_uri=image_uri, update=update)

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -143,9 +143,9 @@ class BaseDeployer:
 
         build_secrets["secret_env"] = {"secretEnv": self.secrets["build"]}
 
-        build_secrets["build_args"] = (
-            " ".join([f"--build-arg={secret_name}=$${secret_name}" for secret_name in self.secrets["build"]]) + " "
-        )
+        build_secrets["build_args"] = [
+            f"--build-arg={secret_name}=$${secret_name}" for secret_name in self.secrets["build"]
+        ]
 
         return available_secrets_option, build_secrets
 

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -47,12 +47,15 @@ class BaseDeployer:
         with open(self.octue_configuration_path) as f:
             self._octue_configuration = yaml.load(f, Loader=yaml.SafeLoader)
 
+        # Only allow a single service in an `octue.yaml` file for now.
+        self._service = self._octue_configuration["services"][0]
+
         # Required configuration file entries.
-        self.name = self._octue_configuration["name"]
-        self.repository_name = self._octue_configuration["repository_name"]
-        self.repository_owner = self._octue_configuration["repository_owner"]
-        self.project_name = self._octue_configuration["project_name"]
-        self.region = self._octue_configuration["region"]
+        self.name = self._service["name"]
+        self.repository_name = self._service["repository_name"]
+        self.repository_owner = self._service["repository_owner"]
+        self.project_name = self._service["project_name"]
+        self.region = self._service["region"]
 
         # Generated attributes.
         self.build_trigger_description = None
@@ -65,12 +68,12 @@ class BaseDeployer:
         )
 
         # Optional configuration file entries.
-        self.dockerfile_path = self._octue_configuration.get("dockerfile_path")
-        self.provided_cloud_build_configuration_path = self._octue_configuration.get("cloud_build_configuration_path")
-        self.maximum_instances = self._octue_configuration.get("maximum_instances", 10)
-        self.branch_pattern = self._octue_configuration.get("branch_pattern", "^main$")
-        self.environment_variables = self._octue_configuration.get("environment_variables", [])
-        self.secrets = self._octue_configuration.get("secrets", {})
+        self.dockerfile_path = self._service.get("dockerfile_path")
+        self.provided_cloud_build_configuration_path = self._service.get("cloud_build_configuration_path")
+        self.maximum_instances = self._service.get("maximum_instances", 10)
+        self.branch_pattern = self._service.get("branch_pattern", "^main$")
+        self.environment_variables = self._service.get("environment_variables", [])
+        self.secrets = self._service.get("secrets", {})
 
     @abstractmethod
     def deploy(self, no_cache=False, update=False):
@@ -208,7 +211,7 @@ class BaseDeployer:
         :return None:
         """
         with ProgressMessage(
-            f"Running build trigger on branch {self._octue_configuration['branch_pattern']!r}",
+            f"Running build trigger on branch {self.branch_pattern!r}",
             3,
             self.TOTAL_NUMBER_OF_STAGES,
         ):

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -143,8 +143,8 @@ class BaseDeployer:
 
         build_secrets["secret_env"] = {"secretEnv": self.secrets["build"]}
 
-        build_secrets["build_args"] = " ".join(
-            [f"--build-arg={secret_name}=$${secret_name}" for secret_name in self.secrets["build"]]
+        build_secrets["build_args"] = (
+            " ".join([f"--build-arg={secret_name}=$${secret_name}" for secret_name in self.secrets["build"]]) + " "
         )
 
         return available_secrets_option, build_secrets

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -60,11 +60,6 @@ class BaseDeployer:
         self.service_id = service_id or str(uuid.uuid4())
         self.required_environment_variables = {"SERVICE_ID": self.service_id, "SERVICE_NAME": self.name}
 
-        if image_uri_template:
-            self._image_uri_provided = True
-        else:
-            self._image_uri_provided = False
-
         self.image_uri_template = image_uri_template or (
             f"{DOCKER_REGISTRY_URL}/{self.project_name}/{self.repository_name}/{self.name}:$SHORT_SHA"
         )
@@ -127,12 +122,6 @@ class BaseDeployer:
             with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
 
                 if self.provided_cloud_build_configuration_path:
-                    if not self._image_uri_provided:
-                        raise DeploymentError(
-                            "If providing a Cloud Build configuration file, the image URI template must also be "
-                            "provided."
-                        )
-
                     configuration_option = [f"--build-config={self.provided_cloud_build_configuration_path}"]
 
                 else:

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -87,9 +87,9 @@ class CloudRunDeployer(BaseDeployer):
             get_dockerfile_step, dockerfile_path = self._create_get_dockerfile_step(DEFAULT_CLOUD_RUN_DOCKERFILE_URL)
 
             if no_cache:
-                cache_option = "--no-cache "
+                cache_option = ["--no-cache"]
             else:
-                cache_option = ""
+                cache_option = []
 
             environment_variables = ",".join(
                 [f"{variable['name']}={variable['value']}" for variable in self.environment_variables]
@@ -107,9 +107,18 @@ class CloudRunDeployer(BaseDeployer):
                         "entrypoint": "bash",
                         "args": [
                             "-c",
-                            (
-                                f"docker build {cache_option}'-t' '{self.image_uri_template}' "
-                                f"{build_secrets['build_args']}. '-f' {dockerfile_path}"
+                            " ".join(
+                                [
+                                    "docker",
+                                    "build",
+                                    *cache_option,
+                                    "'-t'",
+                                    f"{self.image_uri_template!r}",
+                                    *build_secrets["build_args"],
+                                    ".",
+                                    "'-f'",
+                                    dockerfile_path,
+                                ],
                             ),
                         ],
                         **build_secrets["secret_env"],

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -87,7 +87,7 @@ class CloudRunDeployer(BaseDeployer):
             get_dockerfile_step, dockerfile_path = self._create_get_dockerfile_step(DEFAULT_CLOUD_RUN_DOCKERFILE_URL)
 
             if no_cache:
-                cache_option = "--no-cache"
+                cache_option = "--no-cache "
             else:
                 cache_option = ""
 
@@ -108,8 +108,8 @@ class CloudRunDeployer(BaseDeployer):
                         "args": [
                             "-c",
                             (
-                                f"docker build {cache_option} '-t' '{self.image_uri_template}' "
-                                f"{build_secrets['build_args']} . '-f' {dockerfile_path}"
+                                f"docker build {cache_option}'-t' '{self.image_uri_template}' "
+                                f"{build_secrets['build_args']}. '-f' {dockerfile_path}"
                             ),
                         ],
                         **build_secrets["secret_env"],

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -39,10 +39,10 @@ class CloudRunDeployer(BaseDeployer):
         self.build_trigger_description = f"Build the {self.name!r} service and deploy it to Cloud Run."
 
         # Optional configuration file entries.
-        self.concurrency = self._octue_configuration.get("concurrency", 10)
-        self.memory = self._octue_configuration.get("memory", "128Mi")
-        self.cpus = self._octue_configuration.get("cpus", 1)
-        self.minimum_instances = self._octue_configuration.get("minimum_instances", 0)
+        self.concurrency = self._service.get("concurrency", 10)
+        self.memory = self._service.get("memory", "128Mi")
+        self.cpus = self._service.get("cpus", 1)
+        self.minimum_instances = self._service.get("minimum_instances", 0)
 
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml` file, create a build trigger, and run the
@@ -80,7 +80,7 @@ class CloudRunDeployer(BaseDeployer):
 
             if self.provided_cloud_build_configuration_path:
                 progress_message.finish_message = (
-                    f"skipped - using {self._octue_configuration['cloud_build_configuration_path']!r} from repository."
+                    f"skipped - using {self.provided_cloud_build_configuration_path!r} from repository."
                 )
                 return
 

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -49,7 +49,7 @@ class DataflowDeployer(BaseDeployer):
         )
         self.setup_file_path = self._service.get("setup_file_path", DEFAULT_SETUP_FILE_PATH)
         self.service_account_email = self._service.get("service_account_email")
-        self.worker_machine_type = self._service.get("worker_machine_type")
+        self.worker_machine_type = self._service.get("machine_type")
 
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml file, create a build trigger, run it, and

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -44,12 +44,12 @@ class DataflowDeployer(BaseDeployer):
         self.success_message = f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {self.service_id!r}."
 
         # Optional configuration file entries for Dataflow.
-        self.temporary_files_location = self._octue_configuration.get(
+        self.temporary_files_location = self._service.get(
             "temporary_files_location", DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION
         )
-        self.setup_file_path = self._octue_configuration.get("setup_file_path", DEFAULT_SETUP_FILE_PATH)
-        self.service_account_email = self._octue_configuration.get("service_account_email")
-        self.worker_machine_type = self._octue_configuration.get("worker_machine_type")
+        self.setup_file_path = self._service.get("setup_file_path", DEFAULT_SETUP_FILE_PATH)
+        self.service_account_email = self._service.get("service_account_email")
+        self.worker_machine_type = self._service.get("worker_machine_type")
 
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml file, create a build trigger, run it, and
@@ -121,7 +121,7 @@ class DataflowDeployer(BaseDeployer):
 
             if self.provided_cloud_build_configuration_path:
                 progress_message.finish_message = (
-                    f"skipped - using {self._octue_configuration['cloud_build_configuration_path']!r} from repository."
+                    f"skipped - using {self.provided_cloud_build_configuration_path!r} from repository."
                 )
                 return
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.7",
+    version="0.9.8",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",

--- a/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployer.py
+++ b/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployer.py
@@ -8,23 +8,26 @@ from tests.base import BaseTestCase
 
 
 octue_configuration = {
-    "name": "test-service",
-    "repository_name": "test-repository",
-    "repository_owner": "octue",
-    "project_name": "test-project",
-    "region": "europe-west2",
-    "branch_pattern": "my-branch",
+    "services": [
+        {
+            "name": "test-service",
+            "repository_name": "test-repository",
+            "repository_owner": "octue",
+            "project_name": "test-project",
+            "region": "europe-west2",
+            "branch_pattern": "my-branch",
+        }
+    ]
 }
+
+service = octue_configuration["services"][0]
 
 
 GET_SUBSCRIPTIONS_METHOD_PATH = "octue.cloud.deployment.google.cloud_run.deployer.Topic.get_subscriptions"
 
 SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
 
-EXPECTED_IMAGE_NAME = (
-    f"eu.gcr.io/{octue_configuration['project_name']}/{octue_configuration['repository_name']}/"
-    f"{octue_configuration['name']}"
-)
+EXPECTED_IMAGE_NAME = f"eu.gcr.io/{service['project_name']}/{service['repository_name']}/" f"{service['name']}"
 
 EXPECTED_CLOUD_BUILD_CONFIGURATION = {
     "steps": [
@@ -61,10 +64,10 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
                 "test-service",
                 "--platform=managed",
                 f"--image={EXPECTED_IMAGE_NAME}",
-                f"--region={octue_configuration['region']}",
+                f"--region={service['region']}",
                 "--memory=128Mi",
                 "--cpu=1",
-                f"--set-env-vars=SERVICE_ID={SERVICE_ID},SERVICE_NAME={octue_configuration['name']}",
+                f"--set-env-vars=SERVICE_ID={SERVICE_ID},SERVICE_NAME={service['name']}",
                 "--timeout=3600",
                 "--concurrency=10",
                 "--min-instances=0",
@@ -78,17 +81,17 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
 
 EXPECTED_BUILD_TRIGGER_CREATION_COMMAND = [
     "gcloud",
-    f"--project={octue_configuration['project_name']}",
+    f"--project={service['project_name']}",
     "beta",
     "builds",
     "triggers",
     "create",
     "github",
-    f"--name={octue_configuration['name']}",
-    f"--repo-name={octue_configuration['repository_name']}",
-    f"--repo-owner={octue_configuration['repository_owner']}",
-    f"--description=Build the {octue_configuration['name']!r} service and deploy it to Cloud Run.",
-    f"--branch-pattern={octue_configuration['branch_pattern']}",
+    f"--name={service['name']}",
+    f"--repo-name={service['repository_name']}",
+    f"--repo-owner={service['repository_owner']}",
+    f"--description=Build the {service['name']!r} service and deploy it to Cloud Run.",
+    f"--branch-pattern={service['branch_pattern']}",
 ]
 
 
@@ -114,7 +117,7 @@ class TestCloudRunDeployer(BaseTestCase):
         dockerfile path is given.
         """
         try:
-            octue_configuration["dockerfile_path"] = "path/to/Dockerfile"
+            service["dockerfile_path"] = "path/to/Dockerfile"
 
             with tempfile.TemporaryDirectory() as temporary_directory:
                 octue_configuration_path = self._create_octue_configuration_file(
@@ -134,12 +137,12 @@ class TestCloudRunDeployer(BaseTestCase):
             # provided in the first step.
             expected_cloud_build_configuration = copy.deepcopy(EXPECTED_CLOUD_BUILD_CONFIGURATION)
             expected_cloud_build_configuration["steps"] = expected_cloud_build_configuration["steps"][1:]
-            expected_cloud_build_configuration["steps"][0]["args"][5] = octue_configuration["dockerfile_path"]
+            expected_cloud_build_configuration["steps"][0]["args"][5] = service["dockerfile_path"]
 
             self.assertEqual(generated_config, expected_cloud_build_configuration)
 
         finally:
-            del octue_configuration["dockerfile_path"]
+            del service["dockerfile_path"]
 
     def test_deploy(self):
         """Test that the build trigger creation, build and deployment, and Eventarc run trigger creation are requested
@@ -178,13 +181,13 @@ class TestCloudRunDeployer(BaseTestCase):
                 mock_run.call_args_list[1].args[0],
                 [
                     "gcloud",
-                    f"--project={octue_configuration['project_name']}",
+                    f"--project={service['project_name']}",
                     "--format=json",
                     "beta",
                     "builds",
                     "triggers",
                     "run",
-                    octue_configuration["name"],
+                    service["name"],
                     "--branch=my-branch",
                 ],
             )
@@ -194,7 +197,7 @@ class TestCloudRunDeployer(BaseTestCase):
                 mock_run.call_args_list[2].args[0],
                 [
                     "gcloud",
-                    f'--project={octue_configuration["project_name"]}',
+                    f'--project={service["project_name"]}',
                     "--format=json",
                     "builds",
                     "describe",
@@ -207,12 +210,12 @@ class TestCloudRunDeployer(BaseTestCase):
                 mock_run.call_args_list[3].args[0],
                 [
                     "gcloud",
-                    f'--project={octue_configuration["project_name"]}',
+                    f'--project={service["project_name"]}',
                     "run",
                     "services",
                     "add-iam-policy-binding",
-                    octue_configuration["name"],
-                    f'--region={octue_configuration["region"]}',
+                    service["name"],
+                    f'--region={service["region"]}',
                     "--member=allUsers",
                     "--role=roles/run.invoker",
                 ],
@@ -223,15 +226,15 @@ class TestCloudRunDeployer(BaseTestCase):
                 mock_run.call_args_list[4].args[0],
                 [
                     "gcloud",
-                    f'--project={octue_configuration["project_name"]}',
+                    f'--project={service["project_name"]}',
                     "beta",
                     "eventarc",
                     "triggers",
                     "create",
-                    f'{octue_configuration["name"]}-trigger',
+                    f'{service["name"]}-trigger',
                     "--matching-criteria=type=google.cloud.pubsub.topic.v1.messagePublished",
-                    f"--destination-run-service={octue_configuration['name']}",
-                    f"--location={octue_configuration['region']}",
+                    f"--destination-run-service={service['name']}",
+                    f"--location={service['region']}",
                     f"--transport-topic={SERVICE_ID}",
                 ],
             )
@@ -269,12 +272,12 @@ class TestCloudRunDeployer(BaseTestCase):
             mock_run_command.call_args_list[1].args[0],
             [
                 "gcloud",
-                f"--project={octue_configuration['project_name']}",
+                f"--project={service['project_name']}",
                 "beta",
                 "builds",
                 "triggers",
                 "delete",
-                octue_configuration["name"],
+                service["name"],
             ],
         )
 

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -55,14 +55,13 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
         {
             "id": "Build image",
             "name": "gcr.io/cloud-builders/docker",
+            "entrypoint": "bash",
             "args": [
-                "build",
-                *[f"--build-arg=SERVICE_ID={SERVICE_ID}", f"--build-arg=SERVICE_NAME={service['name']}"],
-                "-t",
-                EXPECTED_IMAGE_NAME,
-                ".",
-                "-f",
-                "Dockerfile",
+                "-c",
+                (
+                    f"docker build '-t' {EXPECTED_IMAGE_NAME!r} --build-arg=SERVICE_ID={SERVICE_ID} "
+                    f"--build-arg=SERVICE_NAME={service['name']} . '-f' Dockerfile"
+                ),
             ],
         },
         {

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -39,8 +39,6 @@ octue_configuration_with_cloud_build_path = {
 
 SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
 
-MOCK_HEAD_COMMIT_SHORT_HASH = "3748907"
-
 EXPECTED_IMAGE_NAME = (
     f"eu.gcr.io/{service['project_name']}/{service['repository_name']}/" f"{service['name']}:$SHORT_SHA"
 )

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -166,19 +166,6 @@ class TestDataflowDeployer(BaseTestCase):
                 ],
             )
 
-    def test_error_raised_if_cloudbuild_file_provided_without_image_uri_template(self):
-        """Test that an error is raised if a `cloudbuild.yaml` file is provided without giving the `image_uri_template`
-        parameter.
-        """
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(
-                octue_configuration_with_cloud_build_path,
-                temporary_directory,
-            )
-
-            with self.assertRaises(DeploymentError):
-                DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID).deploy()
-
     def test_deploy_with_cloud_build_file_provided(self):
         """Test deploying to Dataflow with a `cloudbuild.yaml` path provided in the `octue.yaml` file"""
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -26,7 +26,7 @@ octue_configuration = {
             "branch_pattern": "my-branch",
             "service_account_email": "account@domain.com",
             "maximum_instances": 30,
-            "worker_machine_type": "e2-standard-2",
+            "machine_type": "e2-standard-2",
         }
     ]
 }

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -16,20 +16,25 @@ from tests.base import BaseTestCase
 
 
 octue_configuration = {
-    "name": "test-service",
-    "repository_name": "test-repository",
-    "repository_owner": "octue",
-    "project_name": "test-project",
-    "region": "europe-west2",
-    "branch_pattern": "my-branch",
-    "service_account_email": "account@domain.com",
-    "maximum_instances": 30,
-    "worker_machine_type": "e2-standard-2",
+    "services": [
+        {
+            "name": "test-service",
+            "repository_name": "test-repository",
+            "repository_owner": "octue",
+            "project_name": "test-project",
+            "region": "europe-west2",
+            "branch_pattern": "my-branch",
+            "service_account_email": "account@domain.com",
+            "maximum_instances": 30,
+            "worker_machine_type": "e2-standard-2",
+        }
+    ]
 }
 
+service = octue_configuration["services"][0]
+
 octue_configuration_with_cloud_build_path = {
-    **copy.copy(octue_configuration),
-    "cloud_build_configuration_path": "cloudbuild.yaml",
+    "services": [{**copy.copy(service), "cloud_build_configuration_path": "cloudbuild.yaml"}]
 }
 
 SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
@@ -37,8 +42,7 @@ SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
 MOCK_HEAD_COMMIT_SHORT_HASH = "3748907"
 
 EXPECTED_IMAGE_NAME = (
-    f"eu.gcr.io/{octue_configuration['project_name']}/{octue_configuration['repository_name']}/"
-    f"{octue_configuration['name']}:$SHORT_SHA"
+    f"eu.gcr.io/{service['project_name']}/{service['repository_name']}/" f"{service['name']}:$SHORT_SHA"
 )
 
 EXPECTED_CLOUD_BUILD_CONFIGURATION = {
@@ -53,7 +57,7 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
             "name": "gcr.io/cloud-builders/docker",
             "args": [
                 "build",
-                *[f"--build-arg=SERVICE_ID={SERVICE_ID}", f"--build-arg=SERVICE_NAME={octue_configuration['name']}"],
+                *[f"--build-arg=SERVICE_ID={SERVICE_ID}", f"--build-arg=SERVICE_NAME={service['name']}"],
                 "-t",
                 EXPECTED_IMAGE_NAME,
                 ".",
@@ -85,17 +89,17 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
 
 EXPECTED_BUILD_TRIGGER_CREATION_COMMAND = [
     "gcloud",
-    f"--project={octue_configuration['project_name']}",
+    f"--project={service['project_name']}",
     "beta",
     "builds",
     "triggers",
     "create",
     "github",
-    f"--name={octue_configuration['name']}",
-    f"--repo-name={octue_configuration['repository_name']}",
-    f"--repo-owner={octue_configuration['repository_owner']}",
-    f"--description=Build the {octue_configuration['name']!r} service and deploy it to Dataflow.",
-    f"--branch-pattern={octue_configuration['branch_pattern']}",
+    f"--name={service['name']}",
+    f"--repo-name={service['repository_name']}",
+    f"--repo-owner={service['repository_owner']}",
+    f"--description=Build the {service['name']!r} service and deploy it to Dataflow.",
+    f"--branch-pattern={service['branch_pattern']}",
 ]
 
 
@@ -141,13 +145,13 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[1].args[0],
                 [
                     "gcloud",
-                    f"--project={octue_configuration['project_name']}",
+                    f"--project={service['project_name']}",
                     "--format=json",
                     "beta",
                     "builds",
                     "triggers",
                     "run",
-                    octue_configuration["name"],
+                    service["name"],
                     "--branch=my-branch",
                 ],
             )
@@ -157,7 +161,7 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[2].args[0],
                 [
                     "gcloud",
-                    f'--project={octue_configuration["project_name"]}',
+                    f'--project={service["project_name"]}',
                     "--format=json",
                     "builds",
                     "describe",
@@ -205,7 +209,9 @@ class TestDataflowDeployer(BaseTestCase):
             self.assertEqual(
                 mock_run.call_args_list[0].args[0],
                 EXPECTED_BUILD_TRIGGER_CREATION_COMMAND
-                + [f"--build-config={octue_configuration_with_cloud_build_path['cloud_build_configuration_path']}"],
+                + [
+                    f"--build-config={octue_configuration_with_cloud_build_path['services'][0]['cloud_build_configuration_path']}"
+                ],
             )
 
             # Test the build trigger run request.
@@ -213,13 +219,13 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[1].args[0],
                 [
                     "gcloud",
-                    f"--project={octue_configuration_with_cloud_build_path['project_name']}",
+                    f"--project={octue_configuration_with_cloud_build_path['services'][0]['project_name']}",
                     "--format=json",
                     "beta",
                     "builds",
                     "triggers",
                     "run",
-                    octue_configuration_with_cloud_build_path["name"],
+                    octue_configuration_with_cloud_build_path["services"][0]["name"],
                     "--branch=my-branch",
                 ],
             )
@@ -229,7 +235,7 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[2].args[0],
                 [
                     "gcloud",
-                    f'--project={octue_configuration["project_name"]}',
+                    f'--project={service["project_name"]}',
                     "--format=json",
                     "builds",
                     "describe",
@@ -253,10 +259,10 @@ class TestDataflowDeployer(BaseTestCase):
             options = mock_runner.mock_calls[1].kwargs["options"].get_all_options()
             self.assertFalse(options["update"])
             self.assertTrue(options["streaming"])
-            self.assertEqual(options["project"], octue_configuration["project_name"])
-            self.assertEqual(options["job_name"], octue_configuration["name"])
+            self.assertEqual(options["project"], service["project_name"])
+            self.assertEqual(options["job_name"], service["name"])
             self.assertEqual(options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
-            self.assertEqual(options["region"], octue_configuration["region"])
+            self.assertEqual(options["region"], service["region"])
             self.assertEqual(options["dataflow_service_options"], ["enable_prime"])
             self.assertEqual(options["sdk_container_image"], "my-image-uri")
             self.assertEqual(options["setup_file"], DEFAULT_SETUP_FILE_PATH)
@@ -277,10 +283,10 @@ class TestDataflowDeployer(BaseTestCase):
             options = mock_runner.mock_calls[1].kwargs["options"].get_all_options()
             self.assertTrue(options["update"])
             self.assertTrue(options["streaming"])
-            self.assertEqual(options["project"], octue_configuration["project_name"])
-            self.assertEqual(options["job_name"], octue_configuration["name"])
+            self.assertEqual(options["project"], service["project_name"])
+            self.assertEqual(options["job_name"], service["name"])
             self.assertEqual(options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
-            self.assertEqual(options["region"], octue_configuration["region"])
+            self.assertEqual(options["region"], service["region"])
             self.assertEqual(options["dataflow_service_options"], ["enable_prime"])
             self.assertEqual(options["sdk_container_image"], "my-image-uri")
             self.assertEqual(options["setup_file"], DEFAULT_SETUP_FILE_PATH)


### PR DESCRIPTION
## Summary
Add the ability to provide build secrets in `octue.yaml` to be used as build args in the deployers' docker build step. This allows us to remove manual `cloudbuild.yaml` files from some repositories, reducing manual work and repetition, and increasing deployment resilience.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#329](https://github.com/octue/octue-sdk-python/pull/329))

### Enhancements
- Add ability to provide build secrets in `octue.yaml`
- Require services to be specified under services key in `octue.yaml`
- Remove redundant passing of image URI template to deployers

### Refactoring
- Rename `worker_machine_type` to `machine_type` in `octue.yaml`

<!--- END AUTOGENERATED NOTES --->