### PR TITLE
Disable Dataflow Prime if machine type specified in octue.yaml

### DIFF
--- a/octue/cloud/deployment/google/dataflow/pipeline.py
+++ b/octue/cloud/deployment/google/dataflow/pipeline.py
@@ -60,7 +60,6 @@ def create_streaming_job(
         "sdk_container_image": image_uri,
         "setup_file": os.path.abspath(setup_file_path),
         "update": update,
-        "dataflow_service_options": ["enable_prime"],
         "streaming": True,
         **(extra_options or {}),
     }
@@ -70,6 +69,9 @@ def create_streaming_job(
 
     if worker_machine_type:
         pipeline_options["worker_machine_type"] = worker_machine_type
+    else:
+        # Dataflow Prime can only be used if a worker machine type is not specified.
+        pipeline_options["dataflow_service_options"] = ["enable_prime"]
 
     if maximum_instances:
         pipeline_options["max_num_workers"] = maximum_instances

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.9.8",
+    version="0.9.9",
     py_modules=["cli"],
     install_requires=[
         "apache-beam[gcp]==2.35.0",

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -15,7 +15,7 @@ from octue.exceptions import DeploymentError
 from tests.base import BaseTestCase
 
 
-octue_configuration = {
+OCTUE_CONFIGURATION = {
     "services": [
         {
             "name": "test-service",
@@ -31,16 +31,16 @@ octue_configuration = {
     ]
 }
 
-service = octue_configuration["services"][0]
+SERVICE = OCTUE_CONFIGURATION["services"][0]
 
-octue_configuration_with_cloud_build_path = {
-    "services": [{**copy.copy(service), "cloud_build_configuration_path": "cloudbuild.yaml"}]
+OCTUE_CONFIGURATION_WITH_CLOUD_BUILD_PATH = {
+    "services": [{**copy.copy(SERVICE), "cloud_build_configuration_path": "cloudbuild.yaml"}]
 }
 
 SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
 
 EXPECTED_IMAGE_NAME = (
-    f"eu.gcr.io/{service['project_name']}/{service['repository_name']}/" f"{service['name']}:$SHORT_SHA"
+    f"eu.gcr.io/{SERVICE['project_name']}/{SERVICE['repository_name']}/" f"{SERVICE['name']}:$SHORT_SHA"
 )
 
 EXPECTED_CLOUD_BUILD_CONFIGURATION = {
@@ -58,7 +58,7 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
                 "-c",
                 (
                     f"docker build '-t' {EXPECTED_IMAGE_NAME!r} --build-arg=SERVICE_ID={SERVICE_ID} "
-                    f"--build-arg=SERVICE_NAME={service['name']} . '-f' Dockerfile"
+                    f"--build-arg=SERVICE_NAME={SERVICE['name']} . '-f' Dockerfile"
                 ),
             ],
         },
@@ -86,17 +86,17 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
 
 EXPECTED_BUILD_TRIGGER_CREATION_COMMAND = [
     "gcloud",
-    f"--project={service['project_name']}",
+    f"--project={SERVICE['project_name']}",
     "beta",
     "builds",
     "triggers",
     "create",
     "github",
-    f"--name={service['name']}",
-    f"--repo-name={service['repository_name']}",
-    f"--repo-owner={service['repository_owner']}",
-    f"--description=Build the {service['name']!r} service and deploy it to Dataflow.",
-    f"--branch-pattern={service['branch_pattern']}",
+    f"--name={SERVICE['name']}",
+    f"--repo-name={SERVICE['repository_name']}",
+    f"--repo-owner={SERVICE['repository_owner']}",
+    f"--description=Build the {SERVICE['name']!r} service and deploy it to Dataflow.",
+    f"--branch-pattern={SERVICE['branch_pattern']}",
 ]
 
 
@@ -104,7 +104,7 @@ class TestDataflowDeployer(BaseTestCase):
     def test_generate_cloud_build_configuration(self):
         """Test that a correct Google Cloud Build configuration is generated from the given `octue.yaml` file."""
         with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(octue_configuration, temporary_directory)
+            octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
             deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
 
         deployer._generate_cloud_build_configuration()
@@ -113,7 +113,7 @@ class TestDataflowDeployer(BaseTestCase):
     def test_deploy(self):
         """Test that the build trigger creation and run are requested correctly."""
         with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(octue_configuration, temporary_directory)
+            octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
             deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
 
             with patch("subprocess.run", return_value=Mock(returncode=0)) as mock_run:
@@ -142,13 +142,13 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[1].args[0],
                 [
                     "gcloud",
-                    f"--project={service['project_name']}",
+                    f"--project={SERVICE['project_name']}",
                     "--format=json",
                     "beta",
                     "builds",
                     "triggers",
                     "run",
-                    service["name"],
+                    SERVICE["name"],
                     "--branch=my-branch",
                 ],
             )
@@ -158,7 +158,7 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[2].args[0],
                 [
                     "gcloud",
-                    f'--project={service["project_name"]}',
+                    f'--project={SERVICE["project_name"]}',
                     "--format=json",
                     "builds",
                     "describe",
@@ -170,7 +170,7 @@ class TestDataflowDeployer(BaseTestCase):
         """Test deploying to Dataflow with a `cloudbuild.yaml` path provided in the `octue.yaml` file"""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(
-                octue_configuration_with_cloud_build_path,
+                OCTUE_CONFIGURATION_WITH_CLOUD_BUILD_PATH,
                 temporary_directory,
             )
 
@@ -194,7 +194,7 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[0].args[0],
                 EXPECTED_BUILD_TRIGGER_CREATION_COMMAND
                 + [
-                    f"--build-config={octue_configuration_with_cloud_build_path['services'][0]['cloud_build_configuration_path']}"
+                    f"--build-config={OCTUE_CONFIGURATION_WITH_CLOUD_BUILD_PATH['services'][0]['cloud_build_configuration_path']}"
                 ],
             )
 
@@ -203,13 +203,13 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[1].args[0],
                 [
                     "gcloud",
-                    f"--project={octue_configuration_with_cloud_build_path['services'][0]['project_name']}",
+                    f"--project={OCTUE_CONFIGURATION_WITH_CLOUD_BUILD_PATH['services'][0]['project_name']}",
                     "--format=json",
                     "beta",
                     "builds",
                     "triggers",
                     "run",
-                    octue_configuration_with_cloud_build_path["services"][0]["name"],
+                    OCTUE_CONFIGURATION_WITH_CLOUD_BUILD_PATH["services"][0]["name"],
                     "--branch=my-branch",
                 ],
             )
@@ -219,7 +219,7 @@ class TestDataflowDeployer(BaseTestCase):
                 mock_run.call_args_list[2].args[0],
                 [
                     "gcloud",
-                    f'--project={service["project_name"]}',
+                    f'--project={SERVICE["project_name"]}',
                     "--format=json",
                     "builds",
                     "describe",
@@ -230,46 +230,51 @@ class TestDataflowDeployer(BaseTestCase):
     def test_create_streaming_dataflow_job(self):
         """Test creating a streaming dataflow job directly."""
         with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(octue_configuration, temporary_directory)
+            octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
             deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",
                 return_value=Mock(path="projects/my-project/topics/my-topic"),
             ):
-                with patch("octue.cloud.deployment.google.dataflow.pipeline.DataflowRunner") as mock_runner:
+                with patch("octue.cloud.deployment.google.dataflow.pipeline.DataflowRunner.run_pipeline") as mock_run:
                     deployer.create_streaming_dataflow_job(image_uri="my-image-uri")
 
-            options = mock_runner.mock_calls[1].kwargs["options"].get_all_options()
+            options = mock_run.call_args.kwargs["options"].get_all_options()
             self.assertFalse(options["update"])
             self.assertTrue(options["streaming"])
-            self.assertEqual(options["project"], service["project_name"])
-            self.assertEqual(options["job_name"], service["name"])
+            self.assertEqual(options["project"], SERVICE["project_name"])
+            self.assertEqual(options["job_name"], SERVICE["name"])
             self.assertEqual(options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
-            self.assertEqual(options["region"], service["region"])
+            self.assertEqual(options["region"], SERVICE["region"])
             self.assertEqual(options["sdk_container_image"], "my-image-uri")
             self.assertEqual(options["setup_file"], DEFAULT_SETUP_FILE_PATH)
+
+            # Check that "enable_prime" isn't in the Dataflow service options (it should be disabled if a machine type
+            # is specified in the octue configuration file).
+            self.assertIsNone(options["dataflow_service_options"])
 
     def test_updating_streaming_dataflow_job(self):
         """Test updating an existing streaming dataflow job."""
         with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(octue_configuration, temporary_directory)
+            octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
             deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",
                 return_value=Mock(path="projects/my-project/topics/my-topic"),
             ):
-                with patch("octue.cloud.deployment.google.dataflow.pipeline.DataflowRunner") as mock_runner:
+                with patch("octue.cloud.deployment.google.dataflow.pipeline.DataflowRunner.run_pipeline") as mock_run:
                     deployer.create_streaming_dataflow_job(image_uri="my-image-uri", update=True)
 
-            options = mock_runner.mock_calls[1].kwargs["options"].get_all_options()
+            options = mock_run.call_args.kwargs["options"].get_all_options()
             self.assertTrue(options["update"])
             self.assertTrue(options["streaming"])
-            self.assertEqual(options["project"], service["project_name"])
-            self.assertEqual(options["job_name"], service["name"])
+            self.assertIsNone(options["dataflow_service_options"])
+            self.assertEqual(options["project"], SERVICE["project_name"])
+            self.assertEqual(options["job_name"], SERVICE["name"])
             self.assertEqual(options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
-            self.assertEqual(options["region"], service["region"])
+            self.assertEqual(options["region"], SERVICE["region"])
             self.assertEqual(options["sdk_container_image"], "my-image-uri")
             self.assertEqual(options["setup_file"], DEFAULT_SETUP_FILE_PATH)
 
@@ -278,7 +283,7 @@ class TestDataflowDeployer(BaseTestCase):
         already exist results in the job deployment being retried with `update` set to `False`.
         """
         with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(octue_configuration, temporary_directory)
+            octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
             deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
 
             with patch(
@@ -302,7 +307,7 @@ class TestDataflowDeployer(BaseTestCase):
     def test_deployment_error_raised_if_dataflow_job_already_exists(self):
         """Test that a deployment error is raised if a Dataflow job already exists with the same name as the service."""
         with tempfile.TemporaryDirectory() as temporary_directory:
-            octue_configuration_path = self._create_octue_configuration_file(octue_configuration, temporary_directory)
+            octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
             deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
 
             with patch(
@@ -315,3 +320,28 @@ class TestDataflowDeployer(BaseTestCase):
                 ):
                     with self.assertRaises(DeploymentError):
                         deployer.create_streaming_dataflow_job(image_uri="my-image-uri", update=True)
+
+    def test_dataflow_prime_enabled_if_machine_type_not_specified(self):
+        """Test that Dataflow Prime is enabled if the machine type is not specified in the octue configuration."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            octue_configuration_with_no_machine_type = copy.deepcopy(OCTUE_CONFIGURATION)
+            del octue_configuration_with_no_machine_type["services"][0]["machine_type"]
+
+            octue_configuration_path = self._create_octue_configuration_file(
+                octue_configuration_with_no_machine_type,
+                temporary_directory,
+            )
+
+            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+
+            with patch(
+                "octue.cloud.deployment.google.dataflow.pipeline.Topic",
+                return_value=Mock(path="projects/my-project/topics/my-topic"),
+            ):
+                with patch("octue.cloud.deployment.google.dataflow.pipeline.DataflowRunner.run_pipeline") as mock_run:
+                    deployer.create_streaming_dataflow_job(image_uri="my-image-uri")
+
+        self.assertEqual(
+            mock_run.call_args.kwargs["options"].get_all_options()["dataflow_service_options"],
+            ["enable_prime"],
+        )

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -247,7 +247,6 @@ class TestDataflowDeployer(BaseTestCase):
             self.assertEqual(options["job_name"], service["name"])
             self.assertEqual(options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
             self.assertEqual(options["region"], service["region"])
-            self.assertEqual(options["dataflow_service_options"], ["enable_prime"])
             self.assertEqual(options["sdk_container_image"], "my-image-uri")
             self.assertEqual(options["setup_file"], DEFAULT_SETUP_FILE_PATH)
 
@@ -271,7 +270,6 @@ class TestDataflowDeployer(BaseTestCase):
             self.assertEqual(options["job_name"], service["name"])
             self.assertEqual(options["temp_location"], DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION)
             self.assertEqual(options["region"], service["region"])
-            self.assertEqual(options["dataflow_service_options"], ["enable_prime"])
             self.assertEqual(options["sdk_container_image"], "my-image-uri")
             self.assertEqual(options["setup_file"], DEFAULT_SETUP_FILE_PATH)
 


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#330](https://github.com/octue/octue-sdk-python/pull/330))

### Fixes
- Disable Dataflow Prime if machine type provided for job

### Testing
- Test generating Cloud Build config with build secrets

<!--- END AUTOGENERATED NOTES --->