### PR TITLE
Allow log handler function to be applied to a logger instance

### DIFF
--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -50,8 +50,9 @@ def apply_log_handler(
 ):
     """Apply a log handler with the given formatter to the logger with the given name.
 
-    :param str|None logger_name: if this is `None`, the root logger is used
-    :param logging.Handler handler: The handler to use. If `None`, the default `StreamHandler` will be attached.
+    :param str|None logger_name: the name of the logger to apply the handler to; if this and `logger` are `None`, the root logger is used
+    :param logging.Logger|None logger: the logger instance to apply the handler to (takes precedence over a logger name)
+    :param logging.Handler|None handler: The handler to use. If `None`, the default `StreamHandler` will be attached.
     :param int|str log_level: ignore log messages below this level
     :param logging.Formatter|None formatter: if provided, this formatter is used and the other formatting options are ignored
     :param bool include_line_number: if `True`, include the line number in the log context

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -40,6 +40,7 @@ def create_octue_formatter(
 
 def apply_log_handler(
     logger_name=None,
+    logger=None,
     handler=None,
     log_level=logging.INFO,
     formatter=None,
@@ -71,7 +72,7 @@ def apply_log_handler(
     handler.setFormatter(formatter)
     handler.setLevel(log_level)
 
-    logger = logging.getLogger(name=logger_name)
+    logger = logger or logging.getLogger(name=logger_name)
     logger.addHandler(handler)
     logger.setLevel(log_level)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.10.4",
+    version="0.10.5",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#345](https://github.com/octue/octue-sdk-python/pull/345))

### Enhancements
- Allow `apply_log_handler` to be applied to a logger instance (this is useful for adding a handler to the logger provided by `multiprocessing.get_logger`)

<!--- END AUTOGENERATED NOTES --->