### PR TITLE
Simplify manifest creation and cloud storage methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
           - '^style/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/conventional-commits
-    rev: 0.5.2
+    rev: 0.5.3
     hooks:
       - id: check-commit-message-is-conventional
         stages: [commit-msg]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Not all of Octue's API functionality is implemented in the SDK yet, we're active
    logging
    datafile
    dataset
+   manifest
    filter_containers
    analysis_objects
    child_services

--- a/docs/source/logging.rst
+++ b/docs/source/logging.rst
@@ -1,4 +1,4 @@
-.. _child_services:
+.. _logging:
 
 =======
 Logging

--- a/docs/source/manifest.rst
+++ b/docs/source/manifest.rst
@@ -1,0 +1,12 @@
+.. _manifest:
+
+========
+Manifest
+========
+A manifest is a group of datasets needed for an analysis. The datasets can be from one location in cloud storage or
+many, and can even include local datasets if you can guarantee all services that need them can access them (on,
+for example, a supercomputer cluster running several ``octue`` services, it will be much faster to access the required
+datasets locally than upload them to the cloud and then download them again for each service).
+
+.. code-block:: python
+    manifest =

--- a/docs/source/manifest.rst
+++ b/docs/source/manifest.rst
@@ -3,10 +3,61 @@
 ========
 Manifest
 ========
-A manifest is a group of datasets needed for an analysis. The datasets can be from one location in cloud storage or
-many, and can even include local datasets if you can guarantee all services that need them can access them (on,
-for example, a supercomputer cluster running several ``octue`` services, it will be much faster to access the required
-datasets locally than upload them to the cloud and then download them again for each service).
+A manifest is a group of cloud and/or local datasets needed for an analysis. Only using cloud datasets guarantees that
+every service (with the correct permissions) that is sent the manifest will be able to access the datasets. There can be
+speed and cost benefits from using local datasets when dealing with large amounts of data, but the manifest can only
+include them if you can guarantee that all relevant services can access them.
+
+You can instantiate a manifest like this:
 
 .. code-block:: python
-    manifest =
+
+    manifest = Manifest(
+        datasets=[
+            "gs://my-bucket/my_dataset_0",
+            "gs://my-bucket/my_dataset_1",
+            "gs://another-bucket/my_dataset_2",
+        ],
+        keys={"my_dataset_0: 0, "my_dataset_1": 1, "my_dataset_2": 2},
+    )
+
+
+Manifests of local datasets
+---------------------------
+You can include local datasets in your manifest if you can guarantee all services that need them can access them. A use
+case for this is, for example, a supercomputer cluster running several ``octue`` services locally that process and
+transfer large amounts of data. It is much faster to store and access the required datasets locally than upload them to
+the cloud and then download them again for each service (as would happen with cloud datasets).
+
+.. warning::
+
+     If you want to ask a child a question that includes a manifest containing one or more local datasets, you must
+     include the ``allow_local_files`` parameter. For example, if you have an analysis object with a child called
+     "wind_speed":
+
+     .. code-block:: python
+
+        input_manifest = Manifest(
+            datasets=[
+                "gs://my-bucket/my_dataset_0",
+                "local/path/to/my_dataset_1",
+            ],
+            keys={"my_dataset_0: 0, "my_dataset_1": 1},
+        )
+
+        analysis.children["wind_speed"].ask(
+            input_values=analysis.input_values,
+            input_manifest=analysis.input_manifest,
+            allow_local_files=True,
+        )
+
+
+Storing manifests in the cloud
+------------------------------
+You can store a manifest as a JSON file in the cloud and retrieve it later:
+
+.. code-block:: python
+
+    manifest.to_cloud(cloud_path="gs://my-bucket/path/to/my_manifest.json")
+
+    downloaded_manifest = Manifest.from_cloud(cloud_path="gs://my-bucket/path/to/my_manifest.json")

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -3,23 +3,7 @@
 ===============
 Version History
 ===============
-
-0.0.1
-======
-
-New Features
-------------
-#. Development version. Highly unstable.
-
-
-Backward Incompatible API Changes
----------------------------------
-#. Everything. API changes daily.
-
-Bug Fixes & Minor Changes
--------------------------
-#. Minor???!
-
-
-Origins
-=======
+See our `releases on GitHub. <https://github.com/octue/octue-sdk-python/releases>`_ Note that `octue` is still in beta,
+so both breaking changes and features are denoted by an increase in the minor version number. This means the major
+version number can remain at 0, denoting a beta package. Breaking changes are clearly marked in pull requests and
+release notes.

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -3,7 +3,7 @@
 ===============
 Version History
 ===============
-See our `releases on GitHub. <https://github.com/octue/octue-sdk-python/releases>`_ Note that ```octue`` is still in
+See our `releases on GitHub. <https://github.com/octue/octue-sdk-python/releases>`_ Note that ``octue`` is still in
 beta, so both breaking changes and features are denoted by an increase in the minor version number. This means the major
 version number can remain at 0, denoting a beta package. Breaking changes are clearly marked in pull requests and
 release notes.

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -3,7 +3,7 @@
 ===============
 Version History
 ===============
-See our `releases on GitHub. <https://github.com/octue/octue-sdk-python/releases>`_ Note that `octue` is still in beta,
-so both breaking changes and features are denoted by an increase in the minor version number. This means the major
+See our `releases on GitHub. <https://github.com/octue/octue-sdk-python/releases>`_ Note that ```octue`` is still in
+beta, so both breaking changes and features are denoted by an increase in the minor version number. This means the major
 version number can remain at 0, denoting a beta package. Breaking changes are clearly marked in pull requests and
 release notes.

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -23,12 +23,11 @@ OCTUE_MANAGED_CREDENTIALS = "octue-managed"
 class GoogleCloudStorageClient:
     """A client for using Google Cloud Storage.
 
-    :param str project_name:
     :param str|google.auth.credentials.Credentials|None credentials:
     :return None:
     """
 
-    def __init__(self, project_name, credentials=OCTUE_MANAGED_CREDENTIALS):
+    def __init__(self, credentials=OCTUE_MANAGED_CREDENTIALS):
         warnings.simplefilter("ignore", category=ResourceWarning)
 
         if credentials == OCTUE_MANAGED_CREDENTIALS:
@@ -36,8 +35,8 @@ class GoogleCloudStorageClient:
         else:
             credentials = credentials
 
-        self.client = storage.Client(project=project_name, credentials=credentials)
-        self.project_name = project_name
+        self.project_name = credentials.project_id
+        self.client = storage.Client(project=self.project_name, credentials=credentials)
 
     def create_bucket(self, name, location=None, allow_existing=False, timeout=_DEFAULT_TIMEOUT):
         """Create a new bucket. If the bucket already exists, and `allow_existing` is `True`, do nothing; if it is
@@ -142,7 +141,6 @@ class GoogleCloudStorageClient:
             "time_created": blob.time_created,
             "time_deleted": blob.time_deleted,
             "custom_time": blob.custom_time,
-            "project_name": self.project_name,
             "bucket_name": bucket_name,
             "path_in_bucket": path_in_bucket,
         }

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -27,7 +27,13 @@ class GoogleCloudStorageClient:
     :return None:
     """
 
-    def __init__(self, credentials=OCTUE_MANAGED_CREDENTIALS):
+    def __init__(self, project_name=None, credentials=OCTUE_MANAGED_CREDENTIALS):
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         warnings.simplefilter("ignore", category=ResourceWarning)
 
         if credentials == OCTUE_MANAGED_CREDENTIALS:

--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -4,6 +4,15 @@ import os
 CLOUD_STORAGE_PROTOCOL = "gs://"
 
 
+def is_qualified_cloud_path(path):
+    """Determine if the given path is a qualified cloud path - i.e. if it begins with the cloud storage protocol.
+
+    :param str path: the path to check
+    :return bool: `True` if the path starts with the cloud storage protocol
+    """
+    return path.startswith(CLOUD_STORAGE_PROTOCOL)
+
+
 def join(*paths):
     """Join segments of path into a valid Google Cloud storage path. This is an analogue to `os.path.join` for Google
     Cloud storage paths.
@@ -17,7 +26,7 @@ def join(*paths):
     path = os.path.normpath(os.path.join(*paths)).replace("\\", "/")
 
     if path.startswith("gs:/"):
-        if not path.startswith(CLOUD_STORAGE_PROTOCOL):
+        if not is_qualified_cloud_path(path):
             path = path.replace("gs:/", CLOUD_STORAGE_PROTOCOL)
 
     return path
@@ -51,7 +60,7 @@ def strip_protocol_from_path(path):
     :param str path:
     :return str:
     """
-    if not path.startswith(CLOUD_STORAGE_PROTOCOL):
+    if not is_qualified_cloud_path(path):
         return path
     return path.split(":")[1].lstrip("/")
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -103,14 +103,13 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         self._handle_monitor_message(data)
 
-    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, project_name=None, bucket_name=None):
+    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, bucket_name=None):
         """Validate and serialise the output values and manifest, optionally writing them to files and/or the manifest
         to the cloud.
 
         :param str output_dir: path-like pointing to directory where the outputs should be saved to file (if None, files are not written)
         :param bool save_locally:
         :param bool upload_to_cloud:
-        :param str project_name:
         :param str bucket_name:
         :return dict: serialised strings for values and manifest data.
         """
@@ -141,13 +140,8 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         # Optionally write the manifest to Google Cloud storage.
         if upload_to_cloud:
             if hasattr(self, "output_manifest"):
-                self.output_manifest.to_cloud(project_name, bucket_name, output_dir)
-                logger.debug(
-                    "Wrote %r to cloud storage at project %r in bucket %r.",
-                    self.output_manifest,
-                    project_name,
-                    bucket_name,
-                )
+                self.output_manifest.to_cloud(bucket_name, output_dir)
+                logger.debug("Wrote %r to cloud storage bucket %r.", self.output_manifest, bucket_name)
 
         return serialised_strands
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import warnings
 
 import twined.exceptions
 from octue.definitions import OUTPUT_STRANDS
@@ -103,7 +104,7 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         self._handle_monitor_message(data)
 
-    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, bucket_name=None):
+    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, project_name=None, bucket_name=None):
         """Validate and serialise the output values and manifest, optionally writing them to files and/or the manifest
         to the cloud.
 
@@ -113,6 +114,12 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         :param str bucket_name:
         :return dict: serialised strings for values and manifest data.
         """
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         serialised_strands = {}
 
         for output_strand in OUTPUT_STRANDS:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -3,6 +3,7 @@ import functools
 import logging
 import os
 import tempfile
+import warnings
 from urllib.parse import urlparse
 
 import google.api_core.exceptions
@@ -84,6 +85,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         path,
         local_path=None,
         cloud_path=None,
+        project_name=None,
         timestamp=None,
         id=ID_DEFAULT,
         path_from=None,
@@ -95,6 +97,12 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         hypothetical=False,
         **kwargs,
     ):
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         super().__init__(
             id=id,
             name=kwargs.pop("name", None),
@@ -191,7 +199,9 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         datafile._cloud_metadata = cloud_metadata
         return datafile
 
-    def to_cloud(self, cloud_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True):
+    def to_cloud(
+        self, project_name=None, cloud_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True
+    ):
         """Upload a datafile to Google Cloud Storage. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must
         be provided.
 
@@ -201,6 +211,12 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         :param bool update_cloud_metadata: if `True`, update the metadata of the datafile in the cloud at upload time
         :return str: gs:// path for datafile
         """
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         cloud_path = self._get_cloud_location(cloud_path, bucket_name, path_in_bucket)
         self.get_cloud_metadata()
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -18,7 +18,6 @@ from google_crc32c import Checksum
 
 from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
-from octue.cloud.storage.path import CLOUD_STORAGE_PROTOCOL
 from octue.exceptions import CloudLocationNotSpecified, FileNotFoundException, InvalidInputException
 from octue.mixins import Filterable, Hashable, Identifiable, Labelable, Pathable, Serialisable, Taggable
 from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
@@ -120,7 +119,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
         self._cloud_metadata = {}
 
-        if self.path.startswith(CLOUD_STORAGE_PROTOCOL):
+        if storage.path.is_qualified_cloud_path(self.path):
             if project_name is None:
                 raise CloudLocationNotSpecified(
                     f"The `project_name` parameter is required to instantiate a Datafile from a cloud object; received "
@@ -193,8 +192,8 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         """
         cloud_metadata = serialised_datafile.pop("_cloud_metadata", {})
 
-        if not os.path.isabs(serialised_datafile["path"]) and not serialised_datafile["path"].startswith(
-            CLOUD_STORAGE_PROTOCOL
+        if not os.path.isabs(serialised_datafile["path"]) and not storage.path.is_qualified_cloud_path(
+            serialised_datafile["path"]
         ):
             datafile = Datafile(**serialised_datafile, path_from=path_from)
         else:

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -29,9 +29,9 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
     """
 
     _ATTRIBUTES_TO_HASH = ("files",)
-    _SERIALISE_FIELDS = "files", "name", "labels", "tags", "id", "path"
+    _SERIALISE_FIELDS = "files", "name", "labels", "tags", "id", "path", "project_name"
 
-    def __init__(self, files=None, name=None, id=None, path=None, path_from=None, tags=None, labels=None, **kwargs):
+    def __init__(self, files=None, name=None, id=None, path=None, project_name=None, path_from=None, tags=None, labels=None, **kwargs):
         super().__init__(name=name, id=id, tags=tags, labels=labels, path=path, path_from=path_from)
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined
@@ -39,6 +39,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         #  Add a proper `decoder` argument  to the load_json utility in twined so that datasets, datafiles and manifests
         #  get initialised properly, then remove this hackjob.
         self.files = FilterSet()
+        self.project_name = project_name
 
         for file in files or []:
             if isinstance(file, Datafile):
@@ -115,6 +116,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
                 id=dataset_metadata.get("id"),
                 name=dataset_metadata.get("name"),
                 path=cloud_path,
+                project_name=project_name,
                 tags=TagDict(dataset_metadata.get("tags", {})),
                 labels=LabelSet(dataset_metadata.get("labels", [])),
                 files=[Datafile(path=path, project_name=project_name) for path in dataset_metadata["files"]],

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -23,12 +23,15 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
 
     This is used to read a list of files (and their associated properties) into octue analysis, or to compile a
     list of output files (results) and their properties that will be sent back to the octue system.
+
+    :param iter(dict|octue.resources.datafile.Datafile) files: the files belonging to the dataset
+    :return None:
     """
 
     _ATTRIBUTES_TO_HASH = ("files",)
     _SERIALISE_FIELDS = "files", "name", "labels", "tags", "id", "path"
 
-    def __init__(self, name=None, id=None, path=None, path_from=None, tags=None, labels=None, **kwargs):
+    def __init__(self, files=None, name=None, id=None, path=None, path_from=None, tags=None, labels=None, **kwargs):
         super().__init__(name=name, id=id, tags=tags, labels=labels, path=path, path_from=path_from)
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined
@@ -37,7 +40,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         #  get initialised properly, then remove this hackjob.
         self.files = FilterSet()
 
-        for file in kwargs.pop("files", list()):
+        for file in files or []:
             if isinstance(file, Datafile):
                 self.files.add(file)
             else:

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import json
 import os
+import warnings
 
 import google.api_core.exceptions
 
@@ -78,6 +79,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
     @classmethod
     def from_cloud(
         cls,
+        project_name=None,
         cloud_path=None,
         bucket_name=None,
         path_to_dataset_directory=None,
@@ -92,6 +94,12 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained in the dataset directory
         :return Dataset:
         """
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         if cloud_path:
             bucket_name, path_to_dataset_directory = storage.path.split_bucket_name_from_gs_path(cloud_path)
         else:
@@ -129,7 +137,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         dataset._upload_metadata_file(cloud_path)
         return dataset
 
-    def to_cloud(self, cloud_path=None, bucket_name=None, output_directory=None):
+    def to_cloud(self, project_name=None, cloud_path=None, bucket_name=None, output_directory=None):
         """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `cloud_path` must be
         provided.
 
@@ -138,6 +146,12 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         :param str|None output_directory: path to output directory in cloud storage (e.g. `path/to/dataset`)
         :return str: cloud path for dataset
         """
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         if not cloud_path:
             cloud_path = storage.path.generate_gs_path(bucket_name, output_directory, self.name)
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -29,9 +29,20 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
     """
 
     _ATTRIBUTES_TO_HASH = ("files",)
-    _SERIALISE_FIELDS = "files", "name", "labels", "tags", "id", "path", "project_name"
+    _SERIALISE_FIELDS = "files", "name", "labels", "tags", "id", "path"
 
-    def __init__(self, files=None, name=None, id=None, path=None, project_name=None, path_from=None, tags=None, labels=None, **kwargs):
+    def __init__(
+        self,
+        files=None,
+        name=None,
+        id=None,
+        path=None,
+        project_name=None,
+        path_from=None,
+        tags=None,
+        labels=None,
+        **kwargs
+    ):
         super().__init__(name=name, id=id, tags=tags, labels=labels, path=path, path_from=path_from)
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -104,12 +104,9 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         output_directory = storage.path.dirname(path_to_manifest_file)
 
         for dataset in self.datasets:
-
             if store_datasets:
                 dataset_path = dataset.to_cloud(bucket_name=bucket_name, output_directory=output_directory)
-
                 datasets.append(dataset_path)
-
             else:
                 datasets.append(dataset.absolute_path)
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -5,7 +5,6 @@ from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.exceptions import InvalidInputException, InvalidManifestException
 from octue.mixins import Hashable, Identifiable, Pathable, Serialisable
-from octue.resources.datafile import CLOUD_STORAGE_PROTOCOL
 
 from .dataset import Dataset
 
@@ -170,7 +169,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         * manifest.json form - does not include path
         * Including datafiles that already exist
         * Including datafiles that don't yet exist or are not possessed currently (e.g. future output locations or
-          cloud files
+          cloud files)
 
         :param iter(any) datasets:
         :param list key_list:
@@ -184,7 +183,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
 
             else:
                 if "path" in dataset:
-                    if not os.path.isabs(dataset["path"]) and not dataset["path"].startswith(CLOUD_STORAGE_PROTOCOL):
+                    if not os.path.isabs(dataset["path"]) and not storage.path.is_qualified_cloud_path(dataset["path"]):
                         path = dataset.pop("path")
                         self.datasets.append(Dataset(**dataset, path=path, path_from=self))
                     else:

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -17,7 +17,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
     _ATTRIBUTES_TO_HASH = ("datasets",)
     _SERIALISE_FIELDS = "datasets", "keys", "id", "name", "path"
 
-    def __init__(self, id=None, path=None, datasets=None, keys=None, project_name=None, **kwargs):
+    def __init__(self, id=None, path=None, datasets=None, keys=None, **kwargs):
         super().__init__(id=id, path=path)
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined
@@ -165,6 +165,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         """Add the given datasets to the manifest, instantiating them if needed and giving them the correct path.
         There are several possible forms the datasets can come in:
         * Instantiated Dataset instances
+        * A list of dictionaries pointing to cloud datasets
         * Fully serialised form - includes path
         * `manifest.json` form - does not include path
         * Including datafiles that already exist

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,5 +1,6 @@
 import json
 import os
+import warnings
 
 from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
@@ -43,7 +44,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         vars(self).update(**kwargs)
 
     @classmethod
-    def from_cloud(cls, cloud_path=None, bucket_name=None, path_to_manifest_file=None):
+    def from_cloud(cls, project_name=None, cloud_path=None, bucket_name=None, path_to_manifest_file=None):
         """Instantiate a Manifest from Google Cloud storage. Either (`bucket_name` and `path_to_manifest_file`) or
         `cloud_path` must be provided.
 
@@ -52,6 +53,12 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         :param str|None path_to_manifest_file: path to manifest in cloud storage e.g. `path/to/manifest.json`
         :return Dataset:
         """
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         if cloud_path:
             bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
@@ -72,7 +79,9 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
             keys=serialised_manifest["keys"],
         )
 
-    def to_cloud(self, cloud_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=True):
+    def to_cloud(
+        self, project_name=None, cloud_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=True
+    ):
         """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory. Either
         (`bucket_name` and `path_to_manifest_file`) or `cloud_path` must be provided.
 
@@ -82,6 +91,12 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         :param bool store_datasets: if True, upload datasets to same directory as manifest file
         :return str: gs:// path for manifest file
         """
+        if project_name:
+            warnings.warn(
+                message="The `project_name` parameter is no longer needed and will be removed soon.",
+                category=DeprecationWarning,
+            )
+
         if cloud_path:
             bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -170,7 +170,15 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
                 self.datasets.append(dataset)
 
             else:
-                if "path" in dataset:
+                # If `dataset` is just a path to a dataset:
+                if isinstance(dataset, str):
+                    if storage.path.is_qualified_cloud_path(dataset):
+                        self.datasets.append(Dataset.from_cloud(cloud_path=dataset, recursive=True))
+                    else:
+                        self.datasets.append(Dataset.from_local_directory(path_to_directory=dataset, recursive=True))
+
+                # If `dataset` is a dictionary including a "path" key:
+                elif "path" in dataset:
                     # If the path is not a cloud path or an absolute local path:
                     if not os.path.isabs(dataset["path"]) and not storage.path.is_qualified_cloud_path(dataset["path"]):
                         path = dataset.pop("path")
@@ -178,12 +186,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
 
                     # If the path is a cloud path or an absolute local path:
                     else:
-                        if storage.path.is_qualified_cloud_path(dataset["path"]):
-                            dataset = Dataset.from_cloud(cloud_path=dataset["path"], recursive=True)
-                        else:
-                            dataset = Dataset(**dataset)
-
-                        self.datasets.append(dataset)
+                        self.datasets.append(Dataset(**dataset))
 
                 else:
                     self.datasets.append(Dataset(**dataset, path=key, path_from=self))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.10.6",
+    version="0.11.0",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -8,7 +8,7 @@ import google.cloud.exceptions
 
 from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
-from tests import TEST_BUCKET_NAME, TEST_PROJECT_NAME
+from tests import TEST_BUCKET_NAME
 from tests.base import BaseTestCase
 
 
@@ -20,7 +20,7 @@ class TestUploadFileToGoogleCloud(BaseTestCase):
         :return None:
         """
         cls.FILENAME = "my_file.txt"
-        cls.storage_client = GoogleCloudStorageClient(project_name=TEST_PROJECT_NAME)
+        cls.storage_client = GoogleCloudStorageClient()
 
     def test_create_bucket(self):
         """Test that a bucket can be created."""

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -179,7 +179,10 @@ class TestManifest(BaseTestCase):
         )
 
         manifest = Manifest(
-            datasets=[f"gs://{TEST_BUCKET_NAME}/my_dataset_1", "gs://another-test-bucket/my_dataset_2"],
+            datasets=[
+                f"gs://{TEST_BUCKET_NAME}/my_dataset_1",
+                "gs://another-test-bucket/my_dataset_2",
+            ],
             keys={"my_dataset_1": 0, "my_dataset_2": 1},
         )
 
@@ -187,3 +190,15 @@ class TestManifest(BaseTestCase):
 
         files_filtersets = [list(dataset.files)[0] for dataset in manifest.datasets]
         self.assertEqual({file.bucket_name for file in files_filtersets}, {TEST_BUCKET_NAME, "another-test-bucket"})
+
+    def test_instantiating_from_multiple_local_datasets(self):
+        """Test instantiating a manifest from multiple local datasets."""
+        manifest = Manifest(
+            datasets=[
+                os.path.join("path", "to", "dataset_0"),
+                os.path.join("path", "to", "dataset_1"),
+            ],
+            keys={"dataset_0": 0, "dataset_1": 1},
+        )
+
+        self.assertEqual({dataset.name for dataset in manifest.datasets}, {"dataset_0", "dataset_1"})

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -179,10 +179,7 @@ class TestManifest(BaseTestCase):
         )
 
         manifest = Manifest(
-            datasets=[
-                {"path": f"gs://{TEST_BUCKET_NAME}/my_dataset_1"},
-                {"path": "gs://another-test-bucket/my_dataset_2"},
-            ],
+            datasets=[f"gs://{TEST_BUCKET_NAME}/my_dataset_1", "gs://another-test-bucket/my_dataset_2"],
             keys={"my_dataset_1": 0, "my_dataset_2": 1},
         )
 

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -183,14 +183,8 @@ class TestManifest(BaseTestCase):
 
         manifest = Manifest(
             datasets=[
-                {
-                    "path": storage.path.generate_gs_path(TEST_BUCKET_NAME, "my_dataset_1"),
-                    "project_name": TEST_PROJECT_NAME,
-                },
-                {
-                    "path": storage.path.generate_gs_path("another-test-bucket", "my_dataset_2"),
-                    "project_name": TEST_PROJECT_NAME,
-                },
+                {"path": f"gs://{TEST_BUCKET_NAME}/my_dataset_1", "project_name": TEST_PROJECT_NAME},
+                {"path": f"gs://another-test-bucket/my_dataset_2", "project_name": TEST_PROJECT_NAME},
             ],
             keys={"my_dataset_1": 0, "my_dataset_2": 1},
         )

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -172,7 +172,7 @@ class TestManifest(BaseTestCase):
             path_in_bucket="my_dataset_1/file_0.txt",
         )
 
-        GoogleCloudStorageClient().upload_from_string(
+        storage_client.upload_from_string(
             "[4, 5, 6]",
             bucket_name="another-test-bucket",
             path_in_bucket="my_dataset_2/the_data.txt",


### PR DESCRIPTION
## Summary
Simplify manifest creation and simplify `octue.resources` cloud storage methods by inferring `project_name` from credentials file.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#347](https://github.com/octue/octue-sdk-python/pull/347))
**IMPORTANT:** There is 1 breaking change.

### Enhancements
- Allow manifests to be defined by a list of dataset paths
- **BREAKING CHANGE:** Infer `project_name` from credentials file and remove its explicit use as a parameter from the following cloud storage methods:
  - `GoogleCloudStorageClient`
  - `Analysis.finalise`
  - `Datafile`
  - `Datafile.to_cloud`
  - `Dataset.from_cloud`
  - `Dataset.to_cloud`
  - `Manifest.from_cloud`
  - `Manifest.to_cloud`

### Refactoring
- Pull cloud path checking into function
- Explicitly include files as a parameter of `Dataset`

### Documentation
- Add `manifest` documentation page
- Update version history documentation page
- Fix RST document reference on `logging` page

### Style
- Use latest `conventional-commits` pre-commit hook

<!--- END AUTOGENERATED NOTES --->