### PR TITLE
Fix JSON serialisation in GooglePubSubHandler

### DIFF
--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -47,9 +47,9 @@ class GooglePubSubHandler(logging.Handler):
             self.handleError(record)
 
     def _convert_log_record_to_primitives(self, log_record):
-        """Convert a log record to JSON-serialisable primitives by using and interpolating the args into the message,
-        and removing the exception info, which is potentially not JSON-serialisable. This is similar to the approach
-        in `logging.handlers.SocketHandler.makePickle`.
+        """Convert a log record to JSON-serialisable primitives by interpolating the args into the message, and
+        removing the exception info, which is potentially not JSON-serialisable. This is similar to the approach in
+        `logging.handlers.SocketHandler.makePickle`.
 
         :param logging.LogRecord log_record:
         :return dict:

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -47,16 +47,17 @@ class GooglePubSubHandler(logging.Handler):
             self.handleError(record)
 
     def _convert_log_record_to_primitives(self, log_record):
-        """Convert a log record to JSON-serialisable primitives, converting any non-JSON-serialisable `args` to their
-        string representation and removing any exception info to avoid failing JSON serialisation in the `emit` method.
+        """Convert a log record to JSON-serialisable primitives by using and interpolating the args into the message,
+        and removing the exception info, which is potentially not JSON-serialisable. This is similar to the approach
+        in `logging.handlers.SocketHandler.makePickle`.
 
         :param logging.LogRecord log_record:
         :return dict:
         """
         serialised_record = vars(log_record)
 
-        if serialised_record["levelno"] == logging.ERROR:
-            serialised_record["exc_info"] = tuple()
-
-        serialised_record["args"] = tuple(repr(arg) for arg in serialised_record["args"])
+        serialised_record["msg"] = log_record.getMessage()
+        serialised_record["args"] = None
+        serialised_record["exc_info"] = None
+        serialised_record.pop("message", None)
         return serialised_record

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.10.5",
+    version="0.10.6",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -48,6 +48,6 @@ class TestGooglePubSubHandler(BaseTestCase):
             GooglePubSubHandler(service.publisher, topic, "analysis-id").emit(record)
 
         self.assertEqual(
-            json.loads(mock_publish.call_args.kwargs["data"].decode())["log_record"]["args"][0],
-            "NonJSONSerialisableInstance",
+            json.loads(mock_publish.call_args.kwargs["data"].decode())["log_record"]["msg"],
+            "NonJSONSerialisableInstance is not JSON-serialisable",
         )

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -33,7 +33,7 @@ class TestGooglePubSubHandler(BaseTestCase):
         """
         backend = GCPPubSubBackend(project_name="blah")
         service = MockService(backend=backend)
-        topic = MockTopic(name="world", namespace="hello", service=service)
+        topic = MockTopic(name="world-1", namespace="hello", service=service)
         topic.create()
 
         non_json_serialisable_thing = NonJSONSerialisable()

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -1,10 +1,17 @@
 import json
+import logging
 from logging import makeLogRecord
+from unittest.mock import patch
 
 from octue.cloud.pub_sub.logging import GooglePubSubHandler
 from octue.resources.service_backends import GCPPubSubBackend
 from tests.base import BaseTestCase
 from tests.cloud.pub_sub.mocks import MESSAGES, MockService, MockTopic
+
+
+class NonJSONSerialisable:
+    def __repr__(self):
+        return "NonJSONSerialisableInstance"
 
 
 class TestGooglePubSubHandler(BaseTestCase):
@@ -19,3 +26,28 @@ class TestGooglePubSubHandler(BaseTestCase):
         GooglePubSubHandler(service.publisher, topic, "analysis-id").emit(log_record)
 
         self.assertEqual(json.loads(MESSAGES[topic.name][0].data.decode())["log_record"]["msg"], "Starting analysis.")
+
+    def test_emit_with_non_json_serialisable_args(self):
+        """Test that non-JSON-serialisable arguments to log messages are converted to their representation before being
+        serialised to publish to the Pub/Sub topic.
+        """
+        backend = GCPPubSubBackend(project_name="blah")
+        service = MockService(backend=backend)
+        topic = MockTopic(name="world", namespace="hello", service=service)
+        topic.create()
+
+        non_json_serialisable_thing = NonJSONSerialisable()
+
+        # Check that it can't be serialised to JSON.
+        with self.assertRaises(TypeError):
+            json.dumps(non_json_serialisable_thing)
+
+        record = logging.makeLogRecord({"msg": "%r is not JSON-serialisable", "args": (non_json_serialisable_thing,)})
+
+        with patch("tests.cloud.pub_sub.mocks.MockPublisher.publish") as mock_publish:
+            GooglePubSubHandler(service.publisher, topic, "analysis-id").emit(record)
+
+        self.assertEqual(
+            json.loads(mock_publish.call_args.kwargs["data"].decode())["log_record"]["args"][0],
+            "NonJSONSerialisableInstance",
+        )


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#352](https://github.com/octue/octue-sdk-python/pull/352))

### Fixes
- Convert non-JSON-serialisable log record args to strings before Pub/Sub log emission

<!--- END AUTOGENERATED NOTES --->