### PR TITLE
Combine keys and datasets in Manifest instantiation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # This workflow tests and releases a new version of the package, then publishes it to PyPi and the
 # octue/octue-sdk-python Docker Hub repository.
 
-name: Release the package
+name: Release
 
 # Only trigger when a pull request into main branch is merged.
 on:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PyPI version](https://badge.fury.io/py/octue.svg)](https://badge.fury.io/py/octue)
-[![python-ci](https://github.com/octue/octue-sdk-python/actions/workflows/python-ci.yml/badge.svg?branch=main)](https://github.com/octue/octue-sdk-python/actions/workflows/python-ci.yml)
+[![Release](https://github.com/octue/octue-sdk-python/actions/workflows/release.yml/badge.svg)](https://github.com/octue/octue-sdk-python/actions/workflows/release.yml)
 [![codecov](https://codecov.io/gh/octue/octue-sdk-python/branch/main/graph/badge.svg?token=4KdR7fmwcT)](https://codecov.io/gh/octue/octue-sdk-python)
 [![Documentation Status](https://readthedocs.org/projects/octue-python-sdk/badge/?version=latest)](https://octue-python-sdk.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)

--- a/octue/migrations/manifest.py
+++ b/octue/migrations/manifest.py
@@ -1,0 +1,31 @@
+import warnings
+
+
+def translate_datasets_list_to_dictionary(datasets, keys=None):
+    """Translate the old datasets list format to the new dictionary format for use in a manifest, and issue a
+    deprecation warning.
+
+    :param list(octue.resources.dataset.Dataset|str|dict) datasets:
+    :param dict(str, int) keys: a mapping of dataset name/key to the index of the dataset in the `datasets` parameter
+    :return dict: datasets and keys combined as a dictionary of keys mapped to datasets
+    """
+    keys = keys or {}
+    translated_datasets = {}
+
+    for index, dataset in enumerate(datasets):
+        if isinstance(dataset, str):
+            key = f"dataset_{index}"
+        else:
+            key = keys.get(index) or dataset.get("name") or f"dataset_{index}"
+
+        translated_datasets[key] = dataset
+
+    warnings.warn(
+        message=(
+            "Datasets belonging to a manifest should be provided as a dictionary mapping their name/key to "
+            "themselves. Support for providing a list of datasets will be phased out soon."
+        ),
+        category=DeprecationWarning,
+    )
+
+    return translated_datasets

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -13,6 +13,11 @@ from .dataset import Dataset
 class Manifest(Pathable, Serialisable, Identifiable, Hashable):
     """A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
     (or leaving), a data service for an analysis at the configuration, input or output stage.
+
+    :param str|None id: the UUID of the manifest (a UUID is generated if one isn't given)
+    :param str|None path: the path the manifest exists at (defaults to the current working directory)
+    :param dict|None datasets: a mapping of dataset names to `Dataset` instances, serialised datasets, or paths to datasets
+    :return None:
     """
 
     _ATTRIBUTES_TO_HASH = ("datasets",)
@@ -121,21 +126,27 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         return all(dataset.all_files_are_in_cloud for dataset in self.datasets.values())
 
     def get_dataset(self, key):
-        """Get a dataset by its key name (as defined in the twine).
+        """Get a dataset by its key (as defined in the twine).
 
-        :return Dataset: Dataset selected by its key
+        :param str key:
+        :return octue.resources.dataset.Dataset:
         """
         dataset = self.datasets.get(key, None)
 
         if dataset is None:
             raise InvalidInputException(
-                f"Attempted to fetch unknown dataset {key!r} from Manifest. Allowable keys are: {self.datasets.keys()}"
+                f"Attempted to fetch unknown dataset {key!r} from Manifest. Allowable keys are: "
+                f"{list(self.datasets.keys())}"
             )
 
         return dataset
 
     def prepare(self, data):
-        """Prepare new manifest from a manifest_spec"""
+        """Prepare new manifest from a manifest_spec.
+
+        :param dict data:
+        :return Manifest:
+        """
         if len(self.datasets) > 0:
             raise InvalidInputException("You cannot `prepare()` a manifest already instantiated with datasets")
 
@@ -157,7 +168,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         * Including datafiles that don't yet exist or are not possessed currently (e.g. future output locations or
           cloud files)
 
-        :param iter(any) datasets:
+        :param iter(octue.resources.dataset.Dataset|str|dict) datasets: the datasets to add to the manifest
         :return None:
         """
         for key, dataset in datasets.items():

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -24,6 +24,27 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
     _SERIALISE_FIELDS = "datasets", "keys", "id", "name", "path"
 
     def __init__(self, id=None, path=None, datasets=None, **kwargs):
+        if isinstance(datasets, list):
+            translated_datasets = {}
+
+            for index, dataset in enumerate(datasets):
+                if isinstance(dataset, str):
+                    key = f"unknown_{index}"
+                else:
+                    key = dataset.get("name") or kwargs.get("keys", {}).get(index, f"unknown_{index}")
+
+                translated_datasets[key] = dataset
+
+            datasets = translated_datasets
+
+            warnings.warn(
+                message=(
+                    "Datasets belonging to a manifest should be provided as a dictionary mapping their name to "
+                    "themselves. Support for providing a list of datasets will be phased out soon."
+                ),
+                category=DeprecationWarning,
+            )
+
         super().__init__(id=id, path=path)
         self.datasets = {}
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -3,7 +3,7 @@ import os
 
 from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
-from octue.exceptions import InvalidInputException, InvalidManifestException
+from octue.exceptions import InvalidInputException
 from octue.mixins import Hashable, Identifiable, Pathable, Serialisable
 from octue.resources.datafile import CLOUD_STORAGE_PROTOCOL
 
@@ -18,8 +18,9 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
     _ATTRIBUTES_TO_HASH = ("datasets",)
     _SERIALISE_FIELDS = "datasets", "keys", "id", "name", "path"
 
-    def __init__(self, id=None, path=None, datasets=None, keys=None, **kwargs):
+    def __init__(self, id=None, path=None, datasets=None, **kwargs):
         super().__init__(id=id, path=path)
+        self.datasets = {}
 
         # TODO The decoders aren't being used; utils.decoders.OctueJSONDecoder should be used in twined
         #  so that resources get automatically instantiated.
@@ -27,20 +28,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         #  get initialised properly, then tidy up this hackjob. Also need to allow Pathables to update ownership
         #  (because decoders work from the bottom of the tree upwards, not top-down)
 
-        datasets = datasets or []
-        self.keys = keys or {}
-
-        # TODO we need to add keys to the manifest file schema in twined so that we know what dataset(s) map to what keys
-        #  In the meantime, we enforce at this level that keys will match
-        if len(self.keys) != len(datasets):
-            raise InvalidManifestException(
-                f"Manifest instantiated with {len(self.keys)} keys, and {len(datasets)} datasets... keys must match datasets!"
-            )
-
-        # Sort the keys by the dataset index so we have a list of keys in the same order as the dataset list.
-        # We'll use this to name the dataset folders
-        key_list = [key for key, value in sorted(self.keys.items(), key=lambda item: item[1])]
-        self._instantiate_datasets(datasets, key_list)
+        self._instantiate_datasets(datasets or {})
         vars(self).update(**kwargs)
 
     @classmethod
@@ -65,20 +53,17 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
 
         datasets = []
 
-        for dataset in serialised_manifest["datasets"]:
+        for key, dataset in serialised_manifest["datasets"].items():
             dataset_bucket_name, path = storage.path.split_bucket_name_from_gs_path(dataset)
 
-            datasets.append(
-                Dataset.from_cloud(
-                    project_name=project_name, bucket_name=dataset_bucket_name, path_to_dataset_directory=path
-                )
+            datasets[key] = Dataset.from_cloud(
+                project_name=project_name, bucket_name=dataset_bucket_name, path_to_dataset_directory=path
             )
 
         return Manifest(
             id=serialised_manifest["id"],
             path=storage.path.generate_gs_path(bucket_name, path_to_manifest_file),
             datasets=datasets,
-            keys=serialised_manifest["keys"],
         )
 
     def to_cloud(
@@ -97,20 +82,20 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         if cloud_path:
             bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
-        datasets = []
+        datasets = {}
         output_directory = storage.path.dirname(path_to_manifest_file)
 
-        for dataset in self.datasets:
+        for key, dataset in self.datasets.items():
 
             if store_datasets:
                 dataset_path = dataset.to_cloud(
                     project_name, bucket_name=bucket_name, output_directory=output_directory
                 )
 
-                datasets.append(dataset_path)
+                datasets[key] = dataset_path
 
             else:
-                datasets.append(dataset.absolute_path)
+                datasets[key] = dataset.absolute_path
 
         serialised_manifest = self.to_primitive()
         serialised_manifest["datasets"] = sorted(datasets)
@@ -133,20 +118,21 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         if not self.datasets:
             return False
 
-        return all(dataset.all_files_are_in_cloud for dataset in self.datasets)
+        return all(dataset.all_files_are_in_cloud for dataset in self.datasets.values())
 
     def get_dataset(self, key):
         """Get a dataset by its key name (as defined in the twine).
 
         :return Dataset: Dataset selected by its key
         """
-        idx = self.keys.get(key, None)
-        if idx is None:
+        dataset = self.datasets.get(key, None)
+
+        if dataset is None:
             raise InvalidInputException(
-                f"Attempted to fetch unknown dataset '{key}' from Manifest. Allowable keys are: {list(self.keys.keys())}"
+                f"Attempted to fetch unknown dataset {key!r} from Manifest. Allowable keys are: {self.datasets.keys()}"
             )
 
-        return self.datasets[idx]
+        return self.datasets[dataset]
 
     def prepare(self, data):
         """Prepare new manifest from a manifest_spec"""
@@ -154,15 +140,13 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
             raise InvalidInputException("You cannot `prepare()` a manifest already instantiated with datasets")
 
         for index, dataset_specification in enumerate(data["datasets"]):
-
-            self.keys[dataset_specification["key"]] = index
             # TODO generate a unique name based on the filter key, label datasets so that the label filters in the spec
             #  apply automatically and generate a description of the dataset
-            self.datasets.append(Dataset(path_from=self, path=dataset_specification["key"]))
+            self.datasets[dataset_specification["key"]] = Dataset(path_from=self, path=dataset_specification["key"])
 
         return self
 
-    def _instantiate_datasets(self, datasets, key_list):
+    def _instantiate_datasets(self, datasets):
         """Add the given datasets to the manifest, instantiating them if needed and giving them the correct path.
         There are several possible forms the datasets can come in:
         * Instantiated Dataset instances
@@ -173,22 +157,20 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
           cloud files
 
         :param iter(any) datasets:
-        :param list key_list:
         :return None:
         """
-        self.datasets = []
-        for key, dataset in zip(key_list, datasets):
+        for key, dataset in datasets.items():
 
             if isinstance(dataset, Dataset):
-                self.datasets.append(dataset)
+                self.datasets[key] = dataset
 
             else:
                 if "path" in dataset:
                     if not os.path.isabs(dataset["path"]) and not dataset["path"].startswith(CLOUD_STORAGE_PROTOCOL):
                         path = dataset.pop("path")
-                        self.datasets.append(Dataset(**dataset, path=path, path_from=self))
+                        self.datasets[key] = Dataset(**dataset, path=path, path_from=self)
                     else:
-                        self.datasets.append(Dataset(**dataset))
+                        self.datasets[key] = Dataset(**dataset)
 
                 else:
-                    self.datasets.append(Dataset(**dataset, path=key, path_from=self))
+                    self.datasets[key] = Dataset(**dataset, path=key, path_from=self)

--- a/octue/templates/template-python-fractal/twine.json
+++ b/octue/templates/template-python-fractal/twine.json
@@ -61,11 +61,10 @@
 		}
 	},
 	"output_manifest": {
-		"datasets": [
-			{
-				"key": "fractal_figure_files",
+		"datasets": {
+			"fractal_figure_files": {
 				"purpose": "A dataset containing .json files containing the output figures"
 			}
-		]
+		}
 	}
 }

--- a/octue/templates/template-using-manifests/data/input/manifest.json
+++ b/octue/templates/template-using-manifests/data/input/manifest.json
@@ -1,21 +1,28 @@
 {
   "id": "8ead7669-8162-4f64-8cd5-4abe92509e17",
-  "keys": {
-    "raw_met_mast_data": 0
-  },
-  "datasets": [
-    {
+  "datasets": {
+    "raw_met_mast_data": {
       "id": "7ead4669-8162-4f64-8cd5-4abe92509e17",
       "name": "meteorological mast dataset",
       "path": "data/input/raw_met_mast_data",
-      "tags": {"location": 108346},
-      "labels": ["met", "mast", "wind"],
+      "tags": {
+        "location": 108346
+      },
+      "labels": [
+        "met",
+        "mast",
+        "wind"
+      ],
       "files": [
         {
           "path": "08DEC/High Res Meteorological Mast Data - 8 Dec_1.csv",
           "extension": "csv",
-          "tags": {"sequence": 0},
-          "labels": ["timeseries"],
+          "tags": {
+            "sequence": 0
+          },
+          "labels": [
+            "timeseries"
+          ],
           "timestamp": 1605783547.0,
           "id": "acff07bc-7c19-4ed5-be6d-a6546eae8e86",
           "name": "High Res Meteorological Mast Data - 8 Dec_1.csv",
@@ -25,8 +32,12 @@
         {
           "path": "08DEC/High Res Meteorological Mast Data - 8 Dec_2.csv",
           "extension": "csv",
-          "tags": {"sequence": 1},
-          "labels": ["timeseries"],
+          "tags": {
+            "sequence": 1
+          },
+          "labels": [
+            "timeseries"
+          ],
           "timestamp": 1605783547.0,
           "id": "bdff07bc-7c19-4ed5-be6d-a6546eae8e45",
           "name": "High Res Meteorological Mast Data - 8 Dec_2.csv",
@@ -36,8 +47,12 @@
         {
           "path": "08DEC/meta - 8 Dec.dat",
           "extension": "dat",
-          "tags": {"sequence": 0},
-          "labels": ["meta"],
+          "tags": {
+            "sequence": 0
+          },
+          "labels": [
+            "meta"
+          ],
           "timestamp": 1605783547.0,
           "id": "ceff07bc-7c19-4ed5-be6d-a6546eae8e86",
           "name": "meta - 8 Dec_1.da",
@@ -46,5 +61,5 @@
         }
       ]
     }
-  ]
+  }
 }

--- a/octue/templates/template-using-manifests/twine.json
+++ b/octue/templates/template-using-manifests/twine.json
@@ -13,19 +13,17 @@
 		}
 	},
 	"input_manifest": {
-		"datasets": [
-			{
-				"key": "raw_met_mast_data",
+		"datasets": {
+			"raw_met_mast_data": {
 				"purpose": "A dataset containing .csv files of raw meteorological mast data which we need to clean up"
 			}
-		]
+		}
 	},
 	"output_manifest": {
-		"datasets": [
-			{
-				"key": "cleaned_met_mast_data",
+		"datasets": {
+			"cleaned_met_mast_data": {
 				"purpose": "A dataset containing .csv files of cleaned meteorological mast data"
 			}
-		]
+		}
 	}
 }

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.10.6",
+    version="0.12.0",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "google-crc32c>=1.1.2",
         "gunicorn",
         "python-dateutil>=2.8.1",
-        "twined @ https://github.com/octue/twined/archive/enhancement/simplify-manifest-schema.zip",
+        "twined==0.2.0",
     ],
     extras_require={"hdf5": ["h5py==3.6.0"], "dataflow": ["apache-beam[gcp]==2.36.0"]},
     url="https://www.github.com/octue/octue-sdk-python",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "google-crc32c>=1.1.2",
         "gunicorn",
         "python-dateutil>=2.8.1",
-        "twined==0.1.0",
+        "twined @ https://github.com/octue/twined/archive/enhancement/simplify-manifest-schema.zip",
     ],
     extras_require={"hdf5": ["h5py==3.6.0"], "dataflow": ["apache-beam[gcp]==2.36.0"]},
     url="https://www.github.com/octue/octue-sdk-python",

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,8 +50,8 @@ class BaseTestCase(unittest.TestCase):
 
     def create_valid_manifest(self):
         """Create a valid manifest with two valid datasets (they're the same dataset in this case)."""
-        datasets = [self.create_valid_dataset(), self.create_valid_dataset()]
-        manifest = Manifest(datasets=datasets, keys={"my_dataset": 0, "another_dataset": 1})
+        datasets = {"my_dataset": self.create_valid_dataset(), "another_dataset": self.create_valid_dataset()}
+        manifest = Manifest(datasets=datasets)
         return manifest
 
     def _create_octue_configuration_file(self, octue_configuration, directory_path):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -498,7 +498,7 @@ class TestService(BaseTestCase):
             Datafile(path="gs://my-dataset/goodbye.csv", project_name="blah", hypothetical=True),
         ]
 
-        input_manifest = Manifest(datasets=[Dataset(files=files)], path="gs://my-dataset", keys={"my_dataset": 0})
+        input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files)}, path="gs://my-dataset")
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):
             with patch("octue.cloud.pub_sub.service.Subscription", new=MockSubscription):
@@ -529,7 +529,7 @@ class TestService(BaseTestCase):
             Datafile(path="gs://my-dataset/goodbye.csv", project_name=TEST_PROJECT_NAME, hypothetical=True),
         ]
 
-        input_manifest = Manifest(datasets=[Dataset(files=files)], path="gs://my-dataset", keys={"my_dataset": 0})
+        input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files)}, path="gs://my-dataset")
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):
             with patch("octue.cloud.pub_sub.service.Subscription", new=MockSubscription):
@@ -571,7 +571,7 @@ class TestService(BaseTestCase):
         local_file = Datafile(path=temporary_local_path)
         self.assertFalse(local_file.exists_in_cloud)
 
-        manifest = Manifest(datasets=[Dataset(name="my-local-dataset", file=local_file)], keys={0: "my-local-dataset"})
+        manifest = Manifest(datasets={"my-local-dataset": Dataset(name="my-local-dataset", file=local_file)})
 
         # Get the child to open the local file itself and return the contents as output.
         def run_function(analysis_id, input_values, input_manifest, analysis_log_handler, handle_monitor_message):

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -226,4 +226,4 @@ class TestManifest(BaseTestCase):
                 keys={"my_dataset_1": 0, "my_dataset_2": 1},
             )
 
-        self.assertEqual(set(manifest.datasets.keys()), {"unknown_0", "unknown_1"})
+        self.assertEqual(set(manifest.datasets.keys()), {"dataset_0", "dataset_1"})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -135,16 +135,14 @@ class RunnerTestCase(BaseTestCase):
             twine="""
                 {
                     "output_manifest": {
-                        "datasets": [
-                            {
-                                "key": "open_foam_result",
+                        "datasets": {
+                            "open_foam_result": {
                                 "purpose": "A dataset containing solution fields of an openfoam case."
                             },
-                            {
-                                "key": "airfoil_cp_values",
+                            "airfoil_cp_values": {
                                 "purpose": "A file containing cp values"
                             }
-                        ]
+                        }
                     }
                 }
             """,


### PR DESCRIPTION
## Summary
Simplify instantiation of manifests by specifying their datasets as a dictionary instead of a list with a separate keys parameter.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#355](https://github.com/octue/octue-sdk-python/pull/355))
**IMPORTANT:** There are 3 breaking changes.

### Enhancements
- **BREAKING CHANGE:** Subsume `keys` parameter into `datasets` parameter for `Manifest` instantiation by making `datasets` a dictionary
- **BREAKING CHANGE:** Serialise a manifest's datasets as a dictionary
- **BREAKING CHANGE:** Use latest schema for datasets in manifests

### Dependencies
- Use `twined==0.2.0`

### Documentation
- Use correct GitHub workflow badge in `README`

<!--- END AUTOGENERATED NOTES --->