### PR TITLE
Deprecate old cloud storage parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
           - '^refactor/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^test/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
           - '^style/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^deprecation/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/conventional-commits
     rev: 0.5.3

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -129,8 +129,6 @@ class GoogleCloudStorageClient:
         """Get the metadata of the given file in the given bucket.
 
         :param str|None cloud_path: full cloud path to file (e.g. `gs://bucket_name/path/to/file.csv`)
-        :param str|None bucket_name: name of bucket where cloud file is located
-        :param str|None path_in_bucket: path to cloud file (e.g. `path/to/file.csv`)
         :param float timeout: time in seconds to allow for the request to complete
         :return dict:
         """

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -12,6 +12,7 @@ from google_crc32c import Checksum
 from octue.cloud.credentials import GCPCredentialsManager
 from octue.cloud.storage.path import split_bucket_name_from_gs_path
 from octue.exceptions import CloudStorageBucketNotFound
+from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
 from octue.utils.decoders import OctueJSONDecoder
 from octue.utils.encoders import OctueJSONEncoder
 
@@ -57,12 +58,20 @@ class GoogleCloudStorageClient:
 
         self.client.create_bucket(bucket_or_name=name, location=location, timeout=timeout)
 
-    def exists(self, cloud_path=None):
+    def exists(
+        self,
+        cloud_path=None,
+        bucket_name=None,
+        path_in_bucket=None,
+    ):
         """Check if a file exists at the given path.
 
         :param str|None cloud_path: full cloud path to the file (e.g. `gs://bucket_name/path/to/file.csv`)
         :return bool: `True` if the file exists
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path=cloud_path)
         return blob.exists()
 
@@ -70,6 +79,8 @@ class GoogleCloudStorageClient:
         self,
         local_path,
         cloud_path=None,
+        bucket_name=None,
+        path_in_bucket=None,
         metadata=None,
         timeout=_DEFAULT_TIMEOUT,
     ):
@@ -81,6 +92,9 @@ class GoogleCloudStorageClient:
         :param float timeout: time in seconds to allow for the upload to complete
         :return None:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path)
 
         with open(local_path, "rb") as f:
@@ -90,7 +104,9 @@ class GoogleCloudStorageClient:
         self._overwrite_blob_custom_metadata(blob, metadata)
         logger.debug("Uploaded %r to Google Cloud at %r.", local_path, blob.public_url)
 
-    def upload_from_string(self, string, cloud_path=None, metadata=None, timeout=_DEFAULT_TIMEOUT):
+    def upload_from_string(
+        self, string, cloud_path=None, bucket_name=None, path_in_bucket=None, metadata=None, timeout=_DEFAULT_TIMEOUT
+    ):
         """Upload serialised data in string form to a file in a Google Cloud bucket at
         gs://<bucket_name>/<path_in_bucket>.
 
@@ -100,13 +116,16 @@ class GoogleCloudStorageClient:
         :param float timeout: time in seconds to allow for the upload to complete
         :return None:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path)
         blob.crc32c = self._compute_crc32c_checksum(string)
         blob.upload_from_string(data=string, timeout=timeout)
         self._overwrite_blob_custom_metadata(blob, metadata)
         logger.debug("Uploaded data to Google Cloud at %r.", blob.public_url)
 
-    def get_metadata(self, cloud_path=None, timeout=_DEFAULT_TIMEOUT):
+    def get_metadata(self, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
         """Get the metadata of the given file in the given bucket.
 
         :param str|None cloud_path: full cloud path to file (e.g. `gs://bucket_name/path/to/file.csv`)
@@ -115,6 +134,9 @@ class GoogleCloudStorageClient:
         :param float timeout: time in seconds to allow for the request to complete
         :return dict:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         bucket_name, path_in_bucket = split_bucket_name_from_gs_path(cloud_path)
 
         bucket = self.client.get_bucket(bucket_or_name=bucket_name)
@@ -144,17 +166,28 @@ class GoogleCloudStorageClient:
             "path_in_bucket": path_in_bucket,
         }
 
-    def overwrite_custom_metadata(self, metadata, cloud_path=None):
+    def overwrite_custom_metadata(
+        self,
+        metadata,
+        cloud_path=None,
+        bucket_name=None,
+        path_in_bucket=None,
+    ):
         """Overwrite the custom metadata for the given cloud file.
 
         :param dict metadata: key-value pairs to set as the new custom metadata
         :param str|None cloud_path: full cloud path to file (e.g. `gs://bucket_name/path/to/file.csv`)
         :return None:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path)
         self._overwrite_blob_custom_metadata(blob, metadata)
 
-    def download_to_file(self, local_path, cloud_path=None, timeout=_DEFAULT_TIMEOUT):
+    def download_to_file(
+        self, local_path, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT
+    ):
         """Download a file to a file from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>.
 
         :param str local_path: path to download to
@@ -162,30 +195,39 @@ class GoogleCloudStorageClient:
         :param float timeout: time in seconds to allow for the download to complete
         :return None:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path)
         self._create_intermediate_local_directories(local_path)
         blob.download_to_filename(local_path, timeout=timeout)
         logger.debug("Downloaded %r from Google Cloud to %r.", blob.public_url, local_path)
 
-    def download_as_string(self, cloud_path=None, timeout=_DEFAULT_TIMEOUT):
+    def download_as_string(self, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
         """Download a file to a string from a Google Cloud bucket at gs://<bucket_name>/<path_in_bucket>.
 
         :param str|None cloud_path: full cloud path to download from (e.g. `gs://bucket_name/path/to/file.csv`)
         :param float timeout: time in seconds to allow for the download to complete
         :return str:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path)
         data = blob.download_as_bytes(timeout=timeout)
         logger.debug("Downloaded %r from Google Cloud to as string.", blob.public_url)
         return data.decode()
 
-    def delete(self, cloud_path=None, timeout=_DEFAULT_TIMEOUT):
+    def delete(self, cloud_path=None, bucket_name=None, path_in_bucket=None, timeout=_DEFAULT_TIMEOUT):
         """Delete the given file from the given bucket.
 
         :param str|None cloud_path: full cloud path to file to delete (e.g. `gs://bucket_name/path/to/file.csv`)
         :param float timeout: time in seconds to allow for the request to complete
         :return None:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         blob = self._blob(cloud_path)
         blob.delete(timeout=timeout)
         logger.debug("Deleted %r from Google Cloud.", blob.public_url)
@@ -193,6 +235,8 @@ class GoogleCloudStorageClient:
     def scandir(
         self,
         cloud_path=None,
+        bucket_name=None,
+        directory_path=None,
         filter=None,
         recursive=True,
         show_directories_as_blobs=False,
@@ -207,6 +251,9 @@ class GoogleCloudStorageClient:
         :param float timeout: time in seconds to allow for the request to complete
         :yield google.cloud.storage.blob.Blob:
         """
+        if not cloud_path:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, directory_path)
+
         if filter is None:
             filter = lambda blob: True
 
@@ -242,10 +289,7 @@ class GoogleCloudStorageClient:
     def _blob(self, cloud_path=None):
         """Instantiate a blob for the given bucket at the given path. Note that this is not synced up with Google Cloud.
 
-
         :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_in_bucket:
         :raise octue.exceptions.CloudStorageBucketNotFound: if the bucket isn't found
         :return google.cloud.storage.blob.Blob:
         """

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -29,13 +29,7 @@ class GoogleCloudStorageClient:
     :return None:
     """
 
-    def __init__(self, project_name=None, credentials=OCTUE_MANAGED_CREDENTIALS):
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
+    def __init__(self, credentials=OCTUE_MANAGED_CREDENTIALS):
         warnings.simplefilter("ignore", category=ResourceWarning)
 
         if credentials == OCTUE_MANAGED_CREDENTIALS:

--- a/octue/migrations/cloud_storage.py
+++ b/octue/migrations/cloud_storage.py
@@ -1,0 +1,15 @@
+import warnings
+
+from octue.cloud import storage
+
+
+def translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket):
+    warnings.warn(
+        message=(
+            "Using a bucket name and path in bucket will be deprecated soon. Please use `cloud_path` instead e.g."
+            "'gs://bucket_name/path/to/file.txt'."
+        ),
+        category=DeprecationWarning,
+    )
+
+    return storage.path.generate_gs_path(bucket_name, path_in_bucket)

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -4,6 +4,7 @@ import logging
 import twined.exceptions
 from octue.definitions import OUTPUT_STRANDS
 from octue.exceptions import InvalidMonitorMessage
+from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
 from octue.mixins import Hashable, Identifiable, Labelable, Serialisable, Taggable
 from octue.resources.manifest import Manifest
 from octue.utils.encoders import OctueJSONEncoder
@@ -103,7 +104,7 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         self._handle_monitor_message(data)
 
-    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, cloud_path=None):
+    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, cloud_path=None, bucket_name=None):
         """Validate and serialise the output values and manifest, optionally writing them to files and/or the manifest
         to the cloud.
 
@@ -140,6 +141,9 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         # Optionally write the manifest to Google Cloud storage.
         if upload_to_cloud:
             if hasattr(self, "output_manifest"):
+                if not cloud_path:
+                    cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, output_dir)
+
                 self.output_manifest.to_cloud(cloud_path)
                 logger.debug("Wrote %r to %r.", self.output_manifest, cloud_path)
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -1,10 +1,11 @@
 import json
 import logging
+import warnings
 
 import twined.exceptions
+from octue.cloud import storage
 from octue.definitions import OUTPUT_STRANDS
 from octue.exceptions import InvalidMonitorMessage
-from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
 from octue.mixins import Hashable, Identifiable, Labelable, Serialisable, Taggable
 from octue.resources.manifest import Manifest
 from octue.utils.encoders import OctueJSONEncoder
@@ -142,7 +143,15 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         if upload_to_cloud:
             if hasattr(self, "output_manifest"):
                 if not cloud_path:
-                    cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, output_dir)
+                    warnings.warn(
+                        message=(
+                            "Using a bucket name and path in bucket will be deprecated soon. Please use `cloud_path` instead e.g."
+                            "'gs://bucket_name/path/to/file.txt'."
+                        ),
+                        category=DeprecationWarning,
+                    )
+
+                    cloud_path = storage.path.generate_gs_path(bucket_name, output_dir)
 
                 self.output_manifest.to_cloud(cloud_path)
                 logger.debug("Wrote %r to %r.", self.output_manifest, cloud_path)

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -103,7 +103,7 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         self._handle_monitor_message(data)
 
-    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, bucket_name=None):
+    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, cloud_path=None):
         """Validate and serialise the output values and manifest, optionally writing them to files and/or the manifest
         to the cloud.
 
@@ -140,8 +140,8 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         # Optionally write the manifest to Google Cloud storage.
         if upload_to_cloud:
             if hasattr(self, "output_manifest"):
-                self.output_manifest.to_cloud(bucket_name, output_dir)
-                logger.debug("Wrote %r to cloud storage bucket %r.", self.output_manifest, bucket_name)
+                self.output_manifest.to_cloud(cloud_path)
+                logger.debug("Wrote %r to %r.", self.output_manifest, cloud_path)
 
         return serialised_strands
 

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import warnings
 
 import twined.exceptions
 from octue.definitions import OUTPUT_STRANDS
@@ -104,7 +103,7 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         self._handle_monitor_message(data)
 
-    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, project_name=None, bucket_name=None):
+    def finalise(self, output_dir=None, save_locally=False, upload_to_cloud=False, bucket_name=None):
         """Validate and serialise the output values and manifest, optionally writing them to files and/or the manifest
         to the cloud.
 
@@ -114,12 +113,6 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         :param str bucket_name:
         :return dict: serialised strings for values and manifest data.
         """
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         serialised_strands = {}
 
         for output_strand in OUTPUT_STRANDS:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -3,7 +3,6 @@ import functools
 import logging
 import os
 import tempfile
-import warnings
 from urllib.parse import urlparse
 
 import google.api_core.exceptions
@@ -85,7 +84,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         path,
         local_path=None,
         cloud_path=None,
-        project_name=None,
         timestamp=None,
         id=ID_DEFAULT,
         path_from=None,
@@ -97,12 +95,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         hypothetical=False,
         **kwargs,
     ):
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         super().__init__(
             id=id,
             name=kwargs.pop("name", None),
@@ -193,9 +185,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         datafile._cloud_metadata = cloud_metadata
         return datafile
 
-    def to_cloud(
-        self, project_name=None, cloud_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True
-    ):
+    def to_cloud(self, cloud_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True):
         """Upload a datafile to Google Cloud Storage. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must
         be provided.
 
@@ -205,12 +195,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         :param bool update_cloud_metadata: if `True`, update the metadata of the datafile in the cloud at upload time
         :return str: gs:// path for datafile
         """
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         cloud_path = self._get_cloud_location(cloud_path, bucket_name, path_in_bucket)
         self.get_cloud_metadata()
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -115,7 +115,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         self._cloud_metadata = {}
 
         if storage.path.is_qualified_cloud_path(self.path):
-            self._store_cloud_location(cloud_path=path)
+            self._cloud_path = path
 
             if not self._hypothetical:
                 # Collect any non-`None` metadata instantiation parameters so the user can be warned if they conflict
@@ -185,17 +185,14 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         datafile._cloud_metadata = cloud_metadata
         return datafile
 
-    def to_cloud(self, cloud_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True):
-        """Upload a datafile to Google Cloud Storage. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must
-        be provided.
+    def to_cloud(self, cloud_path=None, update_cloud_metadata=True):
+        """Upload a datafile to Google Cloud Storage.
 
         :param str|None cloud_path: full path to cloud storage location to store datafile at (e.g. `gs://bucket_name/path/to/file.csv`)
-        :param str|None bucket_name: name of bucket to store datafile in
-        :param str|None path_in_bucket: cloud storage path to store datafile at (e.g. `path/to/file.csv`)
         :param bool update_cloud_metadata: if `True`, update the metadata of the datafile in the cloud at upload time
         :return str: gs:// path for datafile
         """
-        cloud_path = self._get_cloud_location(cloud_path, bucket_name, path_in_bucket)
+        cloud_path = self._get_cloud_location(cloud_path)
         self.get_cloud_metadata()
 
         # If the datafile's file has been changed locally, overwrite its cloud copy.
@@ -511,44 +508,21 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         except FileNotFoundError:
             return self._cloud_metadata.get("crc32c", EMPTY_STRING_HASH_VALUE)
 
-    def _get_cloud_location(self, cloud_path=None, bucket_name=None, path_in_bucket=None):
+    def _get_cloud_location(self, cloud_path=None):
         """Get the cloud location details for the bucket, allowing the keyword arguments to override any stored values.
-        Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be provided. Once the cloud location details
-        have been determined, update the stored cloud location details.
+        Once the cloud location details have been determined, update the stored cloud location details.
 
         :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_in_bucket:
         :raise octue.exceptions.CloudLocationNotSpecified: if an exact cloud location isn't provided and isn't available implicitly (i.e. the Datafile wasn't loaded from the cloud previously)
         :return (str, str): project name and cloud path
         """
         cloud_path = cloud_path or self.cloud_path
 
         if not cloud_path:
-            try:
-                cloud_path = storage.path.generate_gs_path(bucket_name, path_in_bucket)
-            except (TypeError, AttributeError):
-                self._raise_cloud_location_error()
+            self._raise_cloud_location_error()
 
-        self._store_cloud_location(cloud_path=cloud_path)
+        self._cloud_path = cloud_path
         return cloud_path
-
-    def _store_cloud_location(self, cloud_path=None, bucket_name=None, path_in_bucket=None):
-        """Store the cloud location of the datafile. Either (`bucket_name` and `path_in_bucket`) or `cloud_path` must be
-        provided.
-
-        :param str|None cloud_path:
-        :param str|None bucket_name:
-        :param str|None path_in_bucket:
-        :return None:
-        """
-        if cloud_path:
-            self._cloud_path = cloud_path
-        else:
-            try:
-                self._cloud_path = storage.path.generate_gs_path(bucket_name, path_in_bucket)
-            except (TypeError, AttributeError):
-                self._raise_cloud_location_error()
 
     def _raise_cloud_location_error(self):
         """Raise an error indicating that the cloud location of the datafile has not yet been specified.

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -7,6 +7,8 @@ from urllib.parse import urlparse
 
 import google.api_core.exceptions
 
+from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
+
 
 try:
     import h5py
@@ -185,14 +187,18 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         datafile._cloud_metadata = cloud_metadata
         return datafile
 
-    def to_cloud(self, cloud_path=None, update_cloud_metadata=True):
+    def to_cloud(self, cloud_path=None, bucket_name=None, path_in_bucket=None, update_cloud_metadata=True):
         """Upload a datafile to Google Cloud Storage.
 
         :param str|None cloud_path: full path to cloud storage location to store datafile at (e.g. `gs://bucket_name/path/to/file.csv`)
         :param bool update_cloud_metadata: if `True`, update the metadata of the datafile in the cloud at upload time
         :return str: gs:// path for datafile
         """
+        if bucket_name:
+            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
+
         cloud_path = self._get_cloud_location(cloud_path)
+
         self.get_cloud_metadata()
 
         # If the datafile's file has been changed locally, overwrite its cloud copy.

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,7 +1,6 @@
 import concurrent.futures
 import json
 import os
-import warnings
 
 from octue import definitions
 from octue.cloud import storage
@@ -78,7 +77,6 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
     @classmethod
     def from_cloud(
         cls,
-        project_name=None,
         cloud_path=None,
         bucket_name=None,
         path_to_dataset_directory=None,
@@ -93,12 +91,6 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained in the dataset directory
         :return Dataset:
         """
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         if cloud_path:
             bucket_name = storage.path.split_bucket_name_from_gs_path(cloud_path)[0]
         else:
@@ -125,7 +117,7 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         dataset._upload_dataset_metadata(cloud_path)
         return dataset
 
-    def to_cloud(self, project_name=None, cloud_path=None, bucket_name=None, output_directory=None):
+    def to_cloud(self, cloud_path=None, bucket_name=None, output_directory=None):
         """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `cloud_path` must be
         provided.
 
@@ -134,12 +126,6 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         :param str|None output_directory: path to output directory in cloud storage (e.g. `path/to/dataset`)
         :return str: cloud path for dataset
         """
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         if not cloud_path:
             cloud_path = storage.path.generate_gs_path(bucket_name, output_directory, self.name)
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -109,15 +109,10 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         dataset._upload_dataset_metadata(cloud_path)
         return dataset
 
-    def to_cloud(
-        self,
-        cloud_path=None,
-        bucket_name=None,
-        output_directory=None,
-    ):
-        """Upload a dataset to a cloud location.
+    def to_cloud(self, cloud_path=None, bucket_name=None, output_directory=None):
+        """Upload a dataset to the given cloud path.
 
-        :param str|None cloud_path: full cloud storage path to store dataset at (e.g. `gs://bucket_name/path/to/dataset`)
+        :param str|None cloud_path: cloud path to store dataset at (e.g. `gs://bucket_name/path/to/dataset`)
         :return str: cloud path for dataset
         """
         if not cloud_path:

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -75,26 +75,14 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         return Dataset(path=path_to_directory, files=datafiles, **kwargs)
 
     @classmethod
-    def from_cloud(
-        cls,
-        cloud_path=None,
-        bucket_name=None,
-        path_to_dataset_directory=None,
-        recursive=False,
-    ):
-        """Instantiate a Dataset from Google Cloud storage. Either (`bucket_name` and `path_to_dataset_directory`) or
-        `cloud_path` must be provided.
+    def from_cloud(cls, cloud_path=None, recursive=False):
+        """Instantiate a Dataset from Google Cloud storage.
 
         :param str|None cloud_path: full path to dataset directory in cloud storage (e.g. `gs://bucket_name/path/to/dataset`)
-        :param str|None bucket_name: name of bucket dataset is stored in
-        :param str|None path_to_dataset_directory: path to dataset directory (containing dataset's files) in cloud (e.g. `path/to/dataset`)
         :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained in the dataset directory
         :return Dataset:
         """
-        if cloud_path:
-            bucket_name = storage.path.split_bucket_name_from_gs_path(cloud_path)[0]
-        else:
-            cloud_path = storage.path.generate_gs_path(bucket_name, path_to_dataset_directory)
+        bucket_name = storage.path.split_bucket_name_from_gs_path(cloud_path)[0]
 
         dataset_metadata = cls._get_dataset_metadata(cloud_path=cloud_path)
 
@@ -117,18 +105,12 @@ class Dataset(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashabl
         dataset._upload_dataset_metadata(cloud_path)
         return dataset
 
-    def to_cloud(self, cloud_path=None, bucket_name=None, output_directory=None):
-        """Upload a dataset to a cloud location. Either (`bucket_name` and `output_directory`) or `cloud_path` must be
-        provided.
+    def to_cloud(self, cloud_path=None):
+        """Upload a dataset to a cloud location.
 
         :param str|None cloud_path: full cloud storage path to store dataset at (e.g. `gs://bucket_name/path/to/dataset`)
-        :param str|None bucket_name: name of bucket to store dataset in
-        :param str|None output_directory: path to output directory in cloud storage (e.g. `path/to/dataset`)
         :return str: cloud path for dataset
         """
-        if not cloud_path:
-            cloud_path = storage.path.generate_gs_path(bucket_name, output_directory, self.name)
-
         files_and_paths = []
 
         for datafile in self.files:

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,6 +1,5 @@
 import json
 import os
-import warnings
 
 import octue.migrations.manifest
 from octue.cloud import storage
@@ -40,7 +39,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         vars(self).update(**kwargs)
 
     @classmethod
-    def from_cloud(cls, project_name=None, cloud_path=None, bucket_name=None, path_to_manifest_file=None):
+    def from_cloud(cls, cloud_path=None, bucket_name=None, path_to_manifest_file=None):
         """Instantiate a Manifest from Google Cloud storage. Either (`bucket_name` and `path_to_manifest_file`) or
         `cloud_path` must be provided.
 
@@ -49,12 +48,6 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         :param str|None path_to_manifest_file: path to manifest in cloud storage e.g. `path/to/manifest.json`
         :return Dataset:
         """
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         if cloud_path:
             bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
@@ -74,9 +67,7 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
             datasets=datasets,
         )
 
-    def to_cloud(
-        self, project_name=None, cloud_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=False
-    ):
+    def to_cloud(self, cloud_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=False):
         """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory. Either
         (`bucket_name` and `path_to_manifest_file`) or `cloud_path` must be provided.
 
@@ -86,12 +77,6 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         :param bool store_datasets: if True, upload datasets to same directory as manifest file
         :return str: gs:// path for manifest file
         """
-        if project_name:
-            warnings.warn(
-                message="The `project_name` parameter is no longer needed and will be removed soon.",
-                category=DeprecationWarning,
-            )
-
         if cloud_path:
             bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -39,27 +39,20 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         vars(self).update(**kwargs)
 
     @classmethod
-    def from_cloud(cls, cloud_path=None, bucket_name=None, path_to_manifest_file=None):
-        """Instantiate a Manifest from Google Cloud storage. Either (`bucket_name` and `path_to_manifest_file`) or
-        `cloud_path` must be provided.
+    def from_cloud(cls, cloud_path=None):
+        """Instantiate a Manifest from Google Cloud storage.
 
         :param str|None cloud_path: full path to manifest in cloud storage (e.g. `gs://bucket_name/path/to/manifest.json`)
-        :param str|None bucket_name: name of bucket manifest is stored in
-        :param str|None path_to_manifest_file: path to manifest in cloud storage e.g. `path/to/manifest.json`
         :return Dataset:
         """
-        if cloud_path:
-            bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
+        bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
-        serialised_manifest = json.loads(
-            GoogleCloudStorageClient().download_as_string(bucket_name=bucket_name, path_in_bucket=path_to_manifest_file)
-        )
+        serialised_manifest = json.loads(GoogleCloudStorageClient().download_as_string(cloud_path))
 
         datasets = {}
 
         for key, dataset in serialised_manifest["datasets"].items():
-            dataset_bucket_name, path = storage.path.split_bucket_name_from_gs_path(dataset)
-            datasets[key] = Dataset.from_cloud(bucket_name=dataset_bucket_name, path_to_dataset_directory=path)
+            datasets[key] = Dataset.from_cloud(dataset)
 
         return Manifest(
             id=serialised_manifest["id"],
@@ -67,25 +60,21 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
             datasets=datasets,
         )
 
-    def to_cloud(self, cloud_path=None, bucket_name=None, path_to_manifest_file=None, store_datasets=False):
-        """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory. Either
-        (`bucket_name` and `path_to_manifest_file`) or `cloud_path` must be provided.
+    def to_cloud(self, cloud_path=None, store_datasets=False):
+        """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory.
 
         :param str|None cloud_path: full path to cloud storage location to store manifest at (e.g. `gs://bucket_name/path/to/manifest.json`)
-        :param str|None bucket_name: name of bucket to store manifest in
-        :param str|None path_to_manifest_file: cloud storage path to store manifest at e.g. `path/to/manifest.json`
         :param bool store_datasets: if True, upload datasets to same directory as manifest file
         :return str: gs:// path for manifest file
         """
-        if cloud_path:
-            bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
+        bucket_name, path_to_manifest_file = storage.path.split_bucket_name_from_gs_path(cloud_path)
 
         datasets = {}
         output_directory = storage.path.dirname(path_to_manifest_file)
 
         for key, dataset in self.datasets.items():
             if store_datasets:
-                dataset_path = dataset.to_cloud(bucket_name=bucket_name, output_directory=output_directory)
+                dataset_path = dataset.to_cloud(storage.path.generate_gs_path(bucket_name, output_directory))
                 datasets[key] = dataset_path
             else:
                 datasets[key] = dataset.cloud_path or dataset.absolute_path
@@ -94,13 +83,8 @@ class Manifest(Pathable, Serialisable, Identifiable, Hashable):
         serialised_manifest["datasets"] = datasets
         del serialised_manifest["path"]
 
-        GoogleCloudStorageClient().upload_from_string(
-            string=json.dumps(serialised_manifest),
-            bucket_name=bucket_name,
-            path_in_bucket=path_to_manifest_file,
-        )
-
-        return cloud_path or storage.path.generate_gs_path(bucket_name, path_to_manifest_file)
+        GoogleCloudStorageClient().upload_from_string(string=json.dumps(serialised_manifest), cloud_path=cloud_path)
+        return cloud_path
 
     @property
     def all_datasets_are_in_cloud(self):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.13.0",
+    version="0.14.0",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -18,21 +18,23 @@ class TestDataset(BaseTestCase):
         cloud_storage_client = GoogleCloudStorageClient()
 
         cloud_storage_client.upload_from_string(
-            "[1, 2, 3]", bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/file_0.txt"
+            "[1, 2, 3]", cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, dataset_name, "file_0.txt")
         )
 
         cloud_storage_client.upload_from_string(
-            "[4, 5, 6]", bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/file_1.txt"
+            "[4, 5, 6]", cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, dataset_name, "file_1.txt")
         )
 
         cloud_storage_client.upload_from_string(
-            "['a', 'b', 'c']", bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/sub-directory/sub_file.txt"
+            "['a', 'b', 'c']",
+            cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, dataset_name, "sub-directory/sub_file.txt"),
         )
 
         cloud_storage_client.upload_from_string(
             "['blah', 'b', 'c']",
-            bucket_name=TEST_BUCKET_NAME,
-            path_in_bucket=f"{dataset_name}/sub-directory/sub-sub-directory/sub_sub_file.txt",
+            cloud_path=storage.path.generate_gs_path(
+                TEST_BUCKET_NAME, dataset_name, "sub-directory", "sub-sub-directory", "sub_sub_file.txt"
+            ),
         )
 
     def _create_files_and_nested_subdirectories(self, directory_path):
@@ -282,35 +284,20 @@ class TestDataset(BaseTestCase):
             dataset = create_dataset_with_two_files(temporary_directory)
             dataset.tags = {"a": "b", "c": 1}
 
-            dataset.to_cloud(bucket_name=TEST_BUCKET_NAME, output_directory="a_directory")
+            cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "a_directory", dataset.name)
+            dataset.to_cloud(cloud_path)
+            persisted_dataset = Dataset.from_cloud(cloud_path)
 
-            path_to_dataset_directory = storage.path.join("a_directory", dataset.name)
-            gs_path = f"gs://{TEST_BUCKET_NAME}/{path_to_dataset_directory}"
+            self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}")
+            self.assertEqual(persisted_dataset.id, dataset.id)
+            self.assertEqual(persisted_dataset.name, dataset.name)
+            self.assertEqual(persisted_dataset.hash_value, dataset.hash_value)
+            self.assertEqual(persisted_dataset.tags, dataset.tags)
+            self.assertEqual(persisted_dataset.labels, dataset.labels)
+            self.assertEqual({file.name for file in persisted_dataset.files}, {file.name for file in dataset.files})
 
-            for location_parameters in (
-                {
-                    "bucket_name": TEST_BUCKET_NAME,
-                    "path_to_dataset_directory": path_to_dataset_directory,
-                    "cloud_path": None,
-                },
-                {"bucket_name": None, "path_to_dataset_directory": None, "cloud_path": gs_path},
-            ):
-
-                with self.subTest(**location_parameters):
-                    persisted_dataset = Dataset.from_cloud(**location_parameters)
-
-                    self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}")
-                    self.assertEqual(persisted_dataset.id, dataset.id)
-                    self.assertEqual(persisted_dataset.name, dataset.name)
-                    self.assertEqual(persisted_dataset.hash_value, dataset.hash_value)
-                    self.assertEqual(persisted_dataset.tags, dataset.tags)
-                    self.assertEqual(persisted_dataset.labels, dataset.labels)
-                    self.assertEqual(
-                        {file.name for file in persisted_dataset.files}, {file.name for file in dataset.files}
-                    )
-
-                    for file in persisted_dataset:
-                        self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}/{file.name}")
+            for file in persisted_dataset:
+                self.assertEqual(file.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}/{file.name}")
 
     def test_from_cloud_with_no_datafile_metadata_file(self):
         """Test that any cloud directory can be accessed as a dataset if it has no `dataset_metadata.json` metadata
@@ -398,56 +385,39 @@ class TestDataset(BaseTestCase):
         )
 
     def test_to_cloud(self):
-        """Test that a dataset can be uploaded to the cloud via (`bucket_name`, `output_directory`) and via
-        `cloud_path`, including all its files and a serialised JSON file of the Datafile instance.
+        """Test that a dataset can be uploaded to the cloud, including all its files and a serialised JSON file of the
+        Datafile instance.
         """
         with tempfile.TemporaryDirectory() as temporary_directory:
-            dataset_directory_name = os.path.split(temporary_directory)[-1]
             dataset = create_dataset_with_two_files(temporary_directory)
             dataset.tags = {"a": "b", "c": 1}
 
             output_directory = "my_datasets"
-            cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, output_directory)
+            cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, output_directory, dataset.name)
 
-            for location_parameters in (
-                {"bucket_name": TEST_BUCKET_NAME, "output_directory": output_directory, "cloud_path": None},
-                {"bucket_name": None, "output_directory": None, "cloud_path": cloud_path},
-            ):
-                with self.subTest(**location_parameters):
-                    dataset.to_cloud(**location_parameters)
+            dataset.to_cloud(cloud_path)
 
-                    storage_client = GoogleCloudStorageClient()
+            storage_client = GoogleCloudStorageClient()
 
-                    persisted_file_0 = storage_client.download_as_string(
-                        cloud_path=storage.path.join(cloud_path, dataset.name, "file_0.txt"),
-                    )
+            persisted_file_0 = storage_client.download_as_string(cloud_path=storage.path.join(cloud_path, "file_0.txt"))
+            self.assertEqual(persisted_file_0, "0")
 
-                    self.assertEqual(persisted_file_0, "0")
+            persisted_file_1 = storage_client.download_as_string(storage.path.join(cloud_path, "file_1.txt"))
+            self.assertEqual(persisted_file_1, "1")
 
-                    persisted_file_1 = storage_client.download_as_string(
-                        bucket_name=TEST_BUCKET_NAME,
-                        path_in_bucket=storage.path.join(output_directory, dataset.name, "file_1.txt"),
-                    )
-                    self.assertEqual(persisted_file_1, "1")
+            persisted_dataset = json.loads(
+                storage_client.download_as_string(storage.path.join(cloud_path, definitions.DATASET_METADATA_FILENAME))
+            )
 
-                    persisted_dataset = json.loads(
-                        storage_client.download_as_string(
-                            bucket_name=TEST_BUCKET_NAME,
-                            path_in_bucket=storage.path.join(
-                                output_directory, dataset.name, definitions.DATASET_METADATA_FILENAME
-                            ),
-                        )
-                    )
+            self.assertEqual(
+                persisted_dataset["files"],
+                [
+                    f"gs://octue-test-bucket/my_datasets/{dataset.name}/file_0.txt",
+                    f"gs://octue-test-bucket/my_datasets/{dataset.name}/file_1.txt",
+                ],
+            )
 
-                    self.assertEqual(
-                        persisted_dataset["files"],
-                        [
-                            f"gs://octue-test-bucket/my_datasets/{dataset_directory_name}/file_0.txt",
-                            f"gs://octue-test-bucket/my_datasets/{dataset_directory_name}/file_1.txt",
-                        ],
-                    )
-
-                    self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitive())
+            self.assertEqual(persisted_dataset["tags"], dataset.tags.to_primitive())
 
     def test_to_cloud_with_nested_dataset_preserves_nested_structure(self):
         """Test that uploading a dataset containing datafiles in a nested directory structure to the cloud preserves
@@ -480,10 +450,12 @@ class TestDataset(BaseTestCase):
 
         dataset_name = "another-dataset"
         storage_client.upload_from_string(
-            string=json.dumps([1, 2, 3]), bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/file_0.txt"
+            string=json.dumps([1, 2, 3]),
+            cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, dataset_name, "file_0.txt"),
         )
         storage_client.upload_from_string(
-            string=json.dumps([4, 5, 6]), bucket_name=TEST_BUCKET_NAME, path_in_bucket=f"{dataset_name}/file_1.txt"
+            string=json.dumps([4, 5, 6]),
+            cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, dataset_name, "file_1.txt"),
         )
 
         dataset = Dataset.from_cloud(cloud_path=f"gs://{TEST_BUCKET_NAME}/{dataset_name}")


### PR DESCRIPTION
## Summary
Shift to only supporting full cloud storage paths (e.g. `gs://my-bucket-name/path/to/file.dat`) rather than separate bucket names and paths within buckets (e.g. `my-bucket-name` and `path/to/file.dat`). This makes interacting with cloud storage clearer, makes it clear which cloud provider the data resides with (e.g. Google), and makes the code more resilient.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#366](https://github.com/octue/octue-sdk-python/pull/366))
**IMPORTANT:** There are 6 breaking changes.

### Enhancements
- **BREAKING CHANGES:** Deprecate `bucket_name` and `path_in_bucket` parameters in the cloud methods of
  - `Datafile`
  - `Dataset`
  - `Manifest`
  - `GoogleCloudStorageClient`
  - `Analysis`
- **BREAKING CHANGE:** Store datasets at the exact cloud path given to `Dataset.to_cloud` instead of adding the dataset's name to the end of the path

### Removals
- Remove deprecated `project_name` code
<!--- END AUTOGENERATED NOTES --->