### PR TITLE
FIX: Allow for ADCs not containing project IDs

### DIFF
--- a/octue/cloud/credentials.py
+++ b/octue/cloud/credentials.py
@@ -3,9 +3,10 @@ import logging
 import os
 import warnings
 from json.decoder import JSONDecodeError
-from google.auth import compute_engine
+from google import auth
 from google.oauth2 import service_account
 from octue.exceptions import InvalidInputException
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,9 @@ class GCPCredentialsManager:
 
         if self.using_application_default_credentials:
             logger.debug("Using application default credentials")
-            creds = compute_engine.Credentials()
+            creds, project_id = auth.default()
+            # FFS google why can't you bloody make it simple
+            creds.project_id = project_id
 
         elif os.path.exists(self.environment_variable_value):
             logger.debug("Using credentials from file %s", self.environment_variable_value)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.14.2",
+    version="0.14.3",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/test_credentials.py
+++ b/tests/cloud/test_credentials.py
@@ -1,9 +1,8 @@
 import json
-import logging
 import os
 import tempfile
 from unittest.mock import patch
-from google.auth import compute_engine
+from google.auth.exceptions import DefaultCredentialsError
 import google.oauth2.service_account
 
 from octue.exceptions import InvalidInputException
@@ -51,9 +50,8 @@ class TestGCPCredentialsManager(BaseTestCase):
                 credentials = GCPCredentialsManager().get_credentials(as_dict=True)
                 self.assertEqual(credentials, {"blah": "nah"})
 
-    def test_compute_engine_credentials_are_used_when_environment_unset(self):
+    def test_default_credentials_are_used_when_environment_unset(self):
         """Test that application default credentials are accessed when the environment variable value is not set."""
         with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": ""}):
-            del os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-            creds = GCPCredentialsManager().get_credentials()
-            self.assertIsInstance(creds, compute_engine.credentials.Credentials)
+            with self.assertRaises(DefaultCredentialsError):
+                GCPCredentialsManager().get_credentials()


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->

## Summary

<!--- START AUTOGENERATED NOTES --->
## Contents ([#378](https://github.com/octue/octue-sdk-python/pull/378))

### Fixes
- Allow for ADCs not containing project IDs

### Other
- Merge branch 'main' into fix/default-app-credentials

<!--- END AUTOGENERATED NOTES --->