### PR TITLE
Allow specification of question UUID in child ask method

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests
         env:
           TEST_PROJECT_NAME: ${{ secrets.TEST_PROJECT_NAME }}
-        run: tox -e py
+        run: tox -vv -e py
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run tests
         env:
           TEST_PROJECT_NAME: ${{ secrets.TEST_PROJECT_NAME }}
-        run: tox -e py
+        run: tox -vv -e py
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -188,8 +188,8 @@ class Service(CoolNameable):
         input_manifest=None,
         subscribe_to_logs=True,
         allow_local_files=False,
-        timeout=30,
         question_uuid=None,
+        timeout=30,
     ):
         """Ask a serving Service a question (i.e. send it input values for it to run its app on). The input values must
         be in the format specified by the serving Service's Twine file. A single-use topic and subscription are created
@@ -201,8 +201,8 @@ class Service(CoolNameable):
         :param octue.resources.manifest.Manifest|None input_manifest: the input manifest of the question
         :param bool subscribe_to_logs: if `True`, subscribe to logs from the remote service and handle them with the local log handlers
         :param bool allow_local_files: if `True`, allow the input manifest to contain references to local files - this should only be set to `True` if the serving service will have access to these local files
-        :param float|None timeout: time in seconds to keep retrying sending the question
         :param str|None question_uuid: the UUID to use for the question if a specific one is needed; a UUID is generated if not
+        :param float|None timeout: time in seconds to keep retrying sending the question
         :return (octue.cloud.pub_sub.subscription.Subscription, str): the response subscription and question UUID
         """
         if not allow_local_files:

--- a/octue/resources/child.py
+++ b/octue/resources/child.py
@@ -30,6 +30,7 @@ class Child:
         subscribe_to_logs=True,
         allow_local_files=False,
         handle_monitor_message=None,
+        question_uuid=None,
         timeout=20,
     ):
         """Ask the child a question (i.e. send it some input value and/or a manifest and wait for it to run an analysis
@@ -41,6 +42,7 @@ class Child:
         :param bool allow_local_files: if `True`, allow the input manifest to contain references to local files - this should only be set to `True` if the serving service will have access to these local files
         :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive as an argument (note that this could be an array or object)
         :param float timeout: time in seconds to wait for an answer before raising a timeout error
+        :param str|None question_uuid: the UUID to use for the question if a specific one is needed; a UUID is generated if not
         :raise TimeoutError: if the timeout is exceeded while waiting for an answer
         :return dict: dictionary containing the keys "output_values" and "output_manifest"
         """
@@ -50,6 +52,7 @@ class Child:
             input_manifest=input_manifest,
             subscribe_to_logs=subscribe_to_logs,
             allow_local_files=allow_local_files,
+            question_uuid=question_uuid,
             timeout=timeout,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.15.0",
+    version="0.15.1",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -242,8 +242,8 @@ class MockService(Service):
         input_manifest=None,
         subscribe_to_logs=True,
         allow_local_files=False,
-        timeout=30,
         question_uuid=None,
+        timeout=30,
     ):
         """Put the question into the messages register, register the existence of the corresponding response topic, add
         the response to the register, and return a MockFuture containing the answer subscription path.
@@ -257,7 +257,13 @@ class MockService(Service):
         :return MockFuture, str:
         """
         response_subscription, question_uuid = super().ask(
-            service_id, input_values, input_manifest, subscribe_to_logs, allow_local_files, timeout, question_uuid
+            service_id,
+            input_values,
+            input_manifest,
+            subscribe_to_logs,
+            allow_local_files,
+            question_uuid,
+            timeout,
         )
 
         # Ignore any errors from the answering service as they will be raised on the remote service in practice, not

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -84,6 +84,7 @@ class TestService(BaseTestCase):
         subscribe_to_logs=True,
         allow_local_files=False,
         service_name="my-service",
+        question_uuid=None,
         timeout=30,
         delivery_acknowledgement_timeout=30,
     ):
@@ -97,7 +98,13 @@ class TestService(BaseTestCase):
         :return dict:
         """
         subscription, _ = asking_service.ask(
-            responding_service.id, input_values, input_manifest, subscribe_to_logs, allow_local_files, timeout
+            responding_service.id,
+            input_values,
+            input_manifest,
+            subscribe_to_logs,
+            allow_local_files,
+            question_uuid,
+            timeout,
         )
 
         return asking_service.wait_for_answer(


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#389](https://github.com/octue/octue-sdk-python/pull/389))

### Enhancements
- Allow question UUID to be specified in `Child.ask`

### Operations
- Show CI package installation logs

### Refactoring
- Switch parameter order in `Service.ask`

<!--- END AUTOGENERATED NOTES --->