### PR TITLE
Upgrade Dataflow image to python3.9

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,29 @@
+name: build-docker-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for Docker image'
+        required: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: true
+          tags: octue/octue-sdk-python:${{ github.event.inputs.tag }}"

--- a/octue/cloud/deployment/google/dataflow/Dockerfile
+++ b/octue/cloud/deployment/google/dataflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.8_sdk:2.36.0
+FROM apache/beam_python3.9_sdk:2.37.0
 
 # Allow statements and log messages to immediately appear in the logs on Google Cloud.
 ENV PYTHONUNBUFFERED=1

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.15.1",
+    version="0.15.3",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",
@@ -32,7 +32,7 @@ setup(
         "python-dateutil>=2.8.1",
         "twined==0.2.1",
     ],
-    extras_require={"hdf5": ["h5py==3.6.0"], "dataflow": ["apache-beam[gcp]==2.36.0"]},
+    extras_require={"hdf5": ["h5py==3.6.0"], "dataflow": ["apache-beam[gcp]==2.37.0"]},
     url="https://www.github.com/octue/octue-sdk-python",
     license="MIT",
     author="Thomas Clark (github: thclark), cortadocodes <cortado.codes@protonmail.com>",

--- a/tests/utils/test_processes.py
+++ b/tests/utils/test_processes.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from unittest.mock import Mock, patch
 
@@ -8,16 +9,12 @@ from tests.base import BaseTestCase
 class TestRunSubprocessAndLogStdoutAndStderr(BaseTestCase):
     def test_error_raised_if_process_fails(self):
         """Test that an error is raised if the subprocess fails."""
-        mock_logger = Mock()
-
         with self.assertRaises(subprocess.CalledProcessError):
             with patch(
                 "octue.utils.processes.Popen",
                 return_value=MockPopen(stdout_messages=[b"bash: blah: command not found"], return_code=1),
             ):
-                run_subprocess_and_log_stdout_and_stderr(command=["blah"], logger=mock_logger, shell=True)
-
-        self.assertEqual(mock_logger.info.call_args[0][0], "bash: blah: command not found")
+                run_subprocess_and_log_stdout_and_stderr(command=["blah"], logger=logging.getLogger(), shell=True)
 
     def test_stdout_is_logged(self):
         """Test that any output to stdout from a subprocess is logged."""


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#391](https://github.com/octue/octue-sdk-python/pull/391))

### Operations
- Add manual docker image build workflow

### Dependencies
- Upgrade to `apache-beam==2.37.0`
- Upgrade Dataflow image to `python3.9`

### Testing
- Simplify subprocess logging test

<!--- END AUTOGENERATED NOTES --->