### PR TITLE
Use correct octue.yaml format in configuration loader

### DIFF
--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -73,7 +73,7 @@ class AppConfiguration:
         with open(path) as f:
             raw_app_configuration = json.load(f)
 
-        logger.info("Service configuration loaded from %r.", os.path.abspath(path))
+        logger.info("App configuration loaded from %r.", os.path.abspath(path))
         return cls(**raw_app_configuration)
 
 

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -35,7 +35,9 @@ class ServiceConfiguration:
             raw_service_configuration = yaml.load(f, Loader=yaml.SafeLoader)
 
         logger.info("Service configuration loaded from %r.", os.path.abspath(path))
-        return cls(**raw_service_configuration)
+
+        # Ignore services other than the first for now.
+        return cls(**raw_service_configuration["services"][0])
 
 
 class AppConfiguration:

--- a/octue/templates/template-child-services/elevation_service/octue.yaml
+++ b/octue/templates/template-child-services/elevation_service/octue.yaml
@@ -1,2 +1,3 @@
-name: template-child-services/elevation-service
-app_configuration_path: app_configuration.json
+services:
+  - name: template-child-services/elevation-service
+    app_configuration_path: app_configuration.json

--- a/octue/templates/template-child-services/parent_service/octue.yaml
+++ b/octue/templates/template-child-services/parent_service/octue.yaml
@@ -1,2 +1,3 @@
-name: template-child-services/parent-service
-app_configuration_path: app_configuration.json
+services:
+  - name: template-child-services/parent-service
+    app_configuration_path: app_configuration.json

--- a/octue/templates/template-child-services/wind_speed_service/octue.yaml
+++ b/octue/templates/template-child-services/wind_speed_service/octue.yaml
@@ -1,2 +1,3 @@
-name: template-child-services/wind-speed-service
-app_configuration_path: app_configuration.json
+services:
+  - name: template-child-services/wind-speed-service
+    app_configuration_path: app_configuration.json

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.15.5",
+    version="0.15.6",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployment.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployment.py
@@ -18,7 +18,7 @@ class TestDataflowDeployment(BaseTestCase):
         parent = Service(backend=GCPPubSubBackend(project_name=os.environ["TEST_PROJECT_NAME"]))
 
         subscription, _ = parent.ask(
-            service_id="octue.services.1df81225-7e87-4b1c-9413-cdc375a127a7",
+            service_id="octue.services.c32f9dbd-7ffb-48b1-8be5-a64495a71873",
             input_values={"n_iterations": 3},
         )
 

--- a/tests/cloud/deployment/google/test_answer_pub_sub_question.py
+++ b/tests/cloud/deployment/google/test_answer_pub_sub_question.py
@@ -44,7 +44,8 @@ class TestAnswerPubSubQuestion(TestCase):
         """
         with mock.patch.dict(os.environ, {"SERVICE_ID": SERVICE_ID}):
             with mock.patch(
-                "octue.configuration.open", unittest.mock.mock_open(read_data=yaml.dump({"name": "test-service"}))
+                "octue.configuration.open",
+                unittest.mock.mock_open(read_data=yaml.dump({"services": [{"name": "test-service"}]})),
             ):
                 with mock.patch("octue.cloud.deployment.google.answer_pub_sub_question.Runner") as mock_runner:
                     with mock.patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):
@@ -78,10 +79,14 @@ class TestAnswerPubSubQuestion(TestCase):
             path_to_contents_mapping = {
                 "octue.yaml": yaml.dump(
                     {
-                        "name": "test-service",
-                        "app_source_path": "/path/to/app_dir",
-                        "twine_path": "path/to/twine.json",
-                        "app_configuration_path": "app_configuration.json",
+                        "services": [
+                            {
+                                "name": "test-service",
+                                "app_source_path": "/path/to/app_dir",
+                                "twine_path": "path/to/twine.json",
+                                "app_configuration_path": "app_configuration.json",
+                            }
+                        ]
                     }
                 ),
                 "app_configuration.json": json.dumps({"configuration_values": {"hello": "configuration"}}),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,10 +102,14 @@ class TestStartCommand(BaseTestCase):
             path_to_contents_mapping = {
                 "octue.yaml": yaml.dump(
                     {
-                        "name": "test-service",
-                        "app_source_path": python_fractal_service_path,
-                        "twine_path": os.path.join(python_fractal_service_path, "twine.json"),
-                        "app_configuration_path": "app_configuration.json",
+                        "services": [
+                            {
+                                "name": "test-service",
+                                "app_source_path": python_fractal_service_path,
+                                "twine_path": os.path.join(python_fractal_service_path, "twine.json"),
+                                "app_configuration_path": "app_configuration.json",
+                            }
+                        ]
                     }
                 ),
                 "app_configuration.json": json.dumps(


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#395](https://github.com/octue/octue-sdk-python/pull/395))

### Fixes
- Use correct `octue.yaml` format when loading service configurations in `octue.configuration`

<!--- END AUTOGENERATED NOTES --->