### PR TITLE
Unify deployer configuration with service configuration

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: 'Tag for Docker image'
         required: true
+      ref:
+        description: 'The branch, tag, or commit SHA to build from'
+        required: true
+        default: main
 
 jobs:
   build-and-push:
@@ -14,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,7 +7,7 @@ on:
         description: 'Tag for Docker image'
         required: true
       ref:
-        description: 'The branch, tag, or commit SHA to build from'
+        description: 'Branch, tag, or commit SHA to build from'
         required: true
         default: main
 

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -36,13 +36,9 @@ class CloudRunDeployer(BaseDeployer):
 
     def __init__(self, octue_configuration_path, service_id=None, image_uri_template=None):
         super().__init__(octue_configuration_path, service_id, image_uri_template)
-        self.build_trigger_description = f"Build the {self.name!r} service and deploy it to Cloud Run."
-
-        # Optional configuration file entries.
-        self.concurrency = self._service.get("concurrency", 10)
-        self.memory = self._service.get("memory", "128Mi")
-        self.cpus = self._service.get("cpus", 1)
-        self.minimum_instances = self._service.get("minimum_instances", 0)
+        self.build_trigger_description = (
+            f"Build the {self.service_configuration.name!r} service and deploy it to Cloud Run."
+        )
 
     def deploy(self, no_cache=False, update=False):
         """Create a Google Cloud Build configuration from the `octue.yaml` file, create a build trigger, and run the
@@ -78,9 +74,10 @@ class CloudRunDeployer(BaseDeployer):
             self.TOTAL_NUMBER_OF_STAGES,
         ) as progress_message:
 
-            if self.provided_cloud_build_configuration_path:
+            if self.service_configuration.provided_cloud_build_configuration_path:
                 progress_message.finish_message = (
-                    f"skipped - using {self.provided_cloud_build_configuration_path!r} from repository."
+                    f"skipped - using {self.service_configuration.provided_cloud_build_configuration_path!r} from "
+                    "repository."
                 )
                 return
 
@@ -92,7 +89,10 @@ class CloudRunDeployer(BaseDeployer):
                 cache_option = []
 
             environment_variables = ",".join(
-                [f"{variable['name']}={variable['value']}" for variable in self.environment_variables]
+                [
+                    f"{variable['name']}={variable['value']}"
+                    for variable in self.service_configuration.environment_variables
+                ]
                 + [f"{name}={value}" for name, value in self.required_environment_variables.items()]
             )
 
@@ -136,17 +136,17 @@ class CloudRunDeployer(BaseDeployer):
                             "run",
                             "services",
                             "update",
-                            self.name,
+                            self.service_configuration.name,
                             "--platform=managed",
                             f"--image={self.image_uri_template}",
-                            f"--region={self.region}",
-                            f"--memory={self.memory}",
-                            f"--cpu={self.cpus}",
+                            f"--region={self.service_configuration.region}",
+                            f"--memory={self.service_configuration.memory}",
+                            f"--cpu={self.service_configuration.cpus}",
                             f"--set-env-vars={environment_variables}",
                             "--timeout=3600",
-                            f"--concurrency={self.concurrency}",
-                            f"--min-instances={self.minimum_instances}",
-                            f"--max-instances={self.maximum_instances}",
+                            f"--concurrency={self.service_configuration.concurrency}",
+                            f"--min-instances={self.service_configuration.minimum_instances}",
+                            f"--max-instances={self.service_configuration.maximum_instances}",
                             "--ingress=internal",
                         ],
                     },
@@ -164,12 +164,12 @@ class CloudRunDeployer(BaseDeployer):
         with ProgressMessage("Making service available via Pub/Sub", 4, self.TOTAL_NUMBER_OF_STAGES):
             allow_unauthenticated_messages_command = [
                 "gcloud",
-                f"--project={self.project_name}",
+                f"--project={self.service_configuration.project_name}",
                 "run",
                 "services",
                 "add-iam-policy-binding",
-                self.name,
-                f"--region={self.region}",
+                self.service_configuration.name,
+                f"--region={self.service_configuration.region}",
                 "--member=allUsers",
                 "--role=roles/run.invoker",
             ]
@@ -189,21 +189,24 @@ class CloudRunDeployer(BaseDeployer):
             5,
             self.TOTAL_NUMBER_OF_STAGES,
         ) as progress_message:
-            service = Service(backend=GCPPubSubBackend(project_name=self.project_name), service_id=self.service_id)
+            service = Service(
+                backend=GCPPubSubBackend(project_name=self.service_configuration.project_name),
+                service_id=self.service_id,
+            )
             topic = Topic(name=self.service_id, namespace=OCTUE_NAMESPACE, service=service)
             topic.create(allow_existing=True)
 
             command = [
                 "gcloud",
-                f"--project={self.project_name}",
+                f"--project={self.service_configuration.project_name}",
                 "beta",
                 "eventarc",
                 "triggers",
                 "create",
-                f"{self.name}-trigger",
+                f"{self.service_configuration.name}-trigger",
                 "--matching-criteria=type=google.cloud.pubsub.topic.v1.messagePublished",
-                f"--destination-run-service={self.name}",
-                f"--location={self.region}",
+                f"--destination-run-service={self.service_configuration.name}",
+                f"--location={self.service_configuration.region}",
                 f"--transport-topic={topic.name}",
             ]
 
@@ -213,7 +216,7 @@ class CloudRunDeployer(BaseDeployer):
                 eventarc_subscription_path = None
 
                 for subscription_path in topic.get_subscriptions():
-                    if self.name in subscription_path:
+                    if self.service_configuration.name in subscription_path:
                         eventarc_subscription_path = subscription_path
                         break
 
@@ -227,7 +230,7 @@ class CloudRunDeployer(BaseDeployer):
                 subscription = Subscription(
                     name=eventarc_subscription_path.split("/")[-1],
                     topic=topic,
-                    project_name=self.project_name,
+                    project_name=self.service_configuration.project_name,
                     ack_deadline=10,
                 )
 

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -18,11 +18,63 @@ class ServiceConfiguration:
     :return None:
     """
 
-    def __init__(self, name, app_source_path=".", twine_path="twine.json", app_configuration_path=None):
+    def __init__(
+        self,
+        name,
+        app_source_path=".",
+        twine_path="twine.json",
+        app_configuration_path=None,
+        repository_name=None,
+        repository_owner=None,
+        project_name=None,
+        region=None,
+        dockerfile_path=None,
+        cloud_build_configuration_path=None,
+        maximum_instances=10,
+        branch_pattern="^main$",
+        environment_variables=None,
+        secrets=None,
+        concurrency=10,
+        memory="128Mi",
+        cpus=1,
+        minimum_instances=0,
+        temporary_files_location=None,
+        setup_file_path=None,
+        service_account_email=None,
+        machine_type=None,
+        **kwargs,
+    ):
         self.name = name
         self.app_source_path = app_source_path
         self.twine_path = twine_path
         self.app_configuration_path = app_configuration_path
+
+        # Deployed services only.
+        self.repository_name = repository_name
+        self.repository_owner = repository_owner
+        self.project_name = project_name
+        self.region = region
+        self.dockerfile_path = dockerfile_path
+        self.provided_cloud_build_configuration_path = cloud_build_configuration_path
+        self.maximum_instances = maximum_instances
+        self.branch_pattern = branch_pattern
+        self.environment_variables = environment_variables or []
+        self.secrets = secrets or {}
+
+        # Cloud Run services only.
+        self.concurrency = concurrency
+        self.memory = memory
+        self.cpus = cpus
+        self.minimum_instances = minimum_instances
+
+        # Dataflow services only.
+        self.temporary_files_location = temporary_files_location
+        self.setup_file_path = setup_file_path
+        self.service_account_email = service_account_email
+        self.worker_machine_type = machine_type
+
+        if kwargs:
+            logger.warning(f"The following keyword arguments were not used by {type(self).__name__}: {kwargs!r}.")
 
     @classmethod
     def from_file(cls, path):
@@ -57,6 +109,7 @@ class AppConfiguration:
         configuration_manifest=None,
         output_manifest_path=None,
         children=None,
+        **kwargs,
     ):
         self.configuration_values = configuration_values
         self.configuration_manifest = configuration_manifest

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -116,6 +116,9 @@ class AppConfiguration:
         self.output_manifest_path = output_manifest_path
         self.children = children
 
+        if kwargs:
+            logger.warning(f"The following keyword arguments were not used by {type(self).__name__}: {kwargs!r}.")
+
     @classmethod
     def from_file(cls, path):
         """Load an app configuration from a file.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.15.6",
+    version="0.15.7",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",


### PR DESCRIPTION
## Summary
Unify the configuration format in `octue.yaml` files for use as service configuration and for use by the cloud deployers.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#397](https://github.com/octue/octue-sdk-python/pull/397))

### Enhancements
- Unify deployer configuration with service configuration
- Warn user if there are unused kwargs in `ServiceConfiguration` or `AppConfiguration`

### Operations
- Allow choice of branch in `build-docker-image` workflow

<!--- END AUTOGENERATED NOTES --->