### PR TITLE
Use latest dateparser to avoid regex package bug

### DIFF
--- a/octue/templates/template-using-manifests/requirements.txt
+++ b/octue/templates/template-using-manifests/requirements.txt
@@ -16,7 +16,7 @@ numpy==1.21.0
 pandas
 
 # An incredibly powerful date parsing utility
-dateparser==1.0.0
+dateparser==1.1.1
 
 # A utility library for converting text cases; useful for cleaning up column names and such
 stringcase==1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,7 @@ twine  # <---- nothing to do with the twined library!
 # ------------------------------------------------------------------------------
 
 numpy==1.21.0
-dateparser==1.0.0
+dateparser==1.1.1
 pandas==1.1.4
 stringcase==1.2.0
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("LICENSE") as f:
 
 setup(
     name="octue",
-    version="0.15.8",
+    version="0.15.9",
     py_modules=["cli"],
     install_requires=[
         "click>=7.1.2",

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -69,7 +69,6 @@ class TemplateAppsTestCase(BaseTestCase):
         analysis = runner.run()
         analysis.finalise(output_dir=os.path.join("data", "output"))
 
-    @unittest.skip(reason="See issue https://github.com/octue/octue-sdk-python/issues/385")
     def test_using_manifests(self):
         """Ensure the using-manifests template app works correctly."""
         self.set_template("template-using-manifests")


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents

### Dependencies
- Use `dateparser==1.1.1` in template to avoid `regex` package bug

### Testing
- Re-enable temporarily skipped test
<!--- END AUTOGENERATED NOTES --->
