### PR TITLE
Improve dataset/datafile interaction and make output datasets available after analysis finalisation

### DIFF
--- a/octue/cli.py
+++ b/octue/cli.py
@@ -113,20 +113,11 @@ def octue_cli(id, skip_checks, logger_uri, log_level, force_reset):
     show_default=True,
     help="Directory containing input (overrides --data-dir).",
 )
-@click.option(
-    "--output-dir",
-    type=click.Path(),
-    default=None,
-    show_default=True,
-    help="Directory to write outputs as files (overrides --data-dir).",
-)
 @click.option("--twine", type=click.Path(), default="twine.json", show_default=True, help="Location of Twine file.")
-def run(app_dir, data_dir, config_dir, input_dir, output_dir, twine):
+def run(app_dir, data_dir, config_dir, input_dir, twine):
     """Run an analysis on the given input data."""
     config_dir = config_dir or os.path.join(data_dir, FOLDER_DEFAULTS["configuration"])
     input_dir = input_dir or os.path.join(data_dir, FOLDER_DEFAULTS["input"])
-    output_dir = output_dir or os.path.join(data_dir, FOLDER_DEFAULTS["output"])
-
     twine = Twine(source=twine)
 
     (
@@ -151,7 +142,6 @@ def run(app_dir, data_dir, config_dir, input_dir, output_dir, twine):
         twine=twine,
         configuration_values=configuration_values,
         configuration_manifest=configuration_manifest,
-        output_manifest_path=os.path.join(output_dir, MANIFEST_FILENAME),
         children=children,
         skip_checks=global_cli_context["skip_checks"],
     )

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -164,7 +164,7 @@ def run(app_dir, data_dir, config_dir, input_dir, output_dir, twine):
         analysis_log_handler=global_cli_context["log_handler"],
     )
 
-    analysis.finalise(output_dir=output_dir)
+    analysis.finalise()
     return 0
 
 

--- a/octue/cloud/deployment/google/answer_pub_sub_question.py
+++ b/octue/cloud/deployment/google/answer_pub_sub_question.py
@@ -49,7 +49,6 @@ def answer_question(question, project_name):
             twine=service_configuration.twine_path,
             configuration_values=app_configuration.configuration_values,
             configuration_manifest=app_configuration.configuration_manifest,
-            output_manifest_path=app_configuration.output_manifest_path,
             children=app_configuration.children,
             project_name=project_name,
         )

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -184,7 +184,8 @@ class GoogleCloudStorageClient:
             cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
 
         blob = self._blob(cloud_path)
-        self._create_intermediate_local_directories(local_path)
+
+        os.makedirs(os.path.abspath(os.path.dirname(local_path)), exist_ok=True)
         blob.download_to_filename(local_path, timeout=timeout)
         logger.debug("Downloaded %r from Google Cloud to %r.", blob.public_url, local_path)
 
@@ -336,16 +337,6 @@ class GoogleCloudStorageClient:
 
         blob.metadata = self._encode_metadata(metadata)
         blob.patch()
-
-    def _create_intermediate_local_directories(self, local_path):
-        """Create intermediate directories for the given path to a local file if they don't exist.
-
-        :param str local_path:
-        :return None:
-        """
-        directory = os.path.dirname(os.path.abspath(local_path))
-        if not os.path.exists(directory):
-            os.makedirs(directory)
 
     def _encode_metadata(self, metadata):
         """Encode metadata as a dictionary of JSON strings.

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -262,11 +262,11 @@ class GoogleCloudStorageClient:
                 if filter(blob) and not blob.name.endswith("/"):
                     yield blob
 
-    def create_signed_url(self, cloud_path, expiration=None):
-        """Create a signed URL for accessing the object at the given cloud path that expires after the given expiration
-        date or period.
+    def generate_signed_url(self, cloud_path, expiration=datetime.timedelta(days=30)):
+        """Generate a signed URL for accessing the object at the given cloud path that expires after the given
+        expiration date or period.
 
-        :param str cloud_path: the path to the object to create the signed URL for
+        :param str cloud_path: the path to the object to generate the signed URL for
         :param datetime.datetime|datetime.timedelta expiration: the datetime for the URL to expire at or the amount of time after which it should expire
         :return str:
         """
@@ -277,7 +277,7 @@ class GoogleCloudStorageClient:
         else:
             api_access_endpoint = {}
 
-        return blob.generate_signed_url(expiration=expiration or datetime.timedelta(days=30), **api_access_endpoint)
+        return blob.generate_signed_url(expiration=expiration, **api_access_endpoint)
 
     def _get_bucket_and_path_in_bucket(self, cloud_path):
         """Get the bucket and path within the bucket from the given cloud path.

--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -264,6 +264,17 @@ class GoogleCloudStorageClient:
                 if filter(blob) and not blob.name.endswith("/"):
                     yield blob
 
+    def create_signed_url(self, cloud_path, expiration=None):
+        """Create a signed URL for accessing the object at the given cloud path that expires after the given expiration
+        date or period.
+
+        :param str cloud_path: the path to the object to create the signed URL for
+        :param datetime.datetime|datetime.timedelta expiration: the datetime for the URL to expire at or the amount of time after which it should expire
+        :return str:
+        """
+        blob = self._blob(cloud_path)
+        return blob.generate_signed_url(expiration=expiration)
+
     def _strip_leading_slash(self, path):
         """Strip the leading slash from a path.
 

--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse
 
 
 CLOUD_STORAGE_PROTOCOL = "gs://"
@@ -11,6 +12,15 @@ def is_qualified_cloud_path(path):
     :return bool: `True` if the path starts with the cloud storage protocol
     """
     return path.startswith(CLOUD_STORAGE_PROTOCOL)
+
+
+def is_url(path):
+    """Determine if the given path is an HTTP/HTTPS URL.
+
+    :param str path: the path to check
+    :return bool:
+    """
+    return path.startswith("http") or path.startswith("https")
 
 
 def join(*paths):
@@ -44,14 +54,18 @@ def generate_gs_path(bucket_name, *paths):
     return CLOUD_STORAGE_PROTOCOL + join(bucket_name, paths[0].lstrip("/"), *paths[1:])
 
 
-def split_bucket_name_from_gs_path(gs_path):
-    """Split the bucket name from the path.
+def split_bucket_name_from_cloud_path(path):
+    """Split the bucket name from the path within the bucket and return both.
 
-    :param str gs_path:
-    :return (str, str):
+    :param str path: the path to split
+    :return (str, str): the bucket name and the path within the bucket
     """
-    path = strip_protocol_from_path(gs_path).split("/")
-    return path[0], join(*path[1:])
+    if is_qualified_cloud_path(path):
+        path = strip_protocol_from_path(path).split("/")
+        return path[0], join(*path[1:])
+
+    path = urlparse(path).path.split("/")
+    return path[1], join(*path[2:])
 
 
 def strip_protocol_from_path(path):

--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -5,6 +5,15 @@ from urllib.parse import urlparse
 CLOUD_STORAGE_PROTOCOL = "gs://"
 
 
+def is_cloud_path(path):
+    """Determine if the given path is either a qualified cloud path or a URL cloud path.
+
+    :param str path: the path to check
+    :return bool:
+    """
+    return is_qualified_cloud_path(path) or is_url(path)
+
+
 def is_qualified_cloud_path(path):
     """Determine if the given path is a qualified cloud path - i.e. if it begins with the cloud storage protocol.
 

--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -20,7 +20,7 @@ def is_url(path):
     :param str path: the path to check
     :return bool:
     """
-    return path.startswith("http") or path.startswith("https")
+    return path.startswith("http")
 
 
 def join(*paths):

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -98,7 +98,6 @@ class AppConfiguration:
 
     :param str|None configuration_values: values to configure the app
     :param str|None configuration_manifest: a manifest of files to configure the app
-    :param str|None output_manifest_path: the path to give the output manifest
     :param str|None children: details of the children the app requires
     :return None:
     """
@@ -107,13 +106,11 @@ class AppConfiguration:
         self,
         configuration_values=None,
         configuration_manifest=None,
-        output_manifest_path=None,
         children=None,
         **kwargs,
     ):
         self.configuration_values = configuration_values
         self.configuration_manifest = configuration_manifest
-        self.output_manifest_path = output_manifest_path
         self.children = children
 
         if kwargs:

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -108,3 +108,7 @@ class DeploymentError(OctueSDKException):
 
 class CloudStorageBucketNotFound(OctueSDKException):
     """Raise if attempting to access a cloud storage bucket that cannot be found."""
+
+
+class IncompatibleCloudLocations(OctueSDKException):
+    """Raise if attempting to carry out an operation on objects from incompatible cloud locations."""

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -112,7 +112,3 @@ class CloudStorageBucketNotFound(OctueSDKException):
 
 class PushSubscriptionCannotBePulled(OctueSDKException):
     """Raise if attempting to pull a push subscription."""
-
-
-class IncompatibleCloudLocations(OctueSDKException):
-    """Raise if attempting to carry out an operation on objects from incompatible cloud locations."""

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -103,8 +103,8 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         self._handle_monitor_message(data)
 
     def finalise(self, upload_output_datasets_to=None):
-        """Validate the output values and output manifest, optionally writing the output manifest to the cloud with
-        signed URLs provided for its datasets.
+        """Validate the output values and output manifest, optionally uploading the output manifest's datasets to the
+        cloud and updating its dataset paths to signed URLs.
 
         :param str|None upload_output_datasets_to: if provided, upload any output datasets to this cloud directory and update the output manifest with their locations
         :return None:

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -102,12 +102,11 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         self._handle_monitor_message(data)
 
-    def finalise(self, upload_to_cloud=False, cloud_path=None):
+    def finalise(self, upload_output_datasets_to=None):
         """Validate the output values and output manifest, optionally writing the output manifest to the cloud with
         signed URLs provided for its datasets.
 
-        :param bool upload_to_cloud: if `True`, upload the output datasets to the cloud
-        :param str cloud_path: the path to a cloud directory to upload the output datasets to
+        :param str|None upload_output_datasets_to: if provided, upload any output datasets to this cloud directory and update the output manifest with their locations
         :return None:
         """
         serialised_strands = {"output_values": None, "output_manifest": None}
@@ -121,11 +120,11 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         logger.info("Validating serialised output values and manifest against the twine.")
         self.twine.validate(**serialised_strands)
 
-        if not (upload_to_cloud and hasattr(self, "output_manifest")):
+        if not (upload_output_datasets_to and hasattr(self, "output_manifest")):
             return
 
         for name, dataset in self.output_manifest.datasets.items():
-            dataset.to_cloud(cloud_path=storage.path.join(cloud_path, name))
+            dataset.to_cloud(cloud_path=storage.path.join(upload_output_datasets_to, name))
             self.output_manifest.datasets[name].path = dataset.generate_signed_url()
 
     def _calculate_strand_hashes(self, strands):

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -41,7 +41,7 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
     Analyses are instantiated at the top level of your app/service/twin code and you can import the instantiated
     object from there (see the templates for examples)
 
-    :param twined.Twine|str twine: Twine instance or json source
+    :param twined.Twine|str|dict twine: Twine instance or json source
     :param callable|None handle_monitor_message: a function that sends monitor messages to the parent that requested the analysis
     :param any configuration_values: see Runner.run() for definition
     :param octue.resources.manifest.Manifest configuration_manifest: see Runner.run() for definition
@@ -117,8 +117,8 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         if self.output_manifest:
             serialised_strands["output_manifest"] = self.output_manifest.to_primitive()
 
-        logger.info("Validating serialised output values and manifest against the twine.")
         self.twine.validate(**serialised_strands)
+        logger.info("Validated output values and output manifest against the twine.")
 
         if not (upload_output_datasets_to and hasattr(self, "output_manifest")):
             return
@@ -126,6 +126,8 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
         for name, dataset in self.output_manifest.datasets.items():
             dataset.to_cloud(cloud_path=storage.path.join(upload_output_datasets_to, name))
             self.output_manifest.datasets[name].path = dataset.generate_signed_url()
+
+        logger.info("Uploaded output datasets to %r.", upload_output_datasets_to)
 
     def _calculate_strand_hashes(self, strands):
         """Calculate the hashes of the strands specified in the HASH_FUNCTIONS constant.

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -118,7 +118,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
         self._cloud_metadata = {}
 
-        if storage.path.is_qualified_cloud_path(self.path):
+        if storage.path.is_qualified_cloud_path(self.path) or storage.path.is_url(self.path):
             self._cloud_path = path
 
             if not self._hypothetical:
@@ -517,10 +517,14 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
     def _get_cloud_metadata(self):
         """Get the cloud metadata for the datafile.
 
-        :return dict:
+        :return None:
         """
         if not self.cloud_path:
             self._raise_cloud_location_error()
+
+        # Skip getting metadata for now if the cloud path is a signed URL.
+        if storage.path.is_url(self.cloud_path):
+            return
 
         cloud_metadata = GoogleCloudStorageClient().get_metadata(cloud_path=self.cloud_path)
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -429,7 +429,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
 
         storage_client = GoogleCloudStorageClient()
 
-        # If the datafile's file has been changed locally, overwrite its cloud copy.
+        # If the there is no cloud file or if the datafile's file has been changed locally, overwrite its cloud copy.
         if not storage_client.exists(cloud_path) or self.cloud_hash_value != self.hash_value:
             storage_client.upload_file(
                 local_path=self.local_path,

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -110,7 +110,6 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         )
 
         self.timestamp = timestamp
-        self.extension = os.path.splitext(path)[-1].strip(".")
 
         self._local_path = None
         self._cloud_path = None
@@ -181,6 +180,14 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         :return str:
         """
         return self._name or str(os.path.split(self.path)[-1]).split("?")[0]
+
+    @property
+    def extension(self):
+        """Get the extension of the datafile.
+
+        :return str:
+        """
+        return os.path.splitext(self.name)[-1].strip(".")
 
     @property
     def cloud_path(self):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -373,6 +373,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         if self.exists_in_cloud:
             GoogleCloudStorageClient().download_to_file(local_path=path, cloud_path=self.cloud_path)
         else:
+            os.makedirs(os.path.split(path)[0], exist_ok=True)
             shutil.copy(self._local_path, path)
 
         self._local_path = os.path.abspath(path)

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -117,7 +117,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
         self._cloud_metadata = {}
 
-        if storage.path.is_qualified_cloud_path(self.path) or storage.path.is_url(self.path):
+        if storage.path.is_cloud_path(self.path):
             self._cloud_path = path
 
             if not self._hypothetical:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -180,7 +180,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
 
         :return str:
         """
-        return self._name or str(os.path.split(self.path)[-1])
+        return self._name or str(os.path.split(self.path)[-1]).split("?")[0]
 
     @property
     def cloud_path(self):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -227,7 +227,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         :return str|None:
         """
         if self.cloud_path:
-            return storage.path.split_bucket_name_from_gs_path(self.cloud_path)[0]
+            return storage.path.split_bucket_name_from_cloud_path(self.cloud_path)[0]
         return None
 
     @property
@@ -237,7 +237,7 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
         :return str|None:
         """
         if self.cloud_path:
-            return storage.path.split_bucket_name_from_gs_path(self.cloud_path)[1]
+            return storage.path.split_bucket_name_from_cloud_path(self.cloud_path)[1]
         return None
 
     @property

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -420,9 +420,11 @@ class Datafile(Labelable, Taggable, Serialisable, Pathable, Identifiable, Hashab
 
         self._get_cloud_metadata()
 
+        storage_client = GoogleCloudStorageClient()
+
         # If the datafile's file has been changed locally, overwrite its cloud copy.
-        if self.cloud_hash_value != self.hash_value:
-            GoogleCloudStorageClient().upload_file(
+        if not storage_client.exists(cloud_path) or self.cloud_hash_value != self.hash_value:
+            storage_client.upload_file(
                 local_path=self.local_path,
                 cloud_path=cloud_path,
                 metadata=self.metadata(),

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -148,7 +148,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
 
         :return bool:
         """
-        return storage.path.is_qualified_cloud_path(self.path) or storage.path.is_url(self.path)
+        return storage.path.is_cloud_path(self.path)
 
     @property
     def exists_locally(self):

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -148,7 +148,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
 
         :return bool:
         """
-        return storage.path.is_qualified_cloud_path(self.path)
+        return storage.path.is_qualified_cloud_path(self.path) or storage.path.is_url(self.path)
 
     @property
     def exists_locally(self):
@@ -156,7 +156,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
 
         :return bool:
         """
-        return not storage.path.is_qualified_cloud_path(self.path)
+        return not self.exists_in_cloud
 
     @property
     def bucket_name(self):

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -42,7 +42,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
     # Paths to files are added to the serialisation in `Dataset.to_primitive`.
     _SERIALISE_FIELDS = "name", "labels", "tags", "id", "path"
 
-    def __init__(self, files=None, name=None, id=None, path=None, tags=None, labels=None, save_metadata_locally=True):
+    def __init__(self, files=None, name=None, id=None, path=".", tags=None, labels=None, save_metadata_locally=True):
         super().__init__(name=name, id=id, tags=tags, labels=labels)
         self.path = path
         self.files = self._instantiate_datafiles(files or [])

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -247,8 +247,8 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
         return cloud_path
 
     def generate_signed_url(self, expiration=datetime.timedelta(days=30)):
-        """Generate a signed URL for the dataset. This is done by creating a uniquely named metadata file containing
-        signed URLs to the datasets' files and providing a signed URL to that metadata file.
+        """Generate a signed URL for the dataset. This is done by uploading a uniquely named metadata file containing
+        signed URLs to the datasets' files and returning a signed URL to that metadata file.
 
         :param datetime.datetime|datetime.timedelta expiration: the amount of time or date after which the URL should expire
         :return str: the signed URL for the dataset

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -285,7 +285,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
             new_path = os.path.join(self.path, path_in_dataset)
 
             if datafile.local_path != new_path:
-                os.makedirs(os.path.split(new_path)[0])
+                os.makedirs(os.path.split(new_path)[0], exist_ok=True)
                 datafile.local_path = new_path
 
         self.files.add(datafile)

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -240,7 +240,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
         # Use multiple threads to significantly speed up file uploads by reducing latency.
         with concurrent.futures.ThreadPoolExecutor() as executor:
             for path in executor.map(upload, files_and_paths):
-                logger.info("Uploaded datafile to %r", path)
+                logger.info("Uploaded datafile to %r.", path)
 
         self.path = cloud_path
         self._upload_cloud_metadata()
@@ -362,7 +362,8 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
 
         # Use multiple threads to significantly speed up files downloads by reducing latency.
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            executor.map(download, files_and_paths)
+            for path in executor.map(download, files_and_paths):
+                logger.info("Downloaded datafile to %r.", path)
 
         logger.info("Downloaded %r dataset to %r.", self.name, local_directory)
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -7,7 +7,7 @@ import tempfile
 
 from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
-from octue.exceptions import CloudLocationNotSpecified, IncompatibleCloudLocations, InvalidInputException
+from octue.exceptions import CloudLocationNotSpecified, InvalidInputException
 from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
 from octue.mixins import Hashable, Identifiable, Labelable, Serialisable, Taggable
 from octue.resources.datafile import Datafile
@@ -253,15 +253,9 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
 
             # Adding a cloud datafile to a cloud dataset.
             if datafile.exists_in_cloud:
-                if datafile.bucket_name != self.bucket_name:
-                    raise IncompatibleCloudLocations(
-                        f"Datafiles must be from the same cloud bucket as the dataset they are being added to. The "
-                        f"datafile's bucket is {datafile.bucket_name!r} while the dataset's bucket is "
-                        f"{self.bucket_name!r}. Try changing the cloud location of the datafile and try again."
-                    )
 
-                if path_in_dataset:
-                    new_path = storage.path.join(self.path, path_in_dataset)
+                if path_in_dataset or datafile.bucket_name != self.bucket_name:
+                    new_path = storage.path.join(self.path, path_in_dataset or datafile.name)
 
                     if datafile.cloud_path != new_path:
                         datafile.to_cloud(new_path)

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import copy
+import datetime
 import json
 import logging
 import os
@@ -243,18 +244,18 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
         self._upload_cloud_metadata()
         return cloud_path
 
-    def generate_signed_url(self, expiration=None):
+    def generate_signed_url(self, expiration=datetime.timedelta(days=30)):
         """Generate a signed URL for the dataset. This is done by creating a uniquely named metadata file containing
         signed URLs to the datasets' files and providing a signed URL to that metadata file.
 
-        :param datetime.datetime|datetime.timedelta|None expiration: the time/date after which the URL should expire
+        :param datetime.datetime|datetime.timedelta expiration: the amount of time or date after which the URL should expire
         :return str: the signed URL for the dataset
         """
         storage_client = GoogleCloudStorageClient()
         signed_metadata = self.to_primitive()
 
         signed_metadata["files"] = [
-            storage_client.create_signed_url(cloud_path=datafile_path, expiration=expiration)
+            storage_client.generate_signed_url(cloud_path=datafile_path, expiration=expiration)
             for datafile_path in signed_metadata["files"]
         ]
 
@@ -265,7 +266,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
             cloud_path=path_to_signed_metadata_file,
         )
 
-        return storage_client.create_signed_url(cloud_path=path_to_signed_metadata_file, expiration=expiration)
+        return storage_client.generate_signed_url(cloud_path=path_to_signed_metadata_file, expiration=expiration)
 
     def add(self, datafile, path_in_dataset=None):
         """Add a datafile to the dataset.

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -271,7 +271,8 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
         return storage_client.generate_signed_url(cloud_path=path_to_signed_metadata_file, expiration=expiration)
 
     def add(self, datafile, path_in_dataset=None):
-        """Add a datafile to the dataset.
+        """Add a datafile to the dataset. If the datafile's location is outside the dataset, it is copied to the dataset
+        root or to the `path_in_dataset` if provided.
 
         :param octue.resources.datafile.Datafile datafile: the datafile to add to the dataset
         :param str|None path_in_dataset: if provided, set the datafile's local path to this path within the dataset

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -218,7 +218,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
         files_and_paths = []
 
         for datafile in self.files:
-            datafile_path_relative_to_dataset = datafile.path.split(self.path)[-1].strip(os.path.sep).strip("/")
+            datafile_path_relative_to_dataset = storage.path.relpath(datafile.local_path, self.path)
             files_and_paths.append(
                 (
                     datafile,

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -310,7 +310,6 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
 
         # Adding a local datafile to a local dataset.
         if datafile.local_path != new_local_path:
-            os.makedirs(os.path.split(new_local_path)[0], exist_ok=True)
             datafile.local_path = new_local_path
 
         self.files.add(datafile)

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -285,31 +285,30 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable):
         if self.exists_in_cloud:
             new_cloud_path = storage.path.join(self.path, path_in_dataset or datafile.name)
 
-            # Adding a cloud datafile to a cloud dataset.
+            # Add a cloud datafile to a cloud dataset.
             if datafile.exists_in_cloud:
 
-                if path_in_dataset or datafile.bucket_name != self.bucket_name:
-                    if datafile.cloud_path != new_cloud_path:
-                        datafile.to_cloud(new_cloud_path)
+                if datafile.cloud_path != new_cloud_path and not datafile.cloud_path.startswith(self.path):
+                    datafile.to_cloud(new_cloud_path)
 
                 self.files.add(datafile)
                 return
 
-            # Adding a local datafile to a cloud dataset.
+            # Add a local datafile to a cloud dataset.
             datafile.to_cloud(new_cloud_path)
             self.files.add(datafile)
             return
 
         new_local_path = os.path.join(self.path, path_in_dataset or datafile.name)
 
-        # Adding a cloud datafile to a local dataset.
+        # Add a cloud datafile to a local dataset.
         if datafile.exists_in_cloud:
             datafile.download(local_path=new_local_path)
             self.files.add(datafile)
             return
 
-        # Adding a local datafile to a local dataset.
-        if datafile.local_path != new_local_path:
+        # Add a local datafile to a local dataset.
+        if datafile.local_path != new_local_path and not datafile.local_path.startswith(self.path):
             datafile.local_path = new_local_path
 
         self.files.add(datafile)

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -153,13 +153,13 @@ class Manifest(Serialisable, Identifiable, Hashable):
         # If `dataset` is just a path to a dataset:
         if isinstance(dataset, str):
 
-            if storage.path.is_qualified_cloud_path(dataset) or storage.path.is_url(dataset):
+            if storage.path.is_cloud_path(dataset):
                 return (key, Dataset.from_cloud(cloud_path=dataset, recursive=True))
 
             return (key, Dataset.from_local_directory(path_to_directory=dataset, recursive=True))
 
         # If `dataset` is a dictionary including a "path" key:
-        if storage.path.is_qualified_cloud_path(dataset["path"]) or storage.path.is_url(dataset["path"]):
+        if storage.path.is_cloud_path(dataset["path"]):
             return (key, Dataset.from_cloud(cloud_path=dataset["path"], recursive=True))
 
         return (key, Dataset(**dataset))

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -150,29 +150,26 @@ class Manifest(Serialisable, Identifiable, Hashable):
         if isinstance(dataset, Dataset):
             return (key, dataset)
 
-        else:
-            # If `dataset` is just a path to a dataset:
-            if isinstance(dataset, str):
-                if storage.path.is_qualified_cloud_path(dataset) or storage.path.is_url(dataset):
-                    return (key, Dataset.from_cloud(cloud_path=dataset, recursive=True))
-                else:
-                    return (key, Dataset.from_local_directory(path_to_directory=dataset, recursive=True))
+        # If `dataset` is just a path to a dataset:
+        if isinstance(dataset, str):
+            if storage.path.is_qualified_cloud_path(dataset) or storage.path.is_url(dataset):
+                return (key, Dataset.from_cloud(cloud_path=dataset, recursive=True))
 
-            # If `dataset` is a dictionary including a "path" key:
-            elif "path" in dataset:
+            return (key, Dataset.from_local_directory(path_to_directory=dataset, recursive=True))
 
-                # If the path is a cloud path:
-                if storage.path.is_qualified_cloud_path(dataset["path"]):
-                    return (key, Dataset.from_cloud(cloud_path=dataset["path"], recursive=True))
+        # If `dataset` is a dictionary including a "path" key:
+        if "path" in dataset:
 
-                # If the path is local but not absolute:
-                elif not os.path.isabs(dataset["path"]):
-                    path = dataset.pop("path")
-                    return (key, Dataset(**dataset, path=path))
+            # If the path is a cloud path:
+            if storage.path.is_qualified_cloud_path(dataset["path"]) or storage.path.is_url(dataset["path"]):
+                return (key, Dataset.from_cloud(cloud_path=dataset["path"], recursive=True))
 
-                # If the path is an absolute local path:
-                else:
-                    return (key, Dataset(**dataset))
+            # If the path is local but not absolute:
+            if not os.path.isabs(dataset["path"]):
+                path = dataset.pop("path")
+                return (key, Dataset(**dataset, path=path))
 
-            else:
-                return (key, Dataset(**dataset, path=key))
+            # If the path is an absolute local path:
+            return (key, Dataset(**dataset))
+
+        return (key, Dataset(**dataset, path=key))

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -153,7 +153,7 @@ class Manifest(Serialisable, Identifiable, Hashable):
         else:
             # If `dataset` is just a path to a dataset:
             if isinstance(dataset, str):
-                if storage.path.is_qualified_cloud_path(dataset):
+                if storage.path.is_qualified_cloud_path(dataset) or storage.path.is_url(dataset):
                     return (key, Dataset.from_cloud(cloud_path=dataset, recursive=True))
                 else:
                     return (key, Dataset.from_local_directory(path_to_directory=dataset, recursive=True))

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -1,7 +1,6 @@
 import concurrent.futures
 import copy
 import json
-import os
 import warnings
 
 import octue.migrations.manifest
@@ -164,12 +163,7 @@ class Manifest(Serialisable, Identifiable, Hashable):
             if storage.path.is_qualified_cloud_path(dataset["path"]) or storage.path.is_url(dataset["path"]):
                 return (key, Dataset.from_cloud(cloud_path=dataset["path"], recursive=True))
 
-            # If the path is local but not absolute:
-            if not os.path.isabs(dataset["path"]):
-                path = dataset.pop("path")
-                return (key, Dataset(**dataset, path=path))
-
-            # If the path is an absolute local path:
+            # If the path is local:
             return (key, Dataset(**dataset))
 
         return (key, Dataset(**dataset, path=key))

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -29,7 +29,6 @@ class Runner:
     :param str|twined.Twine twine: path to the twine file, a string containing valid twine json, or a Twine instance
     :param str|dict|_io.TextIOWrapper|None configuration_values: The strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
     :param str|dict|_io.TextIOWrapper|None configuration_manifest: The strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
-    :param Union[str, path-like, None] output_manifest_path: Path where output data will be written
     :param Union[str, dict, None] children: The children strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
     :param bool skip_checks: If true, skip the check that all files in the manifest are present on disc - this can be an extremely long process for large datasets.
     :param str|None project_name: name of Google Cloud project to get credentials from
@@ -42,13 +41,11 @@ class Runner:
         twine="twine.json",
         configuration_values=None,
         configuration_manifest=None,
-        output_manifest_path=None,
         children=None,
         skip_checks=False,
         project_name=None,
     ):
         self.app_src = app_src
-        self.output_manifest_path = output_manifest_path
         self.children = children
         self.skip_checks = skip_checks
 

--- a/octue/templates/template-child-services/parent_service/app.py
+++ b/octue/templates/template-child-services/parent_service/app.py
@@ -47,3 +47,4 @@ def run(analysis, *args, **kwargs):
     )
 
     analysis.output_values = {"wind_speeds": wind_speeds, "elevations": elevations}
+    analysis.finalise()

--- a/octue/templates/template-python-fractal/app.py
+++ b/octue/templates/template-python-fractal/app.py
@@ -38,7 +38,6 @@ def run(analysis, *args, **kwargs):
     """
     # You can use the attached logger to record debug statements, general information, warnings or errors
     # logger.info("The input directory is %s", analysis.input_dir)
-    # logger.info("The output directory is %s", analysis.output_dir)
     # logger.info("The tmp directory, where you can store temporary files or caches, is %s", analysis.tmp_dir)
 
     # Print statements will get logged...

--- a/octue/templates/template-python-fractal/app.py
+++ b/octue/templates/template-python-fractal/app.py
@@ -55,3 +55,8 @@ def run(analysis, *args, **kwargs):
 
     # Run the code
     fractal(analysis)
+
+    # Finalise the analysis. This validates the output data and output manifest against the twine and optionally
+    # uploads any datasets in the output manifest to the service's cloud bucket. Signed URLs are provided so that the
+    # parent that asked the service for the analysis can access the data (until the signed URLs expire).
+    analysis.finalise()

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -88,14 +88,12 @@ def run(analysis, *args, **kwargs):
         labels="timeseries",
     )
 
-    output_dataset.add(timeseries_datafile, path_in_dataset="cleaned.csv")
-
     # Write the file (now we know where to write it)
     with timeseries_datafile.open("w") as fp:
         data.to_csv(path_or_buf=fp)
 
     # And finally we add it to the output
-    output_dataset.add(timeseries_datafile)
+    output_dataset.add(timeseries_datafile, path_in_dataset="cleaned.csv")
 
     # We're done! There's only one datafile in the output dataset, but you could create thousands more and append them
     # all :)

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -3,6 +3,7 @@ import logging
 from cleaner import clean, read_csv_files, read_dat_file
 
 from octue.resources import Datafile
+from tests import TEST_BUCKET_NAME
 
 
 logger = logging.getLogger(__name__)
@@ -101,3 +102,5 @@ def run(analysis, *args, **kwargs):
     # If you're running this on your local machine, that's it - but when this code runs as an analysis in the cloud,
     # The files in the output manifest are copied into the cloud store. Their names and labels are registered in a search
     # index so your colleagues can find the dataset you've produced.
+
+    analysis.finalise(upload_to_cloud=True, cloud_path=f"gs://{TEST_BUCKET_NAME}/output/test_using_manifests_analysis")

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -99,7 +99,7 @@ def run(analysis, *args, **kwargs):
     # Finalise the analysis. This validates the output data and output manifest against the twine and optionally
     # uploads any datasets in the output manifest to the service's cloud bucket. Signed URLs are provided so that the
     # parent that asked the service for the analysis can access the data (until the signed URLs expire).
-    analysis.finalise(upload_to_cloud=True, cloud_path=f"gs://{TEST_BUCKET_NAME}/output/test_using_manifests_analysis")
+    analysis.finalise(upload_output_datasets_to=f"gs://{TEST_BUCKET_NAME}/output/test_using_manifests_analysis")
 
     # We're done! There's only one datafile in the output dataset, but you could create thousands more and append them
     # all :)

--- a/octue/templates/template-using-manifests/app.py
+++ b/octue/templates/template-using-manifests/app.py
@@ -96,11 +96,14 @@ def run(analysis, *args, **kwargs):
     # And finally we add it to the output
     output_dataset.add(timeseries_datafile, path_in_dataset="cleaned.csv")
 
+    # Finalise the analysis. This validates the output data and output manifest against the twine and optionally
+    # uploads any datasets in the output manifest to the service's cloud bucket. Signed URLs are provided so that the
+    # parent that asked the service for the analysis can access the data (until the signed URLs expire).
+    analysis.finalise(upload_to_cloud=True, cloud_path=f"gs://{TEST_BUCKET_NAME}/output/test_using_manifests_analysis")
+
     # We're done! There's only one datafile in the output dataset, but you could create thousands more and append them
     # all :)
     #
     # If you're running this on your local machine, that's it - but when this code runs as an analysis in the cloud,
     # The files in the output manifest are copied into the cloud store. Their names and labels are registered in a search
     # index so your colleagues can find the dataset you've produced.
-
-    analysis.finalise(upload_to_cloud=True, cloud_path=f"gs://{TEST_BUCKET_NAME}/output/test_using_manifests_analysis")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1361,15 +1361,22 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 
 [[package]]
 name = "twined"
-version = "0.3.0"
-description = "A library to help digital twins and data services talk to one another"
+version = "0.3.1"
+description = ""
 category = "main"
 optional = false
 python-versions = ">=3.6"
+develop = false
 
 [package.dependencies]
 jsonschema = ">=4.4.0,<4.5.0"
 python-dotenv = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/octue/twined.git"
+reference = "enhancement/allow-datasets-to-be-optional"
+resolved_reference = "591de328dbdcdced719e25ddf29e8249ee99ce1c"
 
 [[package]]
 name = "typed-ast"
@@ -1485,7 +1492,7 @@ hdf5 = ["h5py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "038320ffb37ae0ff15a14cba99cda8108b0a5cf167331e3b01de059063f1c613"
+content-hash = "39ce37767f9074d0f90e6c4ba6e0a02b7145ae174d2dac3a0f25af83be4a1d54"
 
 [metadata.files]
 apache-beam = [
@@ -2554,10 +2561,7 @@ tox = [
     {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
     {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
 ]
-twined = [
-    {file = "twined-0.3.0-py3-none-any.whl", hash = "sha256:3ade7fcb5f1071353cdbd681e17c740a375f2b39262b511331c315d19fbd9682"},
-    {file = "twined-0.3.0.tar.gz", hash = "sha256:627c81bb062f04ee45c890b6dcb6c5f56132afbf0f14d6a3e68b08a4ab1fab76"},
-]
+twined = []
 typed-ast = [
     {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},
     {file = "typed_ast-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1358,21 +1358,14 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 [[package]]
 name = "twined"
 version = "0.3.1"
-description = ""
+description = "A library to help digital twins and data services talk to one another"
 category = "main"
 optional = false
 python-versions = ">=3.6"
-develop = false
 
 [package.dependencies]
 jsonschema = ">=4.4.0,<4.5.0"
 python-dotenv = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/octue/twined.git"
-reference = "enhancement/allow-datasets-to-be-optional"
-resolved_reference = "591de328dbdcdced719e25ddf29e8249ee99ce1c"
 
 [[package]]
 name = "typed-ast"
@@ -1488,7 +1481,7 @@ hdf5 = ["h5py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "2d22791a3acd7323f40af677a636a99e981c787f64f7c43554c285db95791234"
+content-hash = "2032328c0caa790c6f9aceb34ed66a1086d2d04fd6d7739019d10e10731bf64e"
 
 [metadata.files]
 apache-beam = [
@@ -2556,7 +2549,10 @@ tox = [
     {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
     {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
-twined = []
+twined = [
+    {file = "twined-0.3.1-py3-none-any.whl", hash = "sha256:89091747f1eb9d85de66e791fc0f80ab735d7c5b78c899d3cc7a61f85c3d8be2"},
+    {file = "twined-0.3.1.tar.gz", hash = "sha256:4c25b745ca3a866fccd17f413dd35e04ddc78966b1ff1e294cb3bd2843cd44f9"},
+]
 typed-ast = [
     {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},
     {file = "typed_ast-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1334,7 +1334,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tox"
-version = "3.24.5"
+version = "3.25.0"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
@@ -1441,7 +1441,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.14.0"
+version = "20.14.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -1488,7 +1488,7 @@ hdf5 = ["h5py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "ca840848ec468c42338193c56d6a447d48cc1b54a714565df8a3b522262bb0d3"
+content-hash = "2d22791a3acd7323f40af677a636a99e981c787f64f7c43554c285db95791234"
 
 [metadata.files]
 apache-beam = [
@@ -2553,8 +2553,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 tox = [
-    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
-    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
+    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
+    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
 twined = []
 typed-ast = [
@@ -2604,8 +2604,8 @@ urllib3 = [
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
-    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
+    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
+    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
 ]
 werkzeug = [
     {file = "Werkzeug-2.1.1-py3-none-any.whl", hash = "sha256:3c5493ece8268fecdcdc9c0b112211acd006354723b280d643ec732b6d4063d6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.18.3"
+version = "0.19.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.17.0"
+version = "0.17.1"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]
@@ -34,7 +34,7 @@ python-dateutil = "^2.8.1"
 pyyaml = "^6"
 h5py = { version = "^3.6.0", optional = true }
 apache-beam = { extras = ["gcp"], version = "2.37.0", optional = true }
-twined = "0.3.0"
+twined = {git = "https://github.com/octue/twined.git", rev = "enhancement/allow-datasets-to-be-optional"}
 
 [tool.poetry.extras]
 hdf5 = ["h5py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python-dateutil = "^2.8.1"
 pyyaml = "^6"
 h5py = { version = "^3.6.0", optional = true }
 apache-beam = { extras = ["gcp"], version = "2.37.0", optional = true }
-twined = {git = "https://github.com/octue/twined.git", rev = "enhancement/allow-datasets-to-be-optional"}
+twined = "^0.3.1"
 
 [tool.poetry.extras]
 hdf5 = ["h5py"]

--- a/tests/cloud/deployment/google/test_answer_pub_sub_question.py
+++ b/tests/cloud/deployment/google/test_answer_pub_sub_question.py
@@ -64,7 +64,6 @@ class TestAnswerPubSubQuestion(TestCase):
                 "twine": "twine.json",
                 "configuration_values": None,
                 "configuration_manifest": None,
-                "output_manifest_path": None,
                 "children": None,
                 "project_name": "a-project-name",
             }
@@ -111,7 +110,6 @@ class TestAnswerPubSubQuestion(TestCase):
                 "twine": "path/to/twine.json",
                 "configuration_values": {"hello": "configuration"},
                 "configuration_manifest": None,
-                "output_manifest_path": None,
                 "children": None,
                 "project_name": "a-project-name",
             }

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -320,7 +320,9 @@ class TestGoogleCloudStorageClient(BaseTestCase):
         self.storage_client.upload_from_string(string="some stuff", cloud_path=cloud_path)
 
         expiration_time = 1
-        url = self.storage_client.create_signed_url(cloud_path, expiration=datetime.timedelta(seconds=expiration_time))
+        url = self.storage_client.generate_signed_url(
+            cloud_path, expiration=datetime.timedelta(seconds=expiration_time)
+        )
 
         # Ensure the GOOGLE_APPLICATION_CREDENTIALS environment variable isn't available.
         with patch.dict(os.environ, clear=True):

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -13,6 +13,7 @@ from octue.cloud.storage import GoogleCloudStorageClient
 from octue.exceptions import CloudStorageBucketNotFound
 from tests import TEST_BUCKET_NAME
 from tests.base import BaseTestCase
+from tests.mocks import mock_generate_signed_url
 
 
 class TestGoogleCloudStorageClient(BaseTestCase):
@@ -311,19 +312,7 @@ class TestGoogleCloudStorageClient(BaseTestCase):
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "blah")
         self.storage_client.upload_from_string(string="some stuff", cloud_path=cloud_path)
 
-        # Mock the signing of the URL as it can't currently be done via workload identity federation so the tests would
-        # fail.
-        with patch(
-            "google.cloud.storage.blob.Blob.generate_signed_url",
-            return_value=(
-                f"{self.test_result_modifier.storage_emulator_host}/octue-test-bucket/blah?Expires=1650277335&GoogleAcc"
-                "essId=dev-cortadocodes%40octue-amy.iam.gserviceaccount.com&Signature=UekBIUZIgjZKB8aRSTEIbj3QXDXm5fhcE"
-                "EhRneTKBJoyU7ysnhEmCXiS2Ip5rKwzBS568aFeWJQXbDPSf9Qq43N0%2FHB7QkEwJ6Y5u9S%2FTp6l5%2FqhrKHPhPCSjbJ7gmoak"
-                "sHpfDaDVVEMQTRA%2Bcq59SV2NBRsA00Ek8h73sBNPvw9JlcwNGn9gjbCUunt24ZRVvf3DEThYUZyv7Z2vInv5cbmZYbFd6bA8ahy%"
-                "2FLFdq%2F6vQibao4iOJ1yeBZKEAaLsYzmXRuZJmg19LWWNBTsiAiZqKLy%2Fn5fw6LCRAR%2B04GaL8kVpotN1sOh7tRBFedEqoJ3"
-                "fAXnztdhlJZs2m4OFLg%3D%3D"
-            ),
-        ):
+        with patch("google.cloud.storage.blob.Blob.generate_signed_url", mock_generate_signed_url):
             url = self.storage_client.generate_signed_url(cloud_path, expiration=datetime.timedelta(seconds=1))
 
         # Ensure the GOOGLE_APPLICATION_CREDENTIALS environment variable isn't available.

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -2,7 +2,6 @@ import datetime
 import json
 import os
 import tempfile
-import time
 from unittest.mock import patch
 
 import google.api_core.exceptions
@@ -316,9 +315,7 @@ class TestGoogleCloudStorageClient(BaseTestCase):
         )
 
     def test_create_signed_url(self):
-        """Test that a signed URL to a cloud object can be created, used to access the file, and expired after the
-        given time.
-        """
+        """Test that a signed URL to a cloud object can be created and used to access the file."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "blah")
         self.storage_client.upload_from_string(string="some stuff", cloud_path=cloud_path)
 
@@ -332,10 +329,3 @@ class TestGoogleCloudStorageClient(BaseTestCase):
             response = requests.get(url)
             self.assertEqual(requests.get(url).status_code, 200)
             self.assertEqual(response.text, "some stuff")
-
-            # Test that the signed URL expires in the expected time.
-            time.sleep(expiration_time)
-            self.assertEqual(requests.get(url).status_code, 400)
-
-        # Check that the uploaded file is still available via the correct credentials.
-        self.assertEqual(self.storage_client.download_as_string(cloud_path), "some stuff")

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -306,15 +306,25 @@ class TestGoogleCloudStorageClient(BaseTestCase):
             )
         )
 
-    def test_create_signed_url(self):
-        """Test that a signed URL to a cloud object can be created and used to access the file."""
+    def test_generate_signed_url(self):
+        """Test that a signed URL to a cloud object can be generated and used to access the file."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "blah")
         self.storage_client.upload_from_string(string="some stuff", cloud_path=cloud_path)
 
-        expiration_time = 1
-        url = self.storage_client.generate_signed_url(
-            cloud_path, expiration=datetime.timedelta(seconds=expiration_time)
-        )
+        # Mock the signing of the URL as it can't currently be done via workload identity federation so the tests would
+        # fail.
+        with patch(
+            "google.cloud.storage.blob.Blob.generate_signed_url",
+            return_value=(
+                f"{self.test_result_modifier.storage_emulator_host}/octue-test-bucket/blah?Expires=1650277335&GoogleAcc"
+                "essId=dev-cortadocodes%40octue-amy.iam.gserviceaccount.com&Signature=UekBIUZIgjZKB8aRSTEIbj3QXDXm5fhcE"
+                "EhRneTKBJoyU7ysnhEmCXiS2Ip5rKwzBS568aFeWJQXbDPSf9Qq43N0%2FHB7QkEwJ6Y5u9S%2FTp6l5%2FqhrKHPhPCSjbJ7gmoak"
+                "sHpfDaDVVEMQTRA%2Bcq59SV2NBRsA00Ek8h73sBNPvw9JlcwNGn9gjbCUunt24ZRVvf3DEThYUZyv7Z2vInv5cbmZYbFd6bA8ahy%"
+                "2FLFdq%2F6vQibao4iOJ1yeBZKEAaLsYzmXRuZJmg19LWWNBTsiAiZqKLy%2Fn5fw6LCRAR%2B04GaL8kVpotN1sOh7tRBFedEqoJ3"
+                "fAXnztdhlJZs2m4OFLg%3D%3D"
+            ),
+        ):
+            url = self.storage_client.generate_signed_url(cloud_path, expiration=datetime.timedelta(seconds=1))
 
         # Ensure the GOOGLE_APPLICATION_CREDENTIALS environment variable isn't available.
         with patch.dict(os.environ, clear=True):

--- a/tests/cloud/storage/test_client.py
+++ b/tests/cloud/storage/test_client.py
@@ -287,14 +287,6 @@ class TestGoogleCloudStorageClient(BaseTestCase):
 
         self.assertEqual(metadata["custom_metadata"], {"this": "is-not-json-encoded"})
 
-    def test_create_intermediate_local_directories(self):
-        """Test that intermediate directories are created for the given path to a file."""
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            self.storage_client._create_intermediate_local_directories(
-                os.path.join(temporary_directory, "bam", "jam", "wam.csv")
-            )
-            self.assertTrue(os.path.exists(os.path.join(temporary_directory, "bam", "jam")))
-
     def test_exists(self):
         """Test that an existing cloud file shows as existing."""
         path_to_existing_file = storage.path.generate_gs_path(TEST_BUCKET_NAME, "blah")

--- a/tests/cloud/storage/test_path.py
+++ b/tests/cloud/storage/test_path.py
@@ -22,9 +22,10 @@ class TestStorage(BaseTestCase):
     def test_split_bucket_name_from_gs_path(self):
         """Test that the bucket name can be split from the path in a gs path."""
         self.assertEqual(
-            storage.path.split_bucket_name_from_gs_path("gs://my-bucket/path/file.txt"), ("my-bucket", "path/file.txt")
+            storage.path.split_bucket_name_from_cloud_path("gs://my-bucket/path/file.txt"),
+            ("my-bucket", "path/file.txt"),
         )
-        self.assertEqual(storage.path.split_bucket_name_from_gs_path("gs://my-bucket"), ("my-bucket", ""))
+        self.assertEqual(storage.path.split_bucket_name_from_cloud_path("gs://my-bucket"), ("my-bucket", ""))
 
     def test_strip_protocol_from_path(self):
         """Test that the `gs://` protocol can be stripped from a path."""

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,6 +1,8 @@
 import datetime
 import io
 
+from google.cloud.storage.blob import _API_ACCESS_ENDPOINT
+
 
 class MockOpen:
     """A mock for patching `builtins.open` that returns different text streams depending on the path given to it. To
@@ -26,7 +28,7 @@ class MockOpen:
 
 
 def mock_generate_signed_url(blob, expiration=datetime.timedelta(days=30), **kwargs):
-    """Mock generating a signed URL for a Google Cloud Storage blob. Signed URLS can't currently be generated when using
+    """Mock generating a signed URL for a Google Cloud Storage blob. Signed URLs can't currently be generated when using
     workload identity federation, which we use for our CI tests.
 
     :param google.cloud.storage.blob.Blob blob:
@@ -41,5 +43,5 @@ def mock_generate_signed_url(blob, expiration=datetime.timedelta(days=30), **kwa
         f"siAiZqKLy%2Fn5fw6LCRAR%2B04GaL8kVpotN1sOh7tRBFedEqoJ3fAXnztdhlJZs2m4OFLg%3D%3D"
     )
 
-    base_url = "/".join((kwargs.get("api_access_endpoint", ""), blob.bucket.name, blob.name))
+    base_url = "/".join((kwargs.get("api_access_endpoint", _API_ACCESS_ENDPOINT), blob.bucket.name, blob.name))
     return base_url + mock_signed_query_parameter

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 
 
@@ -22,3 +23,23 @@ class MockOpen:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
+
+
+def mock_generate_signed_url(blob, expiration=datetime.timedelta(days=30), **kwargs):
+    """Mock generating a signed URL for a Google Cloud Storage blob. Signed URLS can't currently be generated when using
+    workload identity federation, which we use for our CI tests.
+
+    :param google.cloud.storage.blob.Blob blob:
+    :param datetime.datetime|datetime.timedelta expiration:
+    :return str:
+    """
+    mock_signed_query_parameter = (
+        f"?Expires={round((datetime.datetime.now() + expiration).timestamp())}&GoogleAccessId=my-service-account%40my-p"
+        f"roject.iam.gserviceaccount.com&Signature=UekBIUZIgjZKB8aRSTEIbj3QXDXm5fhcEEhRneTKBJoyU7ysnhEmCXiS2Ip5rKwzBS56"
+        f"8aFeWJQXbDPSf9Qq43N0%2FHB7QkEwJ6Y5u9S%2FTp6l5%2FqhrKHPhPCSjbJ7gmoaksHpfDaDVVEMQTRA%2Bcq59SV2NBRsA00Ek8h73sBNP"
+        f"vw9JlcwNGn9gjbCUunt24ZRVvf3DEThYUZyv7Z2vInv5cbmZYbFd6bA8ahy%2FLFdq%2F6vQibao4iOJ1yeBZKEAaLsYzmXRuZJmg19LWWNBT"
+        f"siAiZqKLy%2Fn5fw6LCRAR%2B04GaL8kVpotN1sOh7tRBFedEqoJ3fAXnztdhlJZs2m4OFLg%3D%3D"
+    )
+
+    base_url = "/".join((kwargs.get("api_access_endpoint", ""), blob.bucket.name, blob.name))
+    return base_url + mock_signed_query_parameter

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -134,9 +134,16 @@ class AnalysisTestCase(BaseTestCase):
             with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
                 analysis.finalise(upload_output_datasets_to=f"gs://{TEST_BUCKET_NAME}/datasets")
 
-        self.assertTrue(storage.path.is_url(analysis.output_manifest.datasets["the_dataset"].path))
+        signed_url_for_dataset = analysis.output_manifest.datasets["the_dataset"].path
+        self.assertTrue(storage.path.is_url(signed_url_for_dataset))
 
-        downloaded_dataset = Dataset.from_cloud(analysis.output_manifest.datasets["the_dataset"].path)
+        self.assertTrue(
+            signed_url_for_dataset.startswith(
+                f"{self.test_result_modifier.storage_emulator_host}/{TEST_BUCKET_NAME}/datasets/the_dataset"
+            )
+        )
+
+        downloaded_dataset = Dataset.from_cloud(signed_url_for_dataset)
         self.assertEqual(downloaded_dataset.name, "the_dataset")
         self.assertEqual(len(downloaded_dataset.files), 1)
         self.assertEqual(downloaded_dataset.labels, {"one", "two", "three"})

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,9 +1,14 @@
 import logging
+import os
+import tempfile
 
+import twined.exceptions
+from octue.cloud import storage
+from octue.resources import Datafile, Dataset, Manifest
 from octue.resources.analysis import HASH_FUNCTIONS, Analysis
+from tests import TEST_BUCKET_NAME
+from tests.base import BaseTestCase
 from twined import Twine
-
-from ..base import BaseTestCase
 
 
 class AnalysisTestCase(BaseTestCase):
@@ -61,3 +66,77 @@ class AnalysisTestCase(BaseTestCase):
             "Attempted to send a monitor message but no handler is specified.",
             logging_context.output[0],
         )
+
+    def test_error_raised_if_output_fails_to_validate_against_twine_in_finalise(self):
+        """Test that an error is raised if the analysis output fails to validate against the twine."""
+        analysis = Analysis(
+            twine={
+                "output_values_schema": {
+                    "type": "object",
+                    "properties": {"blah": {"type": "integer"}},
+                    "required": ["blah"],
+                }
+            },
+            output_values={"wrong": "hello"},
+        )
+
+        with self.assertRaises(twined.exceptions.InvalidValuesContents):
+            analysis.finalise()
+
+    def test_finalise_validates_output(self):
+        """Test that the `finalise` method with no other arguments just validates the output manifest and values."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            dataset_path = os.path.join(temporary_directory, "the_dataset")
+
+            with Datafile(path=os.path.join(dataset_path, "my_file.dat"), mode="w") as (datafile, f):
+                f.write("hello")
+
+            output_manifest = Manifest(datasets={"the_dataset": Dataset(path=dataset_path, files={datafile.path})})
+
+            analysis = Analysis(
+                twine={
+                    "output_values_schema": {"type": "object", "properties": {"blah": {"type": "integer"}}},
+                    "output_manifest": {"datasets": {"the_dataset": {"purpose": "testing"}}},
+                },
+                output_values={"blah": 3},
+                output_manifest=output_manifest,
+            )
+
+            analysis.finalise()
+
+    def test_finalise_with_upload(self):
+        """Test that the `finalise` method can be used to upload the output manifest's datasets to a cloud location
+        and that it updates the manifest with signed URLs for accessing them.
+        """
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            dataset_path = os.path.join(temporary_directory, "the_dataset")
+
+            with Datafile(path=os.path.join(dataset_path, "my_file.dat"), mode="w") as (datafile, f):
+                f.write("hello")
+
+            output_manifest = Manifest(
+                datasets={
+                    "the_dataset": Dataset(path=dataset_path, files={datafile.path}, labels={"one", "two", "three"})
+                }
+            )
+
+            analysis = Analysis(
+                twine={
+                    "output_values_schema": {"type": "object", "properties": {"blah": {"type": "integer"}}},
+                    "output_manifest": {"datasets": {"the_dataset": {"purpose": "testing"}}},
+                },
+                output_values={"blah": 3},
+                output_manifest=output_manifest,
+            )
+
+            analysis.finalise(upload_output_datasets_to=f"gs://{TEST_BUCKET_NAME}/datasets")
+
+        self.assertTrue(storage.path.is_url(analysis.output_manifest.datasets["the_dataset"].path))
+
+        downloaded_dataset = Dataset.from_cloud(analysis.output_manifest.datasets["the_dataset"].path)
+        self.assertEqual(downloaded_dataset.name, "the_dataset")
+        self.assertEqual(len(downloaded_dataset.files), 1)
+        self.assertEqual(downloaded_dataset.labels, {"one", "two", "three"})
+
+        with downloaded_dataset.files.one() as (downloaded_datafile, f):
+            self.assertEqual(f.read(), "hello")

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+from unittest.mock import patch
 
 import twined.exceptions
 from octue.cloud import storage
@@ -8,6 +9,7 @@ from octue.resources import Datafile, Dataset, Manifest
 from octue.resources.analysis import HASH_FUNCTIONS, Analysis
 from tests import TEST_BUCKET_NAME
 from tests.base import BaseTestCase
+from tests.mocks import mock_generate_signed_url
 from twined import Twine
 
 
@@ -129,7 +131,8 @@ class AnalysisTestCase(BaseTestCase):
                 output_manifest=output_manifest,
             )
 
-            analysis.finalise(upload_output_datasets_to=f"gs://{TEST_BUCKET_NAME}/datasets")
+            with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
+                analysis.finalise(upload_output_datasets_to=f"gs://{TEST_BUCKET_NAME}/datasets")
 
         self.assertTrue(storage.path.is_url(analysis.output_manifest.datasets["the_dataset"].path))
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -181,6 +181,7 @@ class TestDatafile(BaseTestCase):
         self.assertEqual(first_file.hash_value, second_file.hash_value)
 
     def test_hash_of_cloud_datafile_avoids_downloading_file(self):
+        """Test that getting/calculating the hash of a cloud datafile avoids downloading its contents."""
         cloud_datafile, _ = self.create_datafile_in_cloud()
         datafile_reloaded_from_cloud = Datafile(path=cloud_datafile.cloud_path)
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -44,15 +44,13 @@ class TestDatafile(BaseTestCase):
 
     def create_datafile_in_cloud(
         self,
-        bucket_name=TEST_BUCKET_NAME,
-        path_in_bucket="cloud_file.txt",
+        cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "cloud_file.txt"),
         contents="some text",
         **kwargs,
     ):
         """Create a datafile in the cloud. Any metadata attributes can be set via kwargs.
 
-        :param str bucket_name:
-        :param str path_in_bucket:
+        :param str cloud_path:
         :param str contents:
         :return (octue.resources.datafile.Datafile, str):
         """
@@ -60,7 +58,7 @@ class TestDatafile(BaseTestCase):
             temporary_file.write(contents)
 
         datafile = Datafile(path=temporary_file.name, **kwargs)
-        datafile.to_cloud(cloud_path=storage.path.generate_gs_path(bucket_name, path_in_bucket))
+        datafile.to_cloud(cloud_path=cloud_path)
         return datafile, contents
 
     def test_instantiates(self):
@@ -599,9 +597,7 @@ class TestDatafile(BaseTestCase):
         cloud file as well as any local changes.
         """
         try:
-            datafile, original_contents = self.create_datafile_in_cloud(
-                bucket_name=TEST_BUCKET_NAME, path_in_bucket="cloud_file.txt"
-            )
+            datafile, original_contents = self.create_datafile_in_cloud()
             datafile.local_path = "blib.txt"
 
             self.assertEqual(datafile.cloud_path, storage.path.generate_gs_path(TEST_BUCKET_NAME, "cloud_file.txt"))

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -741,8 +741,11 @@ class TestDataset(BaseTestCase):
         downloaded_dataset = Dataset.from_cloud(cloud_path=signed_url)
         self.assertEqual(downloaded_dataset.tags, {"hello": "world"})
 
-        with downloaded_dataset.files.one() as (_, f):
+        with downloaded_dataset.files.one() as (downloaded_datafile, f):
             self.assertEqual(f.read(), "hello")
+
+        self.assertEqual(downloaded_datafile.name, "my-file.dat")
+        self.assertEqual(downloaded_datafile.extension, "dat")
 
     @classmethod
     def setUpClass(cls):

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -197,7 +197,7 @@ class TestDataset(BaseTestCase):
         resource = Dataset(files=files)
 
         # Check working for single result
-        self.assertIs(resource.get_file_by_label("three"), files[2])
+        self.assertEqual(resource.get_file_by_label("three").labels, files[2].labels)
 
         # Check raises for too many results
         with self.assertRaises(exceptions.UnexpectedNumberOfResultsException) as e:
@@ -218,7 +218,9 @@ class TestDataset(BaseTestCase):
             Datafile(path="path-within-dataset/a_test_file.txt"),
         ]
 
-        self.assertEqual(Dataset(files=files).files.filter(name__icontains="txt"), FilterSet({files[1]}))
+        self.assertEqual(
+            Dataset(files=files).files.filter(name__icontains="txt").pop().path, FilterSet({files[1]}).pop().path
+        )
 
     def test_filter_name_filters_exclude_path(self):
         """Ensures that filters applied to the name will not catch terms in the extension"""

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -60,27 +60,24 @@ class TestDataset(BaseTestCase):
         with self.assertRaises(exceptions.InvalidInputException):
             resource.add(NotADatafile())
 
-    def test_error_raised_if_adding_cloud_datafile_from_different_bucket_to_cloud_dataset(self):
-        """Test that an error is raised if attempting to add a cloud datafile to a cloud dataset from a different
-        bucket.
-        """
-        dataset = Dataset(path=storage.path.generate_gs_path("another-bucket", "path", "to", "dataset"))
-        datafile = Datafile(path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "datafile.dat"))
-
-        with self.assertRaises(exceptions.IncompatibleCloudLocations):
-            dataset.add(datafile)
-
     def test_adding_cloud_datafile_to_cloud_dataset(self):
-        """Test that a cloud datafile can be added to a cloud dataset if they're from the same bucket and that it keeps
-        its original path if no `path_within_dataset` is provided.
+        """Test that a cloud datafile can be added to a cloud dataset and that it keeps its original path if no
+        `path_within_dataset` is provided.
         """
         dataset = Dataset(path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "dataset"))
-        datafile = Datafile(path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "datafile.dat"))
+
+        with Datafile(path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "datafile.dat"), mode="w") as (
+            datafile,
+            f,
+        ):
+            f.write("hello")
+
         dataset.add(datafile)
 
         self.assertIn(datafile, dataset)
         self.assertEqual(
-            datafile.cloud_path, storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "datafile.dat")
+            datafile.cloud_path,
+            storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "datafile.dat"),
         )
 
     def test_providing_path_when_adding_cloud_datafile_to_cloud_dataset_copies_datafile_to_path(self):

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -67,7 +67,7 @@ class TestDataset(BaseTestCase):
 
     def test_adding_cloud_datafile_to_cloud_dataset_when_file_is_already_in_dataset_directory(self):
         """Test that a cloud datafile's path is kept as-is when adding it to a cloud dataset if it is already in the
-        dataset directory.
+        dataset directory and no `path_in_dataset` is provided.
         """
         dataset = Dataset(path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "path", "to", "dataset"))
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -12,6 +12,7 @@ from octue.resources.filter_containers import FilterSet
 from octue.utils.local_metadata import LOCAL_METADATA_FILENAME
 from tests import TEST_BUCKET_NAME
 from tests.base import BaseTestCase
+from tests.mocks import mock_generate_signed_url
 from tests.resources import create_dataset_with_two_files
 
 
@@ -732,7 +733,8 @@ class TestDataset(BaseTestCase):
 
             dataset.to_cloud(storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-dataset-to-sign"))
 
-        signed_url = dataset.generate_signed_url()
+        with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
+            signed_url = dataset.generate_signed_url()
 
         downloaded_dataset = Dataset.from_cloud(cloud_path=signed_url)
         self.assertEqual(downloaded_dataset.tags, {"hello": "world"})

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -397,9 +397,7 @@ class TestDataset(BaseTestCase):
         self.assertTrue(Dataset(files=files).all_files_are_in_cloud)
 
     def test_from_cloud(self):
-        """Test that a Dataset in cloud storage can be accessed via (`bucket_name`, `output_directory`) and via
-        `cloud_path`.
-        """
+        """Test that a Dataset in cloud storage can be accessed via a cloud path."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             dataset = create_dataset_with_two_files(temporary_directory)
             dataset.tags = {"a": "b", "c": 1}

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -84,16 +84,16 @@ class TestDataset(BaseTestCase):
 
     def test_add_single_file_to_empty_dataset(self):
         """Ensures that when a dataset is empty, it can be added to"""
-        resource = Dataset()
-        resource.add(Datafile(path="path-within-dataset/a_test_file.csv"))
-        self.assertEqual(len(resource.files), 1)
+        dataset = Dataset(path="dataset")
+        dataset.add(Datafile(path="path-within-dataset/a_test_file.csv"))
+        self.assertEqual(len(dataset.files), 1)
 
     def test_add_single_file_to_existing_dataset(self):
         """Ensures that when a dataset is not empty, it can be added to"""
         files = [Datafile(path="path-within-dataset/a_test_file.csv")]
-        resource = Dataset(files=files, labels="one two", tags={"a": "b"})
-        resource.add(Datafile(path="path-within-dataset/a_test_file.csv"))
-        self.assertEqual(len(resource.files), 2)
+        dataset = Dataset(path="dataset", files=files, labels="one two", tags={"a": "b"})
+        dataset.add(Datafile(path="path-within-dataset/a_test_file.csv"))
+        self.assertEqual(len(dataset.files), 2)
 
     def test_cannot_add_non_datafiles(self):
         """Ensures that exception will be raised if adding a non-datafile object"""

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -93,9 +93,7 @@ class TestManifest(BaseTestCase):
             self.assertEqual(persisted_manifest["datasets"]["my-dataset"], "gs://octue-test-bucket/my-small-dataset")
 
     def test_from_cloud(self):
-        """Test that a Manifest can be instantiated from the cloud via (`bucket_name`, `output_directory`) and via
-        `gs_path`.
-        """
+        """Test that a Manifest can be instantiated from a cloud path."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             dataset = create_dataset_with_two_files(temporary_directory)
             dataset_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "my_nice_dataset")

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -6,13 +6,14 @@ import sys
 import tempfile
 import unittest
 import uuid
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 from octue import REPOSITORY_ROOT, Runner
 from octue.resources.manifest import Manifest
 from octue.utils.processes import ProcessesContextManager
-
-from ..base import BaseTestCase
+from tests.base import BaseTestCase
+from tests.mocks import mock_generate_signed_url
 
 
 class TemplateAppsTestCase(BaseTestCase):
@@ -81,7 +82,8 @@ class TemplateAppsTestCase(BaseTestCase):
             output_manifest_path=os.path.join("data", "output", "manifest.json"),
         )
 
-        analysis = runner.run(input_manifest=os.path.join("data", "input", "manifest.json"))
+        with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
+            analysis = runner.run(input_manifest=os.path.join("data", "input", "manifest.json"))
 
         # Check that the output files have been created.
         self.assertTrue(os.path.isfile(os.path.join("cleaned_met_mast_data", "cleaned.csv")))

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -68,8 +68,7 @@ class TemplateAppsTestCase(BaseTestCase):
             output_manifest_path=os.path.join("data", "output", "manifest.json"),
         )
 
-        analysis = runner.run()
-        analysis.finalise(output_dir=os.path.join("data", "output"))
+        runner.run()
 
     def test_using_manifests(self):
         """Ensure the `using-manifests` template app works correctly."""
@@ -168,6 +167,5 @@ class TemplateAppsTestCase(BaseTestCase):
                     input_values=os.path.join(parent_service_path, "data", "input", "values.json"),
                 )
 
-        analysis.finalise()
         self.assertTrue("elevations" in analysis.output_values)
         self.assertTrue("wind_speeds" in analysis.output_values)

--- a/tests/templates/test_template_apps.py
+++ b/tests/templates/test_template_apps.py
@@ -66,7 +66,6 @@ class TemplateAppsTestCase(BaseTestCase):
             app_src=self.template_path,
             twine=self.template_twine,
             configuration_values=os.path.join("data", "configuration", "configuration_values.json"),
-            output_manifest_path=os.path.join("data", "output", "manifest.json"),
         )
 
         runner.run()
@@ -79,7 +78,6 @@ class TemplateAppsTestCase(BaseTestCase):
             app_src=self.template_path,
             twine=self.template_twine,
             configuration_values=os.path.join("data", "configuration", "values.json"),
-            output_manifest_path=os.path.join("data", "output", "manifest.json"),
         )
 
         with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,52 +38,46 @@ class TestCLI(BaseTestCase):
 class TestRunCommand(BaseTestCase):
     def test_run(self):
         """Test that an arbitrary run command can be used in the run command of the CLI."""
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            result = CliRunner().invoke(
-                octue_cli,
-                [
-                    "run",
-                    f"--app-dir={os.path.join(TESTS_DIR, 'test_app_modules', 'app_module')}",
-                    f"--twine={TWINE_FILE_PATH}",
-                    f'--config-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "configuration")}',
-                    f'--input-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "input")}',
-                    f"--output-dir={temporary_directory}",
-                ],
-            )
+        result = CliRunner().invoke(
+            octue_cli,
+            [
+                "run",
+                f"--app-dir={os.path.join(TESTS_DIR, 'test_app_modules', 'app_module')}",
+                f"--twine={TWINE_FILE_PATH}",
+                f'--config-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "configuration")}',
+                f'--input-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests", "input")}',
+            ],
+        )
 
         assert CUSTOM_APP_RUN_MESSAGE in result.output
 
     def test_run_with_data_dir(self):
         """Test that the run command of the CLI works with the --data-dir option."""
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            result = CliRunner().invoke(
-                octue_cli,
-                [
-                    "run",
-                    f"--app-dir={os.path.join(TESTS_DIR, 'test_app_modules', 'app_module')}",
-                    f"--twine={TWINE_FILE_PATH}",
-                    f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
-                    f"--output-dir={temporary_directory}",
-                ],
-            )
+        result = CliRunner().invoke(
+            octue_cli,
+            [
+                "run",
+                f"--app-dir={os.path.join(TESTS_DIR, 'test_app_modules', 'app_module')}",
+                f"--twine={TWINE_FILE_PATH}",
+                f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
+            ],
+        )
 
         assert CUSTOM_APP_RUN_MESSAGE in result.output
 
     def test_remote_logger_uri_can_be_set(self):
         """Test that remote logger URI can be set via the CLI and that this is logged locally."""
-        with tempfile.TemporaryDirectory() as temporary_directory:
-            with mock.patch("logging.StreamHandler.emit") as mock_local_logger_emit:
-                CliRunner().invoke(
-                    octue_cli,
-                    [
-                        "--logger-uri=wss://0.0.0.1:3000",
-                        "run",
-                        f"--app-dir={TESTS_DIR}",
-                        f"--twine={TWINE_FILE_PATH}",
-                        f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
-                        f"--output-dir={temporary_directory}",
-                    ],
-                )
+        with mock.patch("logging.StreamHandler.emit") as mock_local_logger_emit:
+            CliRunner().invoke(
+                octue_cli,
+                [
+                    "--logger-uri=wss://0.0.0.1:3000",
+                    "run",
+                    f"--app-dir={TESTS_DIR}",
+                    f"--twine={TWINE_FILE_PATH}",
+                    f'--data-dir={os.path.join(TESTS_DIR, "data", "data_dir_with_no_manifests")}',
+                ],
+            )
 
             mock_local_logger_emit.assert_called()
 


### PR DESCRIPTION
## Summary
Improve the interactions of datafiles with datasets and make output datasets available in the cloud via expiring signed URLs after `Analysis.finalise` has been called.

## Contents (https://github.com/octue/octue-sdk-python/pull/416)
IMPORTANT: There are 3 breaking changes.

### New features
- Add the ability to generate expiring signed URLs for datasets and their datafiles
- Add the ability to instantiate datasets and datafiles from signed URLs instead of cloud paths

### Enhancements
- **BREAKING CHANGE:** Re-engineer `Dataset.add` so that datafiles are actually copied/uploaded/downloaded to the dataset when adding them
- **BREAKING CHANGE:** Re-engineer `Analysis.finalise` to:
  - Provide signed URLs for uploaded datasets if a cloud path to a directory is provided
  - Not support local data persistence
- **BREAKING CHANGE:** Remove redundant concepts of `output_dir` and output manifest path
- Add `Datafile.cloud_hash` and `Datafile.extension` properties
- Add `Dataset.bucket_name` and `Dataset.path_in_bucket` properties
- Add `Dataset.__contains__` method
- Avoid downloading cloud datafiles to determine their cloud hash values
- Multithread dataset and datafile instantiations/metadata-gathering in `Manifest` and `Dataset`
- Copy local datafiles to their new paths when setting their `local_path` properties
- Add `is_url` and `is_cloud_path` functions to `octue.cloud.storage.path`

### Fixes
- Set default `Dataset` path to the current working directory
- When calling `Datafile.to_cloud`, allow uploading of the file if nothing exists at the given cloud path
- Calculate relative path of datafile to dataset properly in `Dataset.to_cloud`
- Raise errors from threads used for concurrent download/upload of data/metadata from the cloud
- Call `Analysis.finalise` inside the template apps
- Create directories if missing when setting datafile local path 

### Dependencies
- Use the latest `twined` version, allowing datasets to be optional if specified in `twine.json`
- Loosen the dependency on `twined` to allow freedom in the patch versions of the current minor version

### Refactoring
- Reduce repetition and improve getting of buckets in `GoogleCloudStorageClient`
- Replace `GoogleCloudStorageClient._create_intermediate_local_directories` with proper usage of `os.makedirs`
- Simplify `Manifest._instantiate_dataset` and remove support for datasets with no explicit path

### Testing
- Test calculation/getting of datafile hash values
- Create and use a mock for generating signed URLs to avoid the limitations of workload identity federation in CI testing

<!--- SKIP AUTOGENERATED NOTES --->