### PR TITLE
Support push subscriptions for Pub/Sub services

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -189,6 +189,7 @@ class Service(CoolNameable):
         subscribe_to_logs=True,
         allow_local_files=False,
         question_uuid=None,
+        push_endoint=None,
         timeout=30,
     ):
         """Ask a serving Service a question (i.e. send it input values for it to run its app on). The input values must
@@ -202,6 +203,7 @@ class Service(CoolNameable):
         :param bool subscribe_to_logs: if `True`, subscribe to logs from the remote service and handle them with the local log handlers
         :param bool allow_local_files: if `True`, allow the input manifest to contain references to local files - this should only be set to `True` if the serving service will have access to these local files
         :param str|None question_uuid: the UUID to use for the question if a specific one is needed; a UUID is generated if not
+        :param str|None push_endpoint: if answers to the question should be pushed to an endpoint, provide its URL here; if they should be pulled, leave this as `None`
         :param float|None timeout: time in seconds to keep retrying sending the question
         :return (octue.cloud.pub_sub.subscription.Subscription, str): the response subscription and question UUID
         """
@@ -235,6 +237,7 @@ class Service(CoolNameable):
             namespace=OCTUE_NAMESPACE,
             project_name=self.backend.project_name,
             subscriber=pubsub_v1.SubscriberClient(credentials=self._credentials),
+            push_endpoint=push_endoint,
         )
         response_subscription.create(allow_existing=True)
 
@@ -285,6 +288,11 @@ class Service(CoolNameable):
         :raise TimeoutError: if the timeout is exceeded
         :return dict: dictionary containing the keys "output_values" and "output_manifest"
         """
+        if subscription.is_push_subscription:
+            raise octue.exceptions.PushSubscriptionCannotBePulled(
+                f"Cannot pull from {subscription.path!r} subscription as it is a push subscription."
+            )
+
         subscriber = pubsub_v1.SubscriberClient(credentials=self._credentials)
 
         message_handler = OrderedMessageHandler(

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -108,3 +108,7 @@ class DeploymentError(OctueSDKException):
 
 class CloudStorageBucketNotFound(OctueSDKException):
     """Raise if attempting to access a cloud storage bucket that cannot be found."""
+
+
+class PushSubscriptionCannotBePulled(OctueSDKException):
+    """Raise if attempting to pull a push subscription."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.17.0"
+version = "0.18.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -243,6 +243,7 @@ class MockService(Service):
         subscribe_to_logs=True,
         allow_local_files=False,
         question_uuid=None,
+        push_endpoint=None,
         timeout=30,
     ):
         """Put the question into the messages register, register the existence of the corresponding response topic, add
@@ -253,17 +254,20 @@ class MockService(Service):
         :param octue.resources.manifest.Manifest|None input_manifest:
         :param bool subscribe_to_logs:
         :param bool allow_local_files:
+        :param str|None question_uuid:
+        :param str|None push_endpoint:
         :param float|None timeout:
         :return MockFuture, str:
         """
         response_subscription, question_uuid = super().ask(
-            service_id,
-            input_values,
-            input_manifest,
-            subscribe_to_logs,
-            allow_local_files,
-            question_uuid,
-            timeout,
+            service_id=service_id,
+            input_values=input_values,
+            input_manifest=input_manifest,
+            subscribe_to_logs=subscribe_to_logs,
+            allow_local_files=allow_local_files,
+            question_uuid=question_uuid,
+            push_endoint=push_endpoint,
+            timeout=timeout,
         )
 
         # Ignore any errors from the answering service as they will be raised on the remote service in practice, not

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -175,6 +175,22 @@ class TestService(BaseTestCase):
             with self.assertRaises(TimeoutError):
                 service.wait_for_answer(subscription=mock_subscription, timeout=0.01)
 
+    def test_error_raised_if_attempting_to_wait_for_answer_from_push_subscription(self):
+        """Test that an error is raised if attempting to wait for an answer from a push subscription."""
+        service = Service(backend=BACKEND)
+
+        mock_subscription = MockSubscription(
+            name="world",
+            topic=MockTopic(name="world", namespace="hello", service=service),
+            namespace="hello",
+            project_name=TEST_PROJECT_NAME,
+            subscriber=MockSubscriber(),
+            push_endpoint="https://example.com/endpoint",
+        )
+
+        with self.assertRaises(exceptions.PushSubscriptionCannotBePulled):
+            service.wait_for_answer(subscription=mock_subscription)
+
     def test_exceptions_in_responder_are_handled_and_sent_to_asker(self):
         """Test that exceptions raised in the responding service are handled and sent back to the asker."""
         responding_service = self.make_responding_service_with_error(

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -85,6 +85,7 @@ class TestService(BaseTestCase):
         allow_local_files=False,
         service_name="my-service",
         question_uuid=None,
+        push_endpoint=None,
         timeout=30,
         delivery_acknowledgement_timeout=30,
     ):
@@ -98,13 +99,14 @@ class TestService(BaseTestCase):
         :return dict:
         """
         subscription, _ = asking_service.ask(
-            responding_service.id,
-            input_values,
-            input_manifest,
-            subscribe_to_logs,
-            allow_local_files,
-            question_uuid,
-            timeout,
+            service_id=responding_service.id,
+            input_values=input_values,
+            input_manifest=input_manifest,
+            subscribe_to_logs=subscribe_to_logs,
+            allow_local_files=allow_local_files,
+            question_uuid=question_uuid,
+            push_endpoint=push_endpoint,
+            timeout=timeout,
         )
 
         return asking_service.wait_for_answer(


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#419](https://github.com/octue/octue-sdk-python/pull/419))

### New features
- Support push subscriptions for Google Pub/Sub services, allowing answers to be pushed to an HTTP endpoint

### Enhancements
- Add `push_endpoint` parameter to `Subscription` constructor
- Add  `is_pull_subscription` and `is_push_subscription` properties to `Subscription`

### Testing
- Switch to parent/child language in `Service` tests for greater clarity/consistency

<!--- END AUTOGENERATED NOTES --->