### PR TITLE
Add service-differentiating colours to logs

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,0 +1,43 @@
+# ATTRIBUTIONS
+
+In addition to some modules of our own, `octue-sdk-python` is based on a collection of other projects
+that we've drawn together, patched, enhanced and documented.
+
+The nature of OSS is to stand on the shoulders of giants, and we owe them a tonne... here are their licenses:
+
+## `rgb2ansi`
+
+<details>
+  <summary>Show license</summary>
+
+**BSD 3-Clause License**
+
+Copyright (c) Bruno Renié and contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name of rgb2ansi nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+</details>

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -2,4 +2,12 @@
 License
 =======
 
-See LICENSE text file in the source code root directory.
+The Boring Bit
+==============
+
+See `the octue-sdk-python license <https://github.com/octue/octue-sdk-python/blob/main/LICENSE>`_.
+
+Third Party Libraries
+=====================
+
+**octue-sdk-python** includes or is linked against code from third party libraries - see `our attributions page <https://github.com/octue/octue-sdk-python/blob/main/ATTRIBUTIONS.md>`_.

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -20,13 +20,6 @@ from octue.runner import Runner
 from twined import Twine
 
 
-# Import the Dataflow deployer only if the `apache-beam` package is available (due to installing `octue` with the
-# `dataflow` extras option).
-APACHE_BEAM_PACKAGE_AVAILABLE = bool(importlib.util.find_spec("apache_beam"))
-
-if APACHE_BEAM_PACKAGE_AVAILABLE:
-    from octue.cloud.deployment.google.dataflow.deployer import DataflowDeployer
-
 logger = logging.getLogger(__name__)
 
 global_cli_context = {}
@@ -270,7 +263,11 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
 @click.option("--image-uri", type=str, default=None, help="The actual image URI to use when creating the Dataflow job.")
 def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_job_only, image_uri):
     """Deploy an app as a Google Dataflow streaming job."""
-    if not APACHE_BEAM_PACKAGE_AVAILABLE:
+    if bool(importlib.util.find_spec("apache_beam")):
+        # Import the Dataflow deployer only if the `apache-beam` package is available (due to installing `octue` with
+        # the `dataflow` extras option).
+        from octue.cloud.deployment.google.dataflow.deployer import DataflowDeployer
+    else:
         raise ImportWarning(
             "To use this CLI command, you must install `octue` with the `dataflow` option e.g. "
             "`pip install octue[dataflow]`"

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -57,7 +57,7 @@ class OrderedMessageHandler:
             "result": self._handle_result,
         }
 
-        self._log_message_colour = random.choice([COLOUR_PALETTE[1], COLOUR_PALETTE[3:]])
+        self._log_message_colour = random.choice([COLOUR_PALETTE[1], *COLOUR_PALETTE[3:]])
 
     def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=30):
         """Pull messages and handle them in the order they were sent until a result is returned by a message handler,

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -1,12 +1,15 @@
 import json
 import logging
+import random
 import time
 
 from google.api_core import retry
 
 import octue.exceptions
 import twined.exceptions
+from octue.log_handlers import COLOUR_PALETTE
 from octue.resources.manifest import Manifest
+from octue.utils.colour import colourise
 from octue.utils.exceptions import create_exceptions_mapping
 
 
@@ -53,6 +56,8 @@ class OrderedMessageHandler:
             "exception": self._handle_exception,
             "result": self._handle_result,
         }
+
+        self._log_message_colour = random.choice(COLOUR_PALETTE)
 
     def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=30):
         """Pull messages and handle them in the order they were sent until a result is returned by a message handler,
@@ -194,7 +199,12 @@ class OrderedMessageHandler:
         :return None:
         """
         record = logging.makeLogRecord(message["log_record"])
-        record.msg = f"[{self.service_name} | analysis-{message['analysis_id']}] {record.msg}"
+
+        record.msg = (
+            colourise(f"[{self.service_name} | analysis-{message['analysis_id']}]", foreground=self._log_message_colour)
+            + f" {record.msg}"
+        )
+
         logger.handle(record)
 
     def _handle_exception(self, message):

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -201,7 +201,10 @@ class OrderedMessageHandler:
         record = logging.makeLogRecord(message["log_record"])
 
         record.msg = (
-            colourise(f"[{self.service_name} | analysis-{message['analysis_id']}]", foreground=self._log_message_colour)
+            colourise(
+                f"[{self.service_name} | analysis-{message['analysis_id']}]",
+                text_colour=self._log_message_colour,
+            )
             + f" {record.msg}"
         )
 

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -57,7 +57,7 @@ class OrderedMessageHandler:
             "result": self._handle_result,
         }
 
-        self._log_message_colour = random.choice(COLOUR_PALETTE[2:])
+        self._log_message_colour = random.choice([COLOUR_PALETTE[1], COLOUR_PALETTE[3:]])
 
     def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=30):
         """Pull messages and handle them in the order they were sent until a result is returned by a message handler,

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -57,7 +57,7 @@ class OrderedMessageHandler:
             "result": self._handle_result,
         }
 
-        self._log_message_colour = random.choice(COLOUR_PALETTE)
+        self._log_message_colour = random.choice(COLOUR_PALETTE[2:])
 
     def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=30):
         """Pull messages and handle them in the order they were sent until a result is returned by a message handler,

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -45,7 +45,7 @@ def create_octue_formatter(
             " ".join(
                 colourise(
                     "[" + " | ".join(attributes_section) + "]",
-                    foreground=COLOUR_PALETTE[2],
+                    text_colour=COLOUR_PALETTE[2],
                 )
                 for attributes_section in log_record_attributes[1:]
             )
@@ -59,7 +59,7 @@ def create_octue_formatter(
             [
                 colourise(
                     "[" + " | ".join(log_record_attributes[0] + extra_attributes) + "]",
-                    foreground=COLOUR_PALETTE[0],
+                    text_colour=COLOUR_PALETTE[0],
                 ),
                 *extra_sections,
                 colourise("%(message)s"),

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -85,6 +85,10 @@ def apply_log_handler(
     logger = logger or logging.getLogger(name=logger_name)
     handler = handler or logging.StreamHandler()
 
+    for existing_handler in logger.handlers:
+        if type(existing_handler).__name__ == "StreamHandler" and type(handler).__name__ == "StreamHandler":
+            logger.removeHandler(existing_handler)
+
     if formatter is None:
         formatter = create_octue_formatter(
             get_log_record_attributes_for_environment(),

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -25,7 +25,7 @@ def create_octue_formatter(
     attributes are `["%(asctime)s", "%(levelname)s", "%(name)s"]`, the formatter would format log messages as e.g.
     `[2021-06-29 11:58:10,985 | INFO | octue.runner] This is a log message.`
 
-    :param iter(str) log_record_attributes: an iterable of log record attribute names to use as context for every log message that the formatter is applied to
+    :param log_record_attributes: any number of iterables of log record attribute names to use as context for every log message that the formatter is applied to; each iterable is interpreted as a different section by the formatter
     :param bool include_line_number: if `True`, include the line number in the log context
     :param bool include_process_name: if `True`, include the process name in the log context
     :param bool include_thread_name: if `True`, include the thread name in the log context

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -40,6 +40,20 @@ def create_octue_formatter(
     if include_thread_name:
         extra_attributes.append("%(threadName)s")
 
+    if len(log_record_attributes) > 1:
+        extra_sections = [
+            " ".join(
+                colourise(
+                    "[" + " | ".join(attributes_section) + "]",
+                    foreground=COLOUR_PALETTE[2],
+                )
+                for attributes_section in log_record_attributes[1:]
+            )
+        ]
+
+    else:
+        extra_sections = []
+
     return logging.Formatter(
         " ".join(
             [
@@ -47,13 +61,7 @@ def create_octue_formatter(
                     "[" + " | ".join(log_record_attributes[0] + extra_attributes) + "]",
                     foreground=COLOUR_PALETTE[0],
                 ),
-                " ".join(
-                    colourise(
-                        "[" + " | ".join(attributes_section) + "]",
-                        foreground=COLOUR_PALETTE[1],
-                    )
-                    for attributes_section in log_record_attributes[1:]
-                ),
+                *extra_sections,
                 colourise("%(message)s"),
             ]
         )

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -10,8 +10,8 @@ from octue.utils.colour import colourise
 LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP = ["%(asctime)s", "%(levelname)s", "%(name)s"]
 LOG_RECORD_ATTRIBUTES_WITHOUT_TIMESTAMP = LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP[1:]
 
-# "tab10" colours from Seaborn.
-COLOUR_PALETTE = ["1f77b4", "ff7f0e", "2ca02c", "d62728", "9467bd", "8c564b", "e377c2", "7f7f7f", "bcbd22", "17becf"]
+# "colorblind" colour palette from seaborn/matplotlib.
+COLOUR_PALETTE = ["0173b2", "de8f05", "029e73", "d55e00", "cc78bc", "ca9161", "fbafe4", "949494", "ece133", "56b4e9"]
 DEFAULT_FOREGROUND_COLOUR = COLOUR_PALETTE[0]
 
 

--- a/octue/log_handlers.py
+++ b/octue/log_handlers.py
@@ -3,10 +3,16 @@ import logging.handlers
 import os
 from urllib.parse import urlparse
 
+from octue.utils.colour import colourise
+
 
 # Logging format for analysis runs. All handlers should use this logging format to make logs consistently parseable.
 LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP = ["%(asctime)s", "%(levelname)s", "%(name)s"]
 LOG_RECORD_ATTRIBUTES_WITHOUT_TIMESTAMP = LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP[1:]
+
+# "tab10" colours from Seaborn.
+COLOUR_PALETTE = ["1f77b4", "ff7f0e", "2ca02c", "d62728", "9467bd", "8c564b", "e377c2", "7f7f7f", "bcbd22", "17becf"]
+DEFAULT_FOREGROUND_COLOUR = COLOUR_PALETTE[0]
 
 
 def create_octue_formatter(
@@ -35,7 +41,13 @@ def create_octue_formatter(
     if include_thread_name:
         extra_attributes.append("%(threadName)s")
 
-    return logging.Formatter("[" + " | ".join(log_record_attributes + extra_attributes) + "]" + " %(message)s")
+    return logging.Formatter(
+        colourise(
+            "[" + " | ".join(log_record_attributes + extra_attributes) + "]",
+            foreground=DEFAULT_FOREGROUND_COLOUR,
+        )
+        + colourise(" %(message)s")
+    )
 
 
 def apply_log_handler(

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -327,8 +327,10 @@ class AnalysisLogHandlerSwitcher:
         self._remove_log_handlers()
 
         # Add the analysis ID to the logging metadata.
-        log_record_attributes = get_log_record_attributes_for_environment() + [f"analysis-{self.analysis_id}"]
-        formatter = create_octue_formatter(log_record_attributes=log_record_attributes)
+        formatter = create_octue_formatter(
+            get_log_record_attributes_for_environment(),
+            [f"analysis-{self.analysis_id}"],
+        )
 
         # Apply a local console `StreamHandler` to the logger.
         apply_log_handler(formatter=formatter, log_level=self.analysis_log_level)

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -119,13 +119,18 @@ class Runner:
 
         analysis_id = str(analysis_id) if analysis_id else gen_uuid()
 
+        if analysis_log_handler:
+            extra_log_handlers = [analysis_log_handler]
+        else:
+            extra_log_handlers = None
+
         # Temporarily replace the root logger's handlers with a `StreamHandler` and the analysis log handler that
         # include the analysis ID in the logging metadata.
         with AnalysisLogHandlerSwitcher(
             analysis_id=analysis_id,
             logger=logging.getLogger(),
             analysis_log_level=analysis_log_level,
-            extra_log_handlers=[analysis_log_handler],
+            extra_log_handlers=extra_log_handlers,
         ):
 
             analysis = Analysis(

--- a/octue/utils/colour.py
+++ b/octue/utils/colour.py
@@ -1,3 +1,5 @@
+# The functions in this module were based on https://github.com/brutasse/rgb2ansi.
+
 import binascii
 
 

--- a/octue/utils/colour.py
+++ b/octue/utils/colour.py
@@ -30,10 +30,10 @@ def _convert_colour_to_ansi(colour):
     if isinstance(colour, bytes):
         colour = list(map(int, colour))
 
-    red, green, blue = list(map(_round_color, colour))
+    red, green, blue = list(map(_round_colour, colour))
     return 16 + 36 * red + 6 * green + blue
 
 
-def _round_color(colour):
+def _round_colour(colour):
     quot = 255 / 5
     return round(colour / quot)

--- a/octue/utils/colour.py
+++ b/octue/utils/colour.py
@@ -4,22 +4,34 @@ import binascii
 WHITE = "ffffff"
 
 
-def round_color(h):
-    quot = 255 / 5
-    return round(h / quot)
+def colourise(string, text_colour=WHITE, background_colour=None):
+    """Colour in a string with the given text colour and, optionally, background colour.
+
+    :param str string: the string to colourise
+    :param str text_colour: the hex representation of the text colour
+    :param str|None background_colour: the hex representation of the background colour
+    :return str: the colourised string
+    """
+    text_colour = _convert_colour_to_ansi(text_colour)
+
+    if not background_colour:
+        return f"\x1b[38;5;{text_colour}m{string}\x1b[0m"
+
+    background_colour = _convert_colour_to_ansi(background_colour)
+    return f"\x1b[38;5;{text_colour};48;5;{background_colour}m{string}\x1b[0m"
 
 
-def ansi(rgb):
-    if isinstance(rgb, str):
-        rgb = binascii.a2b_hex(rgb)
-    if isinstance(rgb, bytes):
-        rgb = list(map(int, rgb))
-    red, green, blue = list(map(round_color, rgb))
+def _convert_colour_to_ansi(colour):
+    if isinstance(colour, str):
+        colour = binascii.a2b_hex(colour)
+
+    if isinstance(colour, bytes):
+        colour = list(map(int, colour))
+
+    red, green, blue = list(map(_round_color, colour))
     return 16 + 36 * red + 6 * green + blue
 
 
-def colourise(s, foreground=WHITE, background=None):
-    if not background:
-        return f"\x1b[38;5;{ansi(foreground)}m{s}\x1b[0m"
-
-    return f"\x1b[38;5;{ansi(foreground)};48;5;{ansi(background)}m{s}\x1b[0m"
+def _round_color(colour):
+    quot = 255 / 5
+    return round(colour / quot)

--- a/octue/utils/colour.py
+++ b/octue/utils/colour.py
@@ -1,0 +1,25 @@
+import binascii
+
+
+WHITE = "ffffff"
+
+
+def round_color(h):
+    quot = 255 / 5
+    return round(h / quot)
+
+
+def ansi(rgb):
+    if isinstance(rgb, str):
+        rgb = binascii.a2b_hex(rgb)
+    if isinstance(rgb, bytes):
+        rgb = list(map(int, rgb))
+    red, green, blue = list(map(round_color, rgb))
+    return 16 + 36 * red + 6 * green + blue
+
+
+def colourise(s, foreground=WHITE, background=None):
+    if not background:
+        return f"\x1b[38;5;{ansi(foreground)}m{s}\x1b[0m"
+
+    return f"\x1b[38;5;{ansi(foreground)};48;5;{ansi(background)}m{s}\x1b[0m"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.19.0"
+version = "0.20.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -364,12 +364,12 @@ class TestService(BaseTestCase):
         finish_remote_analysis_message_present = False
 
         for i, log_record in enumerate(logs_context_manager.records):
-            if "[my-super-service" in log_record.msg and "] Starting analysis." in log_record.msg:
+            if "[my-super-service" in log_record.msg and "Starting analysis." in log_record.msg:
                 start_remote_analysis_message_present = True
 
                 if (
                     "[my-super-service" in logs_context_manager.records[i + 1].msg
-                    and "] Finished analysis." in logs_context_manager.records[i + 1].msg
+                    and "Finished analysis." in logs_context_manager.records[i + 1].msg
                 ):
                     finish_remote_analysis_message_present = True
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,7 +167,7 @@ class TestDeployCommand(BaseTestCase):
         """Test that an `ImportWarning` is raised if the `dataflow deploy` CLI command is used when `apache_beam` is
         not available.
         """
-        with mock.patch("octue.cli.APACHE_BEAM_PACKAGE_AVAILABLE", False):
+        with mock.patch("importlib.util.find_spec", return_value=None):
             with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
                 result = CliRunner().invoke(
                     octue_cli,

--- a/tests/test_log_handlers.py
+++ b/tests/test_log_handlers.py
@@ -22,7 +22,7 @@ class TestLogging(BaseTestCase):
                 importlib.reload(sys.modules["octue"])
 
         create_octue_formatter.assert_called_with(
-            log_record_attributes=LOG_RECORD_ATTRIBUTES_WITHOUT_TIMESTAMP,
+            LOG_RECORD_ATTRIBUTES_WITHOUT_TIMESTAMP,
             include_line_number=False,
             include_process_name=False,
             include_thread_name=False,
@@ -37,7 +37,7 @@ class TestLogging(BaseTestCase):
                 importlib.reload(sys.modules["octue"])
 
         create_octue_formatter.assert_called_with(
-            log_record_attributes=LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP,
+            LOG_RECORD_ATTRIBUTES_WITH_TIMESTAMP,
             include_line_number=False,
             include_process_name=False,
             include_thread_name=False,


### PR DESCRIPTION
## Summary
Add colour to the SDK's log messages that differentiate the following three things from each other:
- The basic log attributes (e.g. module name and log level)
- The analysis ID
- Log messages from any number of levels of children

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#430](https://github.com/octue/octue-sdk-python/pull/430))

### New features
- Add service-differentiating colours to logs using the `seaborn` colourblind palette

### Enhancements
- Separate analysis ID into its own section in the logs

### Fixes
- Avoid adding `None` as a log handler in `Runner`
- Only allow one `StreamHandler` to be applied to the logger at once in `apply_log_handler`

### Dependencies
- Only attempt `DataflowDeployer` import inside `dataflow deploy` CLI command

### Other
- Add an `ATTRIBUTION.md` file

<!--- END AUTOGENERATED NOTES --->