### PR TITLE
Add Datafile parameter for ignoring stored metadata

### DIFF
--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -128,12 +128,16 @@ class GoogleCloudStorageClient:
 
         :param str|None cloud_path: full cloud path to file (e.g. `gs://bucket_name/path/to/file.csv`)
         :param float timeout: time in seconds to allow for the request to complete
-        :return dict:
+        :return dict|None: `None` if the bucket or file don't exist
         """
         if not cloud_path:
             cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, path_in_bucket)
 
-        bucket, path_in_bucket = self._get_bucket_and_path_in_bucket(cloud_path)
+        try:
+            bucket, path_in_bucket = self._get_bucket_and_path_in_bucket(cloud_path)
+        except CloudStorageBucketNotFound:
+            return None
+
         blob = bucket.get_blob(blob_name=self._strip_leading_slash(path_in_bucket), timeout=timeout)
 
         if blob is None:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -596,9 +596,9 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         if "id" in datafile_metadata:
             self._set_id(datafile_metadata["id"])
 
-        for parameter in ("timestamp", "tags", "labels"):
-            if parameter in datafile_metadata:
-                setattr(self, parameter, datafile_metadata[parameter])
+        for attribute in ("timestamp", "tags", "labels"):
+            if attribute in datafile_metadata:
+                setattr(self, attribute, datafile_metadata[attribute])
 
     def _update_local_metadata(self):
         """Create or update the local octue metadata file with the datafile's metadata.

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -89,6 +89,8 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
                 category=DeprecationWarning,
             )
 
+            ignore_stored_metadata = kwargs["hypothetical"]
+
         super().__init__(
             id=id,
             name=kwargs.pop("name", None),

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -37,20 +37,19 @@ OCTUE_METADATA_NAMESPACE = "octue"
 
 
 class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filterable):
-    """A representation of a data file on the Octue system. If the given path is a cloud path, the datafile's metadata
-    is pulled from the given cloud location, and any conflicting parameters (see the `Datafile.metadata` method
-    description for the parameter names concerned) are ignored. The metadata of cloud datafiles can be changed using
-    the `Datafile.update_metadata` method, but not during instantiation.
+    """A representation of a data file on the Octue system. Metadata for the file is obtained from its corresponding
+    cloud object or a local `.octue` metadata file, if present. If no stored metadata is available, it can be set during
+    or after instantiation.
 
     :param str|None path: The path of this file locally or in the cloud, which may include folders or subfolders, within the dataset
     :param str|None local_path: If a cloud path is given as the `path` parameter, this is the path to an existing local file that is known to be in sync with the cloud object
     :param str|None cloud_path: If a local path is given for the `path` parameter, this is a cloud path to keep in sync with the local file
     :param datetime.datetime|int|float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when it was created but could relate to a relevant time point for the data
     :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
-    :param dict|TagDict tags: key-value pairs with string keys conforming to the Octue tag format (see TagDict)
-    :param iter(str) labels: Space-separated string of labels relevant to this file
+    :param dict|octue.resources.tag.TagDict|None tags: key-value pairs with string keys conforming to the Octue tag format (see TagDict)
+    :param iter(str)|octue.resources.label.LabelSet|None labels: Space-separated string of labels relevant to this file
     :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin open function)
-    :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of the datafile when the context is exited
+    :param bool update_cloud_metadata: if using as a context manager and this is `True`, update the cloud metadata of the datafile when the context is exited
     :param bool ignore_stored_metadata: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
     :return None:
     """

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -12,6 +12,9 @@ import google.api_core.exceptions
 import pkg_resources
 from google_crc32c import Checksum
 
+from octue.resources.label import LabelSet
+from octue.resources.tag import TagDict
+
 
 try:
     import h5py
@@ -101,10 +104,10 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             logger.debug("Ignored stored metadata for %r.", self)
         else:
             if self.metadata(use_octue_namespace=False, include_sdk_version=False) != {
-                "id": id,
+                "id": id or self.id,
                 "timestamp": timestamp,
-                "tags": tags,
-                "labels": labels,
+                "tags": TagDict(tags),
+                "labels": LabelSet(labels),
             }:
                 logger.warning(
                     "Overriding metadata given at instantiation with stored metadata for %r - set `hypothetical` to "

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -552,7 +552,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         self._local_path = os.path.abspath(path)
 
         if not ignore_stored_metadata:
-            self._get_local_metadata()
+            self._use_local_metadata()
 
         if cloud_path:
             self.cloud_path = cloud_path
@@ -580,12 +580,16 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             self._cloud_metadata = cloud_metadata
 
     def _use_cloud_metadata(self):
-        """Update the datafile's metadata from the metadata of the cloud object located at its path.
+        """Update the datafile's metadata from the metadata of the cloud object located at its path. If no metadata is
+        stored for the datafile, do nothing.
 
         :return None:
         """
         self._get_cloud_metadata()
         cloud_custom_metadata = self._cloud_metadata.get("custom_metadata", {})
+
+        if not cloud_custom_metadata:
+            return
 
         if "id" in cloud_custom_metadata:
             self._set_id(cloud_custom_metadata["id"])
@@ -596,9 +600,9 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             if attribute in cloud_custom_metadata:
                 setattr(self, attribute, cloud_custom_metadata[attribute])
 
-    def _get_local_metadata(self):
-        """Get the datafile's local metadata from the local metadata records file and apply it to the datafile instance.
-        If no metadata is stored for the datafile, do nothing.
+    def _use_local_metadata(self):
+        """Update the datafile's metadata from the local metadata records file. If no metadata is stored for the
+        datafile, do nothing.
 
         :return None:
         """

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -36,10 +36,10 @@ OCTUE_METADATA_NAMESPACE = "octue"
 
 
 class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filterable):
-    """A representation of a data file on the Octue system. If the given path is a cloud path and `hypothetical` is not
-    `True`, the datafile's metadata is pulled from the given cloud location, and any conflicting parameters (see the
-    `Datafile.metadata` method description for the parameter names concerned) are ignored. The metadata of cloud
-    datafiles can be changed using the `Datafile.update_metadata` method, but not during instantiation.
+    """A representation of a data file on the Octue system. If the given path is a cloud path, the datafile's metadata
+    is pulled from the given cloud location, and any conflicting parameters (see the `Datafile.metadata` method
+    description for the parameter names concerned) are ignored. The metadata of cloud datafiles can be changed using
+    the `Datafile.update_metadata` method, but not during instantiation.
 
     :param str|None path: The path of this file locally or in the cloud, which may include folders or subfolders, within the dataset
     :param str|None local_path: If a cloud path is given as the `path` parameter, this is the path to an existing local file that is known to be in sync with the cloud object
@@ -50,7 +50,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
     :param iter(str) labels: Space-separated string of labels relevant to this file
     :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin open function)
     :param bool update_cloud_metadata: if using as a context manager and this is True, update the cloud metadata of the datafile when the context is exited
-    :param bool hypothetical: True if the file does not actually exist or access is not available at instantiation
     :param bool ignore_stored_metadata: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
     :return None:
     """
@@ -77,7 +76,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         labels=None,
         mode="r",
         update_cloud_metadata=True,
-        hypothetical=False,
         ignore_stored_metadata=False,
         **kwargs,
     ):
@@ -90,7 +88,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         )
 
         self.timestamp = timestamp
-        self._hypothetical = hypothetical
         self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
         self._local_path = None
         self._cloud_path = None
@@ -497,7 +494,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         """
         self._cloud_path = path
 
-        if not self._hypothetical and not ignore_stored_metadata:
+        if not ignore_stored_metadata:
             self._use_cloud_metadata()
 
         if local_path:

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import tempfile
+import warnings
 from urllib.parse import urlparse
 
 import google.api_core.exceptions
@@ -79,6 +80,15 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         ignore_stored_metadata=False,
         **kwargs,
     ):
+        if "hypothetical" in kwargs:
+            warnings.warn(
+                message=(
+                    f"The `hypothetical` parameter in `Datafile` instantiation has been deprecated. Please set "
+                    f"`ignore_stored_metadata` to {kwargs['hypothetical']} instead."
+                ),
+                category=DeprecationWarning,
+            )
+
         super().__init__(
             id=id,
             name=kwargs.pop("name", None),

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -591,14 +591,8 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         if not cloud_custom_metadata:
             return
 
-        if "id" in cloud_custom_metadata:
-            self._set_id(cloud_custom_metadata["id"])
-
         self.immutable_hash_value = self.cloud_hash_value or EMPTY_STRING_HASH_VALUE
-
-        for attribute in ("timestamp", "tags", "labels"):
-            if attribute in cloud_custom_metadata:
-                setattr(self, attribute, cloud_custom_metadata[attribute])
+        self._set_metadata(cloud_custom_metadata)
 
     def _use_local_metadata(self):
         """Update the datafile's metadata from the local metadata records file. If no metadata is stored for the
@@ -612,12 +606,20 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         if not datafile_metadata:
             return
 
-        if "id" in datafile_metadata:
-            self._set_id(datafile_metadata["id"])
+        self._set_metadata(datafile_metadata)
+
+    def _set_metadata(self, metadata):
+        """Set the instance's metadata.
+
+        :param dict metadata:
+        :return None:
+        """
+        if "id" in metadata:
+            self._set_id(metadata["id"])
 
         for attribute in ("timestamp", "tags", "labels"):
-            if attribute in datafile_metadata:
-                setattr(self, attribute, datafile_metadata[attribute])
+            if attribute in metadata:
+                setattr(self, attribute, metadata[attribute])
 
     def _calculate_hash(self):
         """Get the hash of the datafile according to the first of the following methods that is applicable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.22.0"
+version = "0.23.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.23.0"
+version = "0.22.1"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -516,8 +516,8 @@ class TestService(BaseTestCase):
         parent = MockService(backend=BACKEND, children={child.id: child})
 
         files = [
-            Datafile(path="gs://my-dataset/hello.txt", project_name="blah", hypothetical=True),
-            Datafile(path="gs://my-dataset/goodbye.csv", project_name="blah", hypothetical=True),
+            Datafile(path="gs://my-dataset/hello.txt", project_name="blah"),
+            Datafile(path="gs://my-dataset/goodbye.csv", project_name="blah"),
         ]
 
         input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files)}, path="gs://my-dataset")
@@ -547,8 +547,8 @@ class TestService(BaseTestCase):
         parent = MockService(backend=BACKEND, children={child.id: child})
 
         files = [
-            Datafile(path="gs://my-dataset/hello.txt", project_name=TEST_PROJECT_NAME, hypothetical=True),
-            Datafile(path="gs://my-dataset/goodbye.csv", project_name=TEST_PROJECT_NAME, hypothetical=True),
+            Datafile(path="gs://my-dataset/hello.txt", project_name=TEST_PROJECT_NAME),
+            Datafile(path="gs://my-dataset/goodbye.csv", project_name=TEST_PROJECT_NAME),
         ]
 
         input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files)}, path="gs://my-dataset")

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -778,3 +778,38 @@ class TestDatafile(BaseTestCase):
         self.assertEqual(datafile.tags, unpickled_datafile.tags)
         self.assertEqual(datafile.id, unpickled_datafile.id)
         self.assertEqual(datafile.hash_value, unpickled_datafile.hash_value)
+
+    def test_stored_metadata_has_priority_over_instantiation_metadata_if_not_hypothetical(self):
+        """Test that stored metadata is used instead of instantiation metadata if `hypothetical` is `False`."""
+        cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "existing_datafile.dat")
+
+        # Create a datafile in the cloud and set some metadata on it.
+        with Datafile(cloud_path, mode="w") as (datafile, f):
+            datafile.tags = {"existing": True}
+
+        # Load it separately from the cloud object and check that the stored metadata is used instead of the
+        # instantiation metadata.
+        with self.assertLogs() as logging_context:
+            reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"})
+
+        self.assertEqual(reloaded_datafile.tags, {"existing": True})
+        self.assertIn("Overriding metadata given at instantiation with stored metadata", logging_context.output[0])
+
+    def test_instantiation_metadata_used_if_not_hypothetical_but_no_stored_metadata(self):
+        """Test that instantiation metadata is used if `hypothetical` is `False` but there's no stored metadata."""
+        cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "non_existing_datafile.dat")
+        datafile = Datafile(cloud_path, tags={"new": "tag"})
+        self.assertEqual(datafile.tags, {"new": "tag"})
+
+    def test_stored_metadata_ignored_if_hypothetical_is_true(self):
+        """Test that instantiation metadata is used instead of stored metadata if `hypothetical` is `True`."""
+        cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "existing_datafile.dat")
+
+        # Create a datafile in the cloud and set some metadata on it.
+        with Datafile(cloud_path, mode="w") as (datafile, f):
+            datafile.tags = {"existing": True}
+
+        # Load it separately from the cloud object and check that the instantiation metadata is used instead of the
+        # stored metadata.
+        reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"}, hypothetical=True)
+        self.assertEqual(reloaded_datafile.tags, {"new": "tag"})

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -262,7 +262,7 @@ class TestDatafile(BaseTestCase):
         datafile, _ = self.create_datafile_in_cloud(labels={"start"})
         datafile.labels = {"finish"}
 
-        with patch("octue.resources.datafile.Datafile._update_cloud_metadata") as mock:
+        with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
             datafile.to_cloud(datafile.cloud_path, update_cloud_metadata=False)
             self.assertFalse(mock.called)
 
@@ -274,7 +274,7 @@ class TestDatafile(BaseTestCase):
 
         new_datafile = Datafile(datafile.cloud_path)
 
-        with patch("octue.resources.datafile.Datafile._update_cloud_metadata") as mock:
+        with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
             new_datafile.to_cloud()
             self.assertFalse(mock.called)
 
@@ -309,7 +309,7 @@ class TestDatafile(BaseTestCase):
 
         new_datafile = Datafile(datafile.cloud_path)
         new_datafile.labels = {"new"}
-        new_datafile._update_cloud_metadata()
+        new_datafile.update_cloud_metadata()
 
         self.assertEqual(Datafile(datafile.cloud_path).labels, {"new"})
 
@@ -320,7 +320,7 @@ class TestDatafile(BaseTestCase):
         datafile = Datafile(path="hello.txt")
 
         with self.assertRaises(exceptions.CloudLocationNotSpecified):
-            datafile._update_cloud_metadata()
+            datafile.update_cloud_metadata()
 
     def test_cloud_path(self):
         """Test that the cloud path property gives the right path."""

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -174,12 +174,12 @@ class TestDatafile(BaseTestCase):
     def test_exists_in_cloud(self):
         """Test whether it can be determined that a datafile exists in the cloud or not."""
         self.assertFalse(self.create_valid_datafile().exists_in_cloud)
-        self.assertTrue(Datafile(path="gs://hello/file.txt", hypothetical=True).exists_in_cloud)
+        self.assertTrue(Datafile(path="gs://hello/file.txt").exists_in_cloud)
 
     def test_exists_locally(self):
         """Test whether it can be determined that a datafile exists locally or not."""
         self.assertTrue(self.create_valid_datafile().exists_locally)
-        self.assertFalse(Datafile(path="gs://hello/file.txt", hypothetical=True).exists_locally)
+        self.assertFalse(Datafile(path="gs://hello/file.txt").exists_locally)
 
         datafile, _ = self.create_datafile_in_cloud()
         new_datafile = Datafile(datafile.cloud_path)
@@ -567,7 +567,7 @@ class TestDatafile(BaseTestCase):
 
     def test_cloud_path_property(self):
         """Test that the cloud path property returns the expected value."""
-        datafile = Datafile(path="gs://blah/no.txt", hypothetical=True)
+        datafile = Datafile(path="gs://blah/no.txt")
         self.assertEqual(datafile.cloud_path, "gs://blah/no.txt")
 
     def test_setting_cloud_path_property(self):
@@ -642,7 +642,7 @@ class TestDatafile(BaseTestCase):
 
     def test_bucket_name_and_path_in_bucket_properties(self):
         """Test the bucket_name and path_in_bucket properties work as expected for cloud and local datafiles."""
-        datafile = Datafile(path="gs://my-bucket/directory/hello.txt", hypothetical=True)
+        datafile = Datafile(path="gs://my-bucket/directory/hello.txt")
         self.assertEqual(datafile.bucket_name, "my-bucket")
         self.assertEqual(datafile.path_in_bucket, "directory/hello.txt")
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -414,11 +414,7 @@ class TestDataset(BaseTestCase):
         self.assertFalse(self.create_valid_dataset().all_files_are_in_cloud)
         self.assertTrue(Dataset().all_files_are_in_cloud)
 
-        files = [
-            Datafile(path="gs://hello/file.txt", hypothetical=True),
-            Datafile(path="gs://goodbye/file.csv", hypothetical=True),
-        ]
-
+        files = [Datafile(path="gs://hello/file.txt"), Datafile(path="gs://goodbye/file.csv")]
         self.assertTrue(Dataset(files=files).all_files_are_in_cloud)
 
     def test_from_cloud(self):

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -31,11 +31,7 @@ class TestManifest(BaseTestCase):
         self.assertFalse(self.create_valid_manifest().all_datasets_are_in_cloud)
         self.assertTrue(Manifest().all_datasets_are_in_cloud)
 
-        files = [
-            Datafile(path="gs://hello/file.txt", hypothetical=True),
-            Datafile(path="gs://goodbye/file.csv", hypothetical=True),
-        ]
-
+        files = [Datafile(path="gs://hello/file.txt"), Datafile(path="gs://goodbye/file.csv")]
         manifest = Manifest(datasets={"my_dataset": Dataset(files=files)})
         self.assertTrue(manifest.all_datasets_are_in_cloud)
 


### PR DESCRIPTION
## Summary
This release simplifies the `Datafile` class internals and clarifies its metadata resolution order. Stored metadata will now be used in preference to instantiation metadata unless the `hypothetical` parameter is `True`, allowing the removal of some confusing internal logic from the class.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#433](https://github.com/octue/octue-sdk-python/pull/433))

### Enhancements
- If `hypothetical` is not `True` when re-instantiating existing datafiles, always use their stored metadata (from the cloud object or local metadata file)
- Store cloud metadata on `Datafile` instances without the `octue__` namespace prefix in its keys
- Make `Datafile` metadata update methods public so they can be called easily by users
- Make it optional whether to include the SDK version in the output of `Datafile.metadata`
- Return `None` from `GoogleCloudStorageClient.get_metadata` if bucket not found instead of raising an error

### Fixes
- Allow instantiation of a cloud datafile with a non-existent or inaccessible cloud path (defer raising errors until attempting to access it)

### Refactoring
- Simplify `Datafile` internals by removing the "initialisation parameters" concept
- Rename `Datafile._get_local_metadata` to `Datafile._use_local_metadata`
- Align `Datafile._use_cloud_metadata` and `Datafile._use_local_metadata` methods
- Factor out setting `Datafile` instance metadata from stored metadata into `_set_metadata` method

<!--- END AUTOGENERATED NOTES --->