### PR TITLE
Validate output location in runner instead of twine

### DIFF
--- a/octue/runner.py
+++ b/octue/runner.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import os
+import re
 import sys
 
 import google.api_core.exceptions
@@ -9,6 +10,7 @@ from google.cloud import secretmanager
 from jsonschema import ValidationError, validate as jsonschema_validate
 
 import twined.exceptions
+from octue import exceptions
 from octue.log_handlers import apply_log_handler, create_octue_formatter, get_log_record_attributes_for_environment
 from octue.resources import Child
 from octue.resources.analysis import CLASS_MAP, Analysis
@@ -47,6 +49,12 @@ class Runner:
     ):
         self.app_src = app_src
         self.children = children
+
+        if not re.match(r"^gs://[a-z\d][a-z\d_./-]*$", output_location):
+            raise exceptions.InvalidInputException(
+                "The output location must be a Google Cloud Storage path e.g. 'gs://bucket-name/output_directory'."
+            )
+
         self.output_location = output_location
 
         # Ensure the twine is present and instantiate it.

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -47,6 +47,7 @@ class Runner:
     ):
         self.app_src = app_src
         self.children = children
+        self.output_location = output_location
 
         # Ensure the twine is present and instantiate it.
         if isinstance(twine, Twine):
@@ -60,7 +61,6 @@ class Runner:
         self.configuration = self.twine.validate(
             configuration_values=configuration_values,
             configuration_manifest=configuration_manifest,
-            output_location=output_location,
             cls=CLASS_MAP,
         )
         logger.debug("Configuration validated.")
@@ -137,6 +137,7 @@ class Runner:
                 id=analysis_id,
                 twine=self.twine,
                 handle_monitor_message=handle_monitor_message,
+                output_location=self.output_location,
                 **self.configuration,
                 **inputs,
                 **outputs_and_monitors,

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -50,7 +50,7 @@ class Runner:
         self.app_src = app_src
         self.children = children
 
-        if not re.match(r"^gs://[a-z\d][a-z\d_./-]*$", output_location):
+        if output_location and not re.match(r"^gs://[a-z\d][a-z\d_./-]*$", output_location):
             raise exceptions.InvalidInputException(
                 "The output location must be a Google Cloud Storage path e.g. 'gs://bucket-name/output_directory'."
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1362,21 +1362,14 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 [[package]]
 name = "twined"
 version = "0.4.1"
-description = ""
+description = "A library to help digital twins and data services talk to one another"
 category = "main"
 optional = false
 python-versions = ">=3.6"
-develop = false
 
 [package.dependencies]
 jsonschema = ">=4.4.0,<4.5.0"
 python-dotenv = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/octue/twined.git"
-reference = "revert-104-feature/add-output-location-strand"
-resolved_reference = "fe7b271841028eb136d22c6908c273bf1f0851f3"
 
 [[package]]
 name = "typed-ast"
@@ -1492,7 +1485,7 @@ hdf5 = ["h5py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "a315f52d821526882e53f4688b146cdad218fe84efe438256e42004b86b2d69b"
+content-hash = "69e2d700f75fe768e01a02300447e6a9eb83d5b92a1e6bf338b6252abe96a26c"
 
 [metadata.files]
 apache-beam = [
@@ -2560,7 +2553,10 @@ tox = [
     {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
     {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
-twined = []
+twined = [
+    {file = "twined-0.4.1-py3-none-any.whl", hash = "sha256:c21e55ba22f266b9d204e0876896ed6f354dc515f191be26313448c905267d3d"},
+    {file = "twined-0.4.1.tar.gz", hash = "sha256:b5d7d5cdfe0ded5082913dba4bf335257e2760ce498a4db4493f23a0c962f4b5"},
+]
 typed-ast = [
     {file = "typed_ast-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ad3b48cf2b487be140072fb86feff36801487d4abb7382bb1929aaac80638ea"},
     {file = "typed_ast-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:542cd732351ba8235f20faa0fc7398946fe1a57f2cdb289e5497e1e7f48cfedb"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1361,15 +1361,22 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 
 [[package]]
 name = "twined"
-version = "0.4.0"
-description = "A library to help digital twins and data services talk to one another"
+version = "0.4.1"
+description = ""
 category = "main"
 optional = false
 python-versions = ">=3.6"
+develop = false
 
 [package.dependencies]
 jsonschema = ">=4.4.0,<4.5.0"
 python-dotenv = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/octue/twined.git"
+reference = "revert-104-feature/add-output-location-strand"
+resolved_reference = "fe7b271841028eb136d22c6908c273bf1f0851f3"
 
 [[package]]
 name = "typed-ast"
@@ -1485,7 +1492,7 @@ hdf5 = ["h5py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "3acadf3f4bdef5475b4677f9728c287cf8bd194306acf1e5800c0cd3f3c37a71"
+content-hash = "a315f52d821526882e53f4688b146cdad218fe84efe438256e42004b86b2d69b"
 
 [metadata.files]
 apache-beam = [
@@ -2553,10 +2560,7 @@ tox = [
     {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
     {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
-twined = [
-    {file = "twined-0.4.0-py3-none-any.whl", hash = "sha256:62fefa5b6646968843da8dc0db2aeca2f924f0b62f0d72637f24bfd9fb05fd97"},
-    {file = "twined-0.4.0.tar.gz", hash = "sha256:77f8e0349ae70d4924423d41e3a016d514784af46b9680b05260f677d608ede9"},
-]
+twined = []
 typed-ast = [
     {file = "typed_ast-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ad3b48cf2b487be140072fb86feff36801487d4abb7382bb1929aaac80638ea"},
     {file = "typed_ast-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:542cd732351ba8235f20faa0fc7398946fe1a57f2cdb289e5497e1e7f48cfedb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python-dateutil = "^2.8"
 pyyaml = "^6"
 h5py = { version = "^3.6", optional = true }
 apache-beam = { extras = ["gcp"], version = "^2.37", optional = true }
-twined = {git = "https://github.com/octue/twined.git", rev = "revert-104-feature/add-output-location-strand"}
+twined = "^0.4.1"
 
 [tool.poetry.extras]
 hdf5 = ["h5py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ python-dateutil = "^2.8"
 pyyaml = "^6"
 h5py = { version = "^3.6", optional = true }
 apache-beam = { extras = ["gcp"], version = "^2.37", optional = true }
-twined = "^0.4"
+twined = {git = "https://github.com/octue/twined.git", rev = "revert-104-feature/add-output-location-strand"}
 
 [tool.poetry.extras]
 hdf5 = ["h5py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.23.0"
+version = "0.23.1"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from jsonschema.validators import RefResolver
 
 import twined
-from octue import Runner
+from octue import Runner, exceptions
 from octue.resources.datafile import Datafile
 from tests import TESTS_DIR
 from tests.base import BaseTestCase
@@ -446,6 +446,15 @@ class TestRunnerWithRequiredDatasetFileTags(BaseTestCase):
 
             runner = Runner(app_src=app, twine=twine_with_input_manifest_with_required_tags_for_multiple_datasets)
             runner.run(input_manifest=input_manifest)
+
+    def test_error_raised_if_output_location_invalid(self):
+        """Test that an error is raised if an invalid output location is given."""
+        with self.assertRaises(exceptions.InvalidInputException):
+            Runner(".", twine="{}", output_location="not_a_cloud_path")
+
+    def test_valid_output_location(self):
+        """Test that a valid cloud path passes output location validation."""
+        Runner(".", twine="{}", output_location="gs://my-bucket/blah")
 
     def _make_serialised_input_manifest_with_correct_dataset_file_tags(self, dataset_path):
         """Make a serialised input manifest and create one dataset and its metadata on the filesystem so that, when


### PR DESCRIPTION
## Summary

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#439](https://github.com/octue/octue-sdk-python/pull/439))

### Enhancements
- Validate output locations given to `Runner`

### Dependencies
- Use `twined=^0.4.1`

<!--- END AUTOGENERATED NOTES --->