### PR TITLE
Add ability to download datafiles from a signed URL without cloud permissions

### DIFF
--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -6,16 +6,16 @@ CLOUD_STORAGE_PROTOCOL = "gs://"
 
 
 def is_cloud_path(path):
-    """Determine if the given path is either a qualified cloud path or a URL cloud path.
+    """Determine if the given path is either a cloud storage URI or a URL.
 
     :param str path: the path to check
     :return bool:
     """
-    return is_qualified_cloud_path(path) or is_url(path)
+    return is_cloud_uri(path) or is_url(path)
 
 
-def is_qualified_cloud_path(path):
-    """Determine if the given path is a qualified cloud path - i.e. if it begins with the cloud storage protocol.
+def is_cloud_uri(path):
+    """Determine if the given path is a cloud storage URI - i.e. if it begins with the cloud storage protocol.
 
     :param str path: the path to check
     :return bool: `True` if the path starts with the cloud storage protocol
@@ -24,10 +24,10 @@ def is_qualified_cloud_path(path):
 
 
 def is_url(path):
-    """Determine if the given path is an HTTP/HTTPS URL.
+    """Determine if the given path is a URL.
 
     :param str path: the path to check
-    :return bool:
+    :return bool: `True` if the path starts with "http"
     """
     return path.startswith("http")
 
@@ -45,14 +45,14 @@ def join(*paths):
     path = os.path.normpath(os.path.join(*paths)).replace("\\", "/")
 
     if path.startswith("gs:/"):
-        if not is_qualified_cloud_path(path):
+        if not is_cloud_uri(path):
             path = path.replace("gs:/", CLOUD_STORAGE_PROTOCOL)
 
     return path
 
 
 def generate_gs_path(bucket_name, *paths):
-    """Generate the Google Cloud storage path for a path in a bucket.
+    """Generate the Google Cloud Storage URI for a path in a bucket.
 
     :param str bucket_name:
     :param iter paths:
@@ -69,7 +69,7 @@ def split_bucket_name_from_cloud_path(path):
     :param str path: the path to split
     :return (str, str): the bucket name and the path within the bucket
     """
-    if is_qualified_cloud_path(path):
+    if is_cloud_uri(path):
         path = strip_protocol_from_path(path).split("/")
         return path[0], join(*path[1:])
 
@@ -83,7 +83,7 @@ def strip_protocol_from_path(path):
     :param str path:
     :return str:
     """
-    if not is_qualified_cloud_path(path):
+    if not is_cloud_path(path):
         return path
     return path.split(":")[1].lstrip("/")
 

--- a/octue/exceptions.py
+++ b/octue/exceptions.py
@@ -112,3 +112,7 @@ class CloudStorageBucketNotFound(OctueSDKException):
 
 class PushSubscriptionCannotBePulled(OctueSDKException):
     """Raise if attempting to pull a push subscription."""
+
+
+class ReadOnlyResource(OctueSDKException):
+    """Raise if attempting to alter a read-only resource."""

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -314,6 +314,11 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         :param datetime.datetime|datetime.timedelta expiration: the amount of time or date after which the URL should expire
         :return str: the signed URL for the dataset
         """
+        if not self.exists_in_cloud:
+            raise CloudLocationNotSpecified(
+                f"{self!r} must exist in the cloud for a signed URL to be generated for it."
+            )
+
         signed_metadata = self.to_primitive()
         signed_metadata["files"] = [datafile.generate_signed_url(expiration=expiration) for datafile in self.files]
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -314,15 +314,12 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         :param datetime.datetime|datetime.timedelta expiration: the amount of time or date after which the URL should expire
         :return str: the signed URL for the dataset
         """
-        storage_client = GoogleCloudStorageClient()
         signed_metadata = self.to_primitive()
-
-        signed_metadata["files"] = [
-            storage_client.generate_signed_url(cloud_path=datafile_path, expiration=expiration)
-            for datafile_path in signed_metadata["files"]
-        ]
+        signed_metadata["files"] = [datafile.generate_signed_url(expiration=expiration) for datafile in self.files]
 
         path_to_signed_metadata_file = storage.path.join(self.path, SIGNED_METADATA_DIRECTORY, coolname.generate_slug())
+
+        storage_client = GoogleCloudStorageClient()
 
         storage_client.upload_from_string(
             string=json.dumps(signed_metadata, cls=OctueJSONEncoder),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.23.1"
+version = "0.23.2"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -815,6 +815,15 @@ class TestDatafile(BaseTestCase):
         reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"}, hypothetical=True)
         self.assertEqual(reloaded_datafile.tags, {"new": "tag"})
 
+    def test_error_raised_if_attempting_to_generate_signed_url_for_local_datafile(self):
+        """Test that an error is raised if trying to generate a signed URL for a local datafile."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with Datafile(path=os.path.join(temporary_directory, "my-file.dat"), mode="w") as (datafile, f):
+                f.write("I will be signed")
+
+            with self.assertRaises(exceptions.CloudLocationNotSpecified):
+                datafile.generate_signed_url()
+
     def test_generating_signed_url_from_datafile_and_recreating_datafile_from_it(self):
         """Test that a signed URL can be generated for a datafile and used to recreate the datafile without any extra
         permissions.

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -672,6 +672,14 @@ class TestDataset(BaseTestCase):
             datafile_paths = {datafile.local_path for datafile in dataset.files}
             self.assertEqual(datafile_paths, set(paths))
 
+    def test_error_raised_if_attempting_to_generate_signed_url_for_local_dataset(self):
+        """Test that an error is raised if trying to generate a signed URL for a local dataset."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            dataset = Dataset(path=temporary_directory, tags={"hello": "world"})
+
+            with self.assertRaises(exceptions.CloudLocationNotSpecified):
+                dataset.generate_signed_url()
+
     def test_generating_signed_url_from_dataset_and_recreating_dataset_from_it(self):
         """Test that a signed URL can be generated for a dataset that can be used to recreate/get it, its metadata, and
         all its files.


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#440](https://github.com/octue/octue-sdk-python/pull/440))

### Enhancements
- Add ability to download datafiles from a signed URL without cloud permissions
- Add `Datafile.generate_signed_url` method
- Raise error if trying to modify a URL-based datafile
- Raise error if trying to generate a signed URL for a local datafile or dataset

### Refactoring
- Use URI terminology in cloud storage path module

### Testing
- Test that datafiles and datasets can be downloaded from URLs without cloud permissions

<!--- END AUTOGENERATED NOTES --->