### PR TITLE
Unify metadata update methods

### DIFF
--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import tempfile
+import warnings
 from urllib.parse import urlparse
 
 import google.api_core.exceptions
@@ -81,6 +82,18 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         hypothetical=False,
         **kwargs,
     ):
+        if "update_cloud_metadata" in kwargs:
+            warnings.warn(
+                message=(
+                    "The `Datafile` instantiation parameter `update_cloud_metadata` has been deprecated and renamed to "
+                    "`update_metadata`. The old name will become unavailable soon, so please update to the new one. It "
+                    "has been translated for now."
+                ),
+                category=DeprecationWarning,
+            )
+
+            update_metadata = kwargs["update_cloud_metadata"]
+
         super().__init__(
             id=id,
             name=kwargs.pop("name", None),

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -52,7 +52,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
     :param dict|octue.resources.tag.TagDict|None tags: key-value pairs with string keys conforming to the Octue tag format (see TagDict)
     :param iter(str)|octue.resources.label.LabelSet|None labels: Space-separated string of labels relevant to this file
     :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin `open` function)
-    :param bool update_cloud_metadata: if using as a context manager and this is `True`, update the cloud metadata of the datafile when the context is exited
+    :param bool update_metadata: if using as a context manager and this is `True`, update the stored metadata of the datafile when the context is exited
     :param bool hypothetical: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
     :return None:
     """
@@ -77,7 +77,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         tags=None,
         labels=None,
         mode="r",
-        update_cloud_metadata=True,
+        update_metadata=True,
         hypothetical=False,
         **kwargs,
     ):
@@ -90,7 +90,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         )
 
         self.timestamp = timestamp
-        self._open_attributes = {"mode": mode, "update_cloud_metadata": update_cloud_metadata, **kwargs}
+        self._open_attributes = {"mode": mode, "update_metadata": update_metadata, **kwargs}
         self._local_path = None
         self._cloud_path = None
         self._cloud_metadata = {}
@@ -485,6 +485,17 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
 
         return {f"{OCTUE_METADATA_NAMESPACE}__{key}": value for key, value in metadata.items()}
 
+    def update_metadata(self):
+        """If the datafile is cloud-based, update its cloud metadata; otherwise, update its local metadata.
+
+        :return None:
+        """
+        if self.exists_in_cloud:
+            self.update_cloud_metadata()
+            return
+
+        self.update_local_metadata()
+
     def update_cloud_metadata(self):
         """Update the cloud metadata for the datafile.
 
@@ -694,16 +705,16 @@ class _DatafileContextManager:
 
     :param octue.resources.datafile.Datafile datafile:
     :param str mode: open the datafile for reading/editing in this mode (the mode options are the same as for the builtin `open` function)
-    :param bool update_cloud_metadata: if this is True, update the cloud metadata of the datafile when the context is exited
+    :param bool update_metadata: if this is `True`, update the stored metadata of the datafile when the context is exited
     :return None:
     """
 
     MODIFICATION_MODES = {"w", "a", "x", "+", "U"}
 
-    def __init__(self, datafile, mode="r", update_cloud_metadata=True, **kwargs):
+    def __init__(self, datafile, mode="r", update_metadata=True, **kwargs):
         self.datafile = datafile
         self.mode = mode
-        self._update_cloud_metadata = update_cloud_metadata
+        self._update_metadata = update_metadata
         self.kwargs = kwargs
         self._fp = None
 
@@ -743,11 +754,11 @@ class _DatafileContextManager:
 
         if any(character in self.mode for character in self.MODIFICATION_MODES):
 
-            # If the datafile is local-first, update its local metadata.
-            if not self.datafile.exists_in_cloud:
+            if self.datafile.exists_in_cloud:
+                self.datafile.to_cloud(update_cloud_metadata=self._update_metadata)
+
+            elif self._update_metadata:
                 self.datafile.update_local_metadata()
-            else:
-                self.datafile.to_cloud(update_cloud_metadata=self._update_cloud_metadata)
 
 
 def calculate_hash(path):

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -236,10 +236,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
 
         :return None:
         """
-        if self.exists_in_cloud:
-            self.update_cloud_metadata()
-        else:
-            self.update_local_metadata()
+        self.update_metadata()
 
     def to_cloud(self, cloud_path=None, bucket_name=None, output_directory=None):
         """Upload a dataset to the given cloud path.
@@ -281,6 +278,17 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         self.path = cloud_path
         self.update_cloud_metadata()
         return cloud_path
+
+    def update_metadata(self):
+        """If the dataset is cloud-based, update its cloud metadata; otherwise, update its local metadata.
+
+        :return None:
+        """
+        if self.exists_in_cloud:
+            self.update_cloud_metadata()
+            return
+
+        self.update_local_metadata()
 
     def update_cloud_metadata(self):
         """Create or update the cloud metadata file for the dataset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.23.2"
+version = "0.23.3"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -872,7 +872,7 @@ class TestDatafile(BaseTestCase):
 
     def test_update_metadata_with_local_datafile(self):
         """Test the `update_metadata` method with a local datafile."""
-        with tempfile.NamedTemporaryFile() as temporary_file:
+        with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
             with Datafile(temporary_file.name, mode="w") as (datafile, f):
                 f.write("blah")
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -772,6 +772,36 @@ class TestDataset(BaseTestCase):
         reloaded_datafile = Dataset.from_cloud(cloud_path, tags={"new": "tag"}, hypothetical=True)
         self.assertEqual(reloaded_datafile.tags, {"new": "tag"})
 
+    def test_update_metadata_with_local_datafile(self):
+        """Test the `update_metadata` method with a local dataset."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            dataset = Dataset.from_local_directory(temporary_directory)
+
+            # Update the instance metadata but don't update the local stored metadata.
+            dataset.tags["hello"] = "world"
+
+            # Check the instance metadata hasn't been stored locally.
+            self.assertEqual(Dataset.from_local_directory(temporary_directory).tags, {})
+
+            # Update the local stored metadata and check it.
+            dataset.update_metadata()
+            self.assertEqual(Dataset.from_local_directory(temporary_directory).tags, {"hello": "world"})
+
+    def test_update_metadata_with_cloud_datafile(self):
+        """Test the `update_metadata` method with a cloud dataset."""
+        dataset_path = self._create_nested_cloud_dataset()
+        dataset = Dataset.from_cloud(dataset_path)
+
+        # Update the instance metadata but don't update the cloud stored metadata.
+        dataset.tags["hello"] = "world"
+
+        # Check the instance metadata hasn't been stored in the cloud.
+        self.assertEqual(Dataset.from_cloud(dataset.path).tags, {})
+
+        # Update the cloud stored metadata and check it.
+        dataset.update_metadata()
+        self.assertEqual(Dataset.from_cloud(dataset.path).tags, {"hello": "world"})
+
     def _create_nested_cloud_dataset(self, dataset_name="a_dataset"):
         """Create a dataset in cloud storage with the given name containing a nested set of files.
 


### PR DESCRIPTION
## Summary
Add a single method for updating stored datafile and dataset metadata that deduces whether to update the local or cloud metadata.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#443](https://github.com/octue/octue-sdk-python/pull/443))

### Enhancements
- Add `Datafile.update_metadata` method
- Add `Dataset.update_metadata` method

### Refactoring
- Rename `update_cloud_metadata` parameter to `update_metadata` in `Datafile` instantiation and raise a deprecation warning if the old parameter name is used

<!--- END AUTOGENERATED NOTES --->