### PR TITLE
Make Cloud Run services idempotent to questions

### DIFF
--- a/octue/cloud/deployment/google/answer_pub_sub_question.py
+++ b/octue/cloud/deployment/google/answer_pub_sub_question.py
@@ -61,5 +61,5 @@ def answer_question(question, project_name):
 
     # Forward any errors in the deployment configuration (errors in the analysis are already forwarded by the service).
     except BaseException as error:  # noqa
-        service.send_exception_to_asker(topic=answer_topic)
+        service.send_exception(topic=answer_topic)
         logger.exception(error)

--- a/octue/cloud/deployment/google/cloud_run/flask_app.py
+++ b/octue/cloud/deployment/google/cloud_run/flask_app.py
@@ -35,8 +35,9 @@ def index():
     # Acknowledge questions that are redelivered to stop further redelivery and redundant processing.
     if question_uuid in delivered_questions:
         logger.info(
-            "This question has already been received by the service. It will now be acknowledged to prevent further "
-            "redundant redelivery."
+            "Question %r has already been received by the service. It will now be acknowledged to prevent further "
+            "redundant redelivery.",
+            question_uuid,
         )
         return ("", 204)
 
@@ -66,7 +67,7 @@ def _load_metadata_file():
 
     except Exception as e:
         logger.exception(e)
-        return []
+        return set()
 
 
 def _save_metadata_file(data):

--- a/octue/cloud/deployment/google/cloud_run/flask_app.py
+++ b/octue/cloud/deployment/google/cloud_run/flask_app.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from flask import Flask, request
@@ -20,14 +21,6 @@ def index():
     if not envelope:
         return _log_bad_request_and_return_400_response("No Pub/Sub message received.")
 
-    # Acknowledge questions that are redelivered to stop further redelivery and redundant processing.
-    if envelope.get("deliveryAttempt", 0) > 1:
-        logger.info(
-            "This question has already been received by the service. It will now be acknowledged to prevent further "
-            "redundant redelivery."
-        )
-        return ("", 204)
-
     if not isinstance(envelope, dict) or "message" not in envelope:
         return _log_bad_request_and_return_400_response("Invalid Pub/Sub message format.")
 
@@ -35,6 +28,17 @@ def index():
 
     if "data" not in question or "attributes" not in question or "question_uuid" not in question["attributes"]:
         return _log_bad_request_and_return_400_response("Invalid Pub/Sub message format.")
+
+    question_uuid = question["attributes"]["question_uuid"]
+    delivered_questions = _load_metadata_file()
+
+    # Acknowledge questions that are redelivered to stop further redelivery and redundant processing.
+    if question_uuid in delivered_questions:
+        return ("", 204)
+
+    # Otherwise add the question UUID to the set.
+    delivered_questions.add(question_uuid)
+    _save_metadata_file(delivered_questions)
 
     project_name = envelope["subscription"].split("/")[1]
     answer_question(question=question, project_name=project_name)
@@ -49,3 +53,18 @@ def _log_bad_request_and_return_400_response(message):
     """
     logger.error(message)
     return (f"Bad Request: {message}", 400)
+
+
+def _load_metadata_file():
+    try:
+        with open(".octue") as f:
+            return set(json.load(f))
+
+    except Exception as e:
+        logger.exception(e)
+        return []
+
+
+def _save_metadata_file(data):
+    with open(".octue", "w") as f:
+        json.dump(data, f)

--- a/octue/cloud/deployment/google/cloud_run/flask_app.py
+++ b/octue/cloud/deployment/google/cloud_run/flask_app.py
@@ -34,6 +34,10 @@ def index():
 
     # Acknowledge questions that are redelivered to stop further redelivery and redundant processing.
     if question_uuid in delivered_questions:
+        logger.info(
+            "This question has already been received by the service. It will now be acknowledged to prevent further "
+            "redundant redelivery."
+        )
         return ("", 204)
 
     # Otherwise add the question UUID to the set.

--- a/octue/cloud/deployment/google/cloud_run/flask_app.py
+++ b/octue/cloud/deployment/google/cloud_run/flask_app.py
@@ -3,7 +3,7 @@ import logging
 from flask import Flask, request
 
 from octue.cloud.deployment.google.answer_pub_sub_question import answer_question
-from octue.utils.metadata import load_local_metadata_file, save_local_metadata_file
+from octue.utils.metadata import load_local_metadata_file, overwrite_local_metadata_file
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def index():
 
     # Otherwise add the question UUID to the set.
     delivered_questions.add(question_uuid)
-    save_local_metadata_file(local_metadata)
+    overwrite_local_metadata_file(local_metadata)
 
     project_name = envelope["subscription"].split("/")[1]
     answer_question(question=question, project_name=project_name)

--- a/octue/cloud/deployment/google/cloud_run/flask_app.py
+++ b/octue/cloud/deployment/google/cloud_run/flask_app.py
@@ -4,6 +4,8 @@ import logging
 from flask import Flask, request
 
 from octue.cloud.deployment.google.answer_pub_sub_question import answer_question
+from octue.utils.decoders import OctueJSONDecoder
+from octue.utils.encoders import OctueJSONEncoder
 
 
 logger = logging.getLogger(__name__)
@@ -63,7 +65,7 @@ def _log_bad_request_and_return_400_response(message):
 def _load_metadata_file():
     try:
         with open(".octue") as f:
-            return set(json.load(f))
+            return json.load(f, cls=OctueJSONDecoder)
 
     except Exception as e:
         logger.exception(e)
@@ -72,4 +74,4 @@ def _load_metadata_file():
 
 def _save_metadata_file(data):
     with open(".octue", "w") as f:
-        json.dump(data, f)
+        json.dump(data, f, cls=OctueJSONEncoder)

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -66,7 +66,7 @@ class OrderedMessageHandler:
 
         self._log_message_colours = [COLOUR_PALETTE[1], *COLOUR_PALETTE[3:]]
 
-    def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=30):
+    def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=120):
         """Pull messages and handle them in the order they were sent until a result is returned by a message handler,
         then return that result.
 

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -32,9 +32,9 @@ BATCH_SETTINGS = pubsub_v1.types.BatchSettings(max_bytes=10 * 1000 * 1000, max_l
 
 class Service(CoolNameable):
     """A Twined service that can be used in two modes:
-    * As a server accepting questions (input values and manifests), running them through its app, and responding to the
-    requesting service with the results of the analysis.
-    * As a requester of answers from another Service in the above mode.
+    - As a child accepting questions (input values and manifests) from parents, running them through its app, and
+      responding with the results of the analysis
+    - As a parent asking questions to children in the above mode
 
     Services communicate entirely via Google Pub/Sub and can ask and/or respond to questions from any other Service that
     has a corresponding topic on Google Pub/Sub.
@@ -117,11 +117,11 @@ class Service(CoolNameable):
 
     def answer(self, question, answer_topic=None, timeout=30):
         """Answer a question (i.e. run the Service's app to analyse the given data, and return the output values to the
-        asker). Answers are published to a topic whose name is generated from the UUID sent with the question, and are
+        parent). Answers are published to a topic whose name is generated from the UUID sent with the question, and are
         in the format specified in the Service's Twine file.
 
         :param dict|Message question:
-        :param octue.cloud.pub_sub.topic.Topic|None answer_topic: provide if messages need to be sent to the asker from outside the service (e.g. in octue.cloud.deployment.google.cloud_run.flask_app)
+        :param octue.cloud.pub_sub.topic.Topic|None answer_topic: provide if messages need to be sent to the parent from outside the service (e.g. in octue.cloud.deployment.google.cloud_run.flask_app)
         :param float|None timeout: time in seconds to keep retrying sending of the answer once it has been calculated
         :raise Exception: if any exception arises during running analysis and sending its results
         :return None:
@@ -166,7 +166,7 @@ class Service(CoolNameable):
             logger.info("%r responded to question %r.", self, question_uuid)
 
         except BaseException as error:  # noqa
-            self.send_exception_to_asker(topic, timeout)
+            self.send_exception(topic, timeout)
             raise error
 
     def instantiate_answer_topic(self, question_uuid, service_id=None):
@@ -294,8 +294,34 @@ class Service(CoolNameable):
             subscription.delete()
             subscriber.close()
 
+    def send_exception(self, topic, timeout=30):
+        """Serialise and send the exception being handled to the parent.
+
+        :param octue.cloud.pub_sub.topic.Topic topic:
+        :param float|None timeout: time in seconds to keep retrying sending of the exception
+        :return None:
+        """
+        exception = convert_exception_to_primitives()
+        exception_message = f"Error in {self!r}: {exception['message']}"
+
+        self.publisher.publish(
+            topic=topic.path,
+            data=json.dumps(
+                {
+                    "type": "exception",
+                    "exception_type": exception["type"],
+                    "exception_message": exception_message,
+                    "traceback": exception["traceback"],
+                    "message_number": topic.messages_published,
+                }
+            ).encode(),
+            retry=retry.Retry(deadline=timeout),
+        )
+
+        topic.messages_published += 1
+
     def _send_delivery_acknowledgment(self, topic, timeout=30):
-        """Send an acknowledgement of question delivery to the asker.
+        """Send an acknowledgement of question delivery to the parent.
 
         :param octue.cloud.pub_sub.topic.Topic topic: topic to send acknowledgement to
         :param float timeout: time in seconds after which to give up sending
@@ -318,7 +344,7 @@ class Service(CoolNameable):
         topic.messages_published += 1
 
     def _send_monitor_message(self, data, topic, timeout=30):
-        """Send a monitor message to the asker.
+        """Send a monitor message to the parent.
 
         :param any data: the data to send as a monitor message
         :param octue.cloud.pub_sub.topic.Topic topic: the topic to send the message to
@@ -333,32 +359,6 @@ class Service(CoolNameable):
                 {
                     "type": "monitor_message",
                     "data": json.dumps(data),
-                    "message_number": topic.messages_published,
-                }
-            ).encode(),
-            retry=retry.Retry(deadline=timeout),
-        )
-
-        topic.messages_published += 1
-
-    def send_exception_to_asker(self, topic, timeout=30):
-        """Serialise and send the exception being handled to the asker.
-
-        :param octue.cloud.pub_sub.topic.Topic topic:
-        :param float|None timeout: time in seconds to keep retrying sending of the exception
-        :return None:
-        """
-        exception = convert_exception_to_primitives()
-        exception_message = f"Error in {self!r}: {exception['message']}"
-
-        self.publisher.publish(
-            topic=topic.path,
-            data=json.dumps(
-                {
-                    "type": "exception",
-                    "exception_type": exception["type"],
-                    "exception_message": exception_message,
-                    "traceback": exception["traceback"],
                     "message_number": topic.messages_published,
                 }
             ).encode(),

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -30,7 +30,7 @@ from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_buc
 from octue.mixins import Filterable, Hashable, Identifiable, Labelable, Metadata, Serialisable, Taggable
 from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
 from octue.utils.decoders import OctueJSONDecoder
-from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, save_local_metadata_file
+from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, overwrite_local_metadata_file
 
 
 logger = logging.getLogger(__name__)
@@ -529,7 +529,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             existing_metadata_records["datafiles"] = {}
 
         existing_metadata_records["datafiles"][self.name] = self.metadata(use_octue_namespace=False)
-        save_local_metadata_file(data=existing_metadata_records, path=self._local_metadata_path)
+        overwrite_local_metadata_file(data=existing_metadata_records, path=self._local_metadata_path)
 
     def generate_signed_url(self, expiration=datetime.timedelta(days=7)):
         """Generate a signed URL for the datafile.

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -30,8 +30,7 @@ from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_buc
 from octue.mixins import Filterable, Hashable, Identifiable, Labelable, Metadata, Serialisable, Taggable
 from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
 from octue.utils.decoders import OctueJSONDecoder
-from octue.utils.encoders import OctueJSONEncoder
-from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file
+from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, save_local_metadata_file
 
 
 logger = logging.getLogger(__name__)
@@ -530,9 +529,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             existing_metadata_records["datafiles"] = {}
 
         existing_metadata_records["datafiles"][self.name] = self.metadata(use_octue_namespace=False)
-
-        with open(self._local_metadata_path, "w") as f:
-            json.dump(existing_metadata_records, f, cls=OctueJSONEncoder)
+        save_local_metadata_file(data=existing_metadata_records, path=self._local_metadata_path)
 
     def generate_signed_url(self, expiration=datetime.timedelta(days=7)):
         """Generate a signed URL for the datafile.

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -20,7 +20,7 @@ from octue.resources.filter_containers import FilterSet
 from octue.resources.label import LabelSet
 from octue.resources.tag import TagDict
 from octue.utils.encoders import OctueJSONEncoder
-from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, save_local_metadata_file
+from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, overwrite_local_metadata_file
 
 
 logger = logging.getLogger(__name__)
@@ -319,7 +319,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         existing_metadata_records = load_local_metadata_file(self._metadata_path)
         existing_metadata_records["dataset"] = self.to_primitive(include_files=False)
         os.makedirs(self.path, exist_ok=True)
-        save_local_metadata_file(data=existing_metadata_records, path=self._metadata_path)
+        overwrite_local_metadata_file(data=existing_metadata_records, path=self._metadata_path)
 
     def generate_signed_url(self, expiration=datetime.timedelta(days=7)):
         """Generate a signed URL for the dataset. This is done by uploading a uniquely named metadata file containing

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -20,7 +20,7 @@ from octue.resources.filter_containers import FilterSet
 from octue.resources.label import LabelSet
 from octue.resources.tag import TagDict
 from octue.utils.encoders import OctueJSONEncoder
-from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file
+from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, save_local_metadata_file
 
 
 logger = logging.getLogger(__name__)
@@ -319,9 +319,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         existing_metadata_records = load_local_metadata_file(self._metadata_path)
         existing_metadata_records["dataset"] = self.to_primitive(include_files=False)
         os.makedirs(self.path, exist_ok=True)
-
-        with open(self._metadata_path, "w") as f:
-            json.dump(existing_metadata_records, f, cls=OctueJSONEncoder)
+        save_local_metadata_file(data=existing_metadata_records, path=self._metadata_path)
 
     def generate_signed_url(self, expiration=datetime.timedelta(days=7)):
         """Generate a signed URL for the dataset. This is done by uploading a uniquely named metadata file containing

--- a/octue/utils/metadata.py
+++ b/octue/utils/metadata.py
@@ -33,8 +33,8 @@ def load_local_metadata_file(path=METADATA_FILENAME):
             return {}
 
 
-def save_local_metadata_file(data, path=METADATA_FILENAME):
-    """Overwrite the given local metadata file with the given data.
+def overwrite_local_metadata_file(data, path=METADATA_FILENAME):
+    """Create or overwrite the given local metadata file with the given data.
 
     :param dict data:
     :param str path:

--- a/octue/utils/metadata.py
+++ b/octue/utils/metadata.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from octue.utils.decoders import OctueJSONDecoder
+from octue.utils.encoders import OctueJSONEncoder
 
 
 logger = logging.getLogger(__name__)
@@ -11,10 +12,11 @@ logger = logging.getLogger(__name__)
 METADATA_FILENAME = ".octue"
 
 
-def load_local_metadata_file(path):
+def load_local_metadata_file(path=METADATA_FILENAME):
     """Load metadata from a local metadata records file, returning an empty dictionary if the file does not exist or is
     incorrectly formatted.
 
+    :param str path:
     :return dict:
     """
     if not os.path.exists(path):
@@ -25,7 +27,18 @@ def load_local_metadata_file(path):
             return json.load(f, cls=OctueJSONDecoder)
         except json.decoder.JSONDecodeError:
             logger.warning(
-                f"The {METADATA_FILENAME!r} metadata file at {path!r} is incorrectly formatted so no metadata "
-                f"can be read from it. Please fix or delete it."
+                f"The metadata file at {path!r} is incorrectly formatted so no metadata can be read from it. Please "
+                "fix or delete it."
             )
             return {}
+
+
+def save_local_metadata_file(data, path=METADATA_FILENAME):
+    """Overwrite the given local metadata file with the given data.
+
+    :param dict data:
+    :param str path:
+    :return None:
+    """
+    with open(path, "w") as f:
+        json.dump(data, f, cls=OctueJSONEncoder)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.23.4"
+version = "0.23.5"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]


### PR DESCRIPTION
## Summary
Stop Cloud Run services from running a given question more than once and rely on Pub/Sub retries for connection problems.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#446](https://github.com/octue/octue-sdk-python/pull/446))

### Enhancements
- Increase default delivery acknowledgement deadline to 120s

### Fixes
- Acknowledge and drop questions redelivered to Cloud Run services based on their UUIDs
- Remove redundant question retries in `Service` and raise error instead if the delivery acknowledgement deadline is reached

### Refactoring
- Factor out saving/updating of local metadata files
- Rename local metadata save function
- Rename `Service.send_exception_to_asker` to `Service.send_exception`
- Use "answer" instead of "response" terminology in `Service`

<!--- END AUTOGENERATED NOTES --->