### PR TITLE
Allow `Dataset.to_cloud` to infer cloud location

### DIFF
--- a/octue/mixins/__init__.py
+++ b/octue/mixins/__init__.py
@@ -1,4 +1,5 @@
 from .base import MixinBase
+from .cloud_pathable import CloudPathable
 from .cool_nameable import CoolNameable
 from .filterable import Filterable
 from .hashable import Hashable
@@ -10,6 +11,7 @@ from .taggable import Taggable
 
 
 __all__ = (
+    "CloudPathable",
     "CoolNameable",
     "Filterable",
     "Hashable",

--- a/octue/mixins/cloud_pathable.py
+++ b/octue/mixins/cloud_pathable.py
@@ -1,0 +1,90 @@
+from urllib.parse import urlparse
+
+from octue.cloud import storage
+from octue.exceptions import CloudLocationNotSpecified
+
+
+class CloudPathable:
+    _CLOUD_PATH_ATTRIBUTE_NAME = "path"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def __cloud_path(self):
+        return getattr(self, self._CLOUD_PATH_ATTRIBUTE_NAME)
+
+    @property
+    def exists_in_cloud(self):
+        """Return `True` if the dataset exists in the cloud.
+
+        :return bool:
+        """
+        if self.__cloud_path:
+            return storage.path.is_cloud_path(self.__cloud_path)
+        return None
+
+    @property
+    def exists_locally(self):
+        """Return `True` if the dataset exists locally.
+
+        :return bool:
+        """
+        return not self.exists_in_cloud
+
+    @property
+    def cloud_protocol(self):
+        """Get the cloud protocol of the instance if it exists in the cloud (e.g. "gs" for a cloud path of
+        "gs://my-bucket/my-file.txt").
+
+        :return str|None:
+        """
+        if not self.exists_in_cloud:
+            return None
+        return urlparse(self.__cloud_path).scheme
+
+    @property
+    def bucket_name(self):
+        """Get the name of the bucket the dataset exists in if it exists in the cloud.
+
+        :return str|None:
+        """
+        if self.exists_in_cloud:
+            return storage.path.split_bucket_name_from_cloud_path(self.__cloud_path)[0]
+        return None
+
+    @property
+    def path_in_bucket(self):
+        """Get the path of the dataset in its bucket if it exists in the cloud.
+
+        :return str|None:
+        """
+        if self.exists_in_cloud:
+            return storage.path.split_bucket_name_from_cloud_path(self.__cloud_path)[1]
+        return None
+
+    def _get_cloud_location(self, cloud_path=None):
+        """Get the cloud location details for the instance.
+
+        :param str|None cloud_path:
+        :raise octue.exceptions.CloudLocationNotSpecified: if an exact cloud location isn't provided and isn't available implicitly (i.e. the instance wasn't loaded from the cloud previously)
+        :return (str, str): project name and cloud path
+        """
+        cloud_path = cloud_path or self.__cloud_path
+
+        if not cloud_path:
+            self._raise_cloud_location_error()
+
+        self._cloud_path = cloud_path
+        return cloud_path
+
+    def _raise_cloud_location_error(self):
+        """Raise an error indicating that the cloud location of the instance has not yet been specified.
+
+        :raise CloudLocationNotSpecified:
+        :return None:
+        """
+        raise CloudLocationNotSpecified(
+            f"{self!r} wasn't previously loaded from the cloud so doesn't have an implicit cloud location - please "
+            f"specify its exact location (its project name and cloud path)."
+        )

--- a/octue/mixins/cloud_pathable.py
+++ b/octue/mixins/cloud_pathable.py
@@ -5,18 +5,13 @@ from octue.exceptions import CloudLocationNotSpecified
 
 
 class CloudPathable:
+    """A mixin providing cloud-related properties and functions common to `octue` resources."""
+
     _CLOUD_PATH_ATTRIBUTE_NAME = "path"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    @property
-    def __cloud_path(self):
-        return getattr(self, self._CLOUD_PATH_ATTRIBUTE_NAME)
 
     @property
     def exists_in_cloud(self):
-        """Return `True` if the dataset exists in the cloud.
+        """Return `True` if the instance exists in the cloud.
 
         :return bool:
         """
@@ -26,7 +21,7 @@ class CloudPathable:
 
     @property
     def exists_locally(self):
-        """Return `True` if the dataset exists locally.
+        """Return `True` if the instance exists locally.
 
         :return bool:
         """
@@ -45,7 +40,7 @@ class CloudPathable:
 
     @property
     def bucket_name(self):
-        """Get the name of the bucket the dataset exists in if it exists in the cloud.
+        """Get the name of the bucket the instance exists in if it exists in the cloud.
 
         :return str|None:
         """
@@ -55,7 +50,7 @@ class CloudPathable:
 
     @property
     def path_in_bucket(self):
-        """Get the path of the dataset in its bucket if it exists in the cloud.
+        """Get the path of the instance in its bucket if it exists in the cloud.
 
         :return str|None:
         """
@@ -68,7 +63,7 @@ class CloudPathable:
 
         :param str|None cloud_path:
         :raise octue.exceptions.CloudLocationNotSpecified: if an exact cloud location isn't provided and isn't available implicitly (i.e. the instance wasn't loaded from the cloud previously)
-        :return (str, str): project name and cloud path
+        :return str: the instance's cloud path
         """
         cloud_path = cloud_path or self.__cloud_path
 
@@ -86,5 +81,13 @@ class CloudPathable:
         """
         raise CloudLocationNotSpecified(
             f"{self!r} wasn't previously loaded from the cloud so doesn't have an implicit cloud location - please "
-            f"specify its exact location (its project name and cloud path)."
+            f"specify its cloud path."
         )
+
+    @property
+    def __cloud_path(self):
+        """Get the cloud path for the instance according to the class variable `_CLOUD_PATH_ATTRIBUTE_NAME`.
+
+        :return str:
+        """
+        return getattr(self, self._CLOUD_PATH_ATTRIBUTE_NAME)

--- a/octue/mixins/cloud_pathable.py
+++ b/octue/mixins/cloud_pathable.py
@@ -20,14 +20,6 @@ class CloudPathable:
         return None
 
     @property
-    def exists_locally(self):
-        """Return `True` if the instance exists locally.
-
-        :return bool:
-        """
-        return not self.exists_in_cloud
-
-    @property
     def cloud_protocol(self):
         """Get the cloud protocol of the instance if it exists in the cloud (e.g. "gs" for a cloud path of
         "gs://my-bucket/my-file.txt").

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -273,14 +273,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             return None
 
     @property
-    def exists_in_cloud(self):
-        """Return `True` if the file exists in the cloud.
-
-        :return bool:
-        """
-        return self.cloud_path is not None
-
-    @property
     def exists_locally(self):
         """Return `True` if the file exists locally.
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import tempfile
 import warnings
-from urllib.parse import urlparse
 
 import google.api_core.exceptions
 import pkg_resources
@@ -27,7 +26,7 @@ from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.exceptions import CloudLocationNotSpecified, ReadOnlyResource
 from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
-from octue.mixins import Filterable, Hashable, Identifiable, Labelable, Metadata, Serialisable, Taggable
+from octue.mixins import CloudPathable, Filterable, Hashable, Identifiable, Labelable, Metadata, Serialisable, Taggable
 from octue.mixins.hashable import EMPTY_STRING_HASH_VALUE
 from octue.utils.decoders import OctueJSONDecoder
 from octue.utils.metadata import METADATA_FILENAME, load_local_metadata_file, overwrite_local_metadata_file
@@ -39,7 +38,7 @@ logger = logging.getLogger(__name__)
 OCTUE_METADATA_NAMESPACE = "octue"
 
 
-class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filterable, Metadata):
+class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filterable, Metadata, CloudPathable):
     """A representation of a data file on the Octue system. Metadata for the file is obtained from its corresponding
     cloud object or a local `.octue` metadata file, if present. If no stored metadata is available, it can be set during
     or after instantiation.
@@ -56,6 +55,8 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
     :param bool hypothetical: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
     :return None:
     """
+
+    _CLOUD_PATH_ATTRIBUTE_NAME = "cloud_path"
 
     _METADATA_ATTRIBUTES = ("id", "timestamp", "tags", "labels")
 
@@ -193,37 +194,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
 
         else:
             self.to_cloud(cloud_path=path)
-
-    @property
-    def cloud_protocol(self):
-        """Get the cloud protocol of the datafile if it exists in the cloud (e.g. "gs" for a cloud path of
-        "gs://my-bucket/my-file.txt").
-
-        :return str|None:
-        """
-        if not self.exists_in_cloud:
-            return None
-        return urlparse(self.cloud_path).scheme
-
-    @property
-    def bucket_name(self):
-        """Get the name of the bucket the datafile exists in if it exists in the cloud.
-
-        :return str|None:
-        """
-        if self.cloud_path:
-            return storage.path.split_bucket_name_from_cloud_path(self.cloud_path)[0]
-        return None
-
-    @property
-    def path_in_bucket(self):
-        """Get the path of the datafile in its bucket if it exists in the cloud.
-
-        :return str|None:
-        """
-        if self.cloud_path:
-            return storage.path.split_bucket_name_from_cloud_path(self.cloud_path)[1]
-        return None
 
     @property
     def cloud_hash_value(self):
@@ -664,33 +634,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             return super()._calculate_hash(hash_value)
         else:
             return self.cloud_hash_value or EMPTY_STRING_HASH_VALUE
-
-    def _get_cloud_location(self, cloud_path=None):
-        """Get the cloud location details for the bucket, allowing the keyword arguments to override any stored values.
-        Once the cloud location details have been determined, update the stored cloud location details.
-
-        :param str|None cloud_path:
-        :raise octue.exceptions.CloudLocationNotSpecified: if an exact cloud location isn't provided and isn't available implicitly (i.e. the Datafile wasn't loaded from the cloud previously)
-        :return (str, str): project name and cloud path
-        """
-        cloud_path = cloud_path or self.cloud_path
-
-        if not cloud_path:
-            self._raise_cloud_location_error()
-
-        self._cloud_path = cloud_path
-        return cloud_path
-
-    def _raise_cloud_location_error(self):
-        """Raise an error indicating that the cloud location of the datafile has not yet been specified.
-
-        :raise CloudLocationNotSpecified:
-        :return None:
-        """
-        raise CloudLocationNotSpecified(
-            f"{self!r} wasn't previously loaded from the cloud so doesn't have an implicit cloud location - please "
-            f"specify its exact location (its project name and cloud path)."
-        )
 
 
 class _DatafileContextManager:

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -225,7 +225,12 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         files_and_paths = []
 
         for datafile in self.files:
-            datafile_path_relative_to_dataset = self._datafile_path_relative_to_self(datafile, path_type="local_path")
+            if self.exists_in_cloud:
+                path_type = "cloud_path"
+            else:
+                path_type = "local_path"
+
+            datafile_path_relative_to_dataset = self._datafile_path_relative_to_self(datafile, path_type=path_type)
 
             files_and_paths.append(
                 (

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -166,6 +166,14 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         self._name = name
 
     @property
+    def exists_locally(self):
+        """Return `True` if the dataset exists locally.
+
+        :return bool:
+        """
+        return not self.exists_in_cloud
+
+    @property
     def all_files_are_in_cloud(self):
         """Do all the files of the dataset exist in the cloud?
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -14,7 +14,7 @@ from octue.cloud import storage
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.exceptions import CloudLocationNotSpecified, InvalidInputException
 from octue.migrations.cloud_storage import translate_bucket_name_and_path_in_bucket_to_cloud_path
-from octue.mixins import Hashable, Identifiable, Labelable, Metadata, Serialisable, Taggable
+from octue.mixins import CloudPathable, Hashable, Identifiable, Labelable, Metadata, Serialisable, Taggable
 from octue.resources.datafile import Datafile
 from octue.resources.filter_containers import FilterSet
 from octue.resources.label import LabelSet
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 SIGNED_METADATA_DIRECTORY = ".signed_metadata_files"
 
 
-class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadata):
+class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadata, CloudPathable):
     """A representation of a dataset, containing files, labels, etc.
 
     This is used to read a list of files (and their associated properties) into octue analysis, or to compile a
@@ -166,42 +166,6 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         self._name = name
 
     @property
-    def exists_in_cloud(self):
-        """Return `True` if the dataset exists in the cloud.
-
-        :return bool:
-        """
-        return storage.path.is_cloud_path(self.path)
-
-    @property
-    def exists_locally(self):
-        """Return `True` if the dataset exists locally.
-
-        :return bool:
-        """
-        return not self.exists_in_cloud
-
-    @property
-    def bucket_name(self):
-        """Get the name of the bucket the dataset exists in if it exists in the cloud.
-
-        :return str|None:
-        """
-        if self.exists_in_cloud:
-            return storage.path.split_bucket_name_from_cloud_path(self.path)[0]
-        return None
-
-    @property
-    def path_in_bucket(self):
-        """Get the path of the dataset in its bucket if it exists in the cloud.
-
-        :return str|None:
-        """
-        if self.exists_in_cloud:
-            return storage.path.split_bucket_name_from_cloud_path(self.path)[1]
-        return None
-
-    @property
     def all_files_are_in_cloud(self):
         """Do all the files of the dataset exist in the cloud?
 
@@ -253,7 +217,10 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         :return str: cloud path for dataset
         """
         if not cloud_path:
-            cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, output_directory)
+            if not (bucket_name and output_directory):
+                cloud_path = self._get_cloud_location(cloud_path)
+            else:
+                cloud_path = translate_bucket_name_and_path_in_bucket_to_cloud_path(bucket_name, output_directory)
 
         files_and_paths = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.23.5"
+version = "0.23.6"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -599,6 +599,14 @@ class TestDataset(BaseTestCase):
 
         self.assertEqual(cloud_datafile_relative_paths, local_datafile_relative_paths)
 
+    def test_to_cloud_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
+        """Test `Dataset.to_cloud` works with an implicit cloud location if the cloud location has previously been
+        provided.
+        """
+        dataset_path = self._create_nested_cloud_dataset()
+        dataset = Dataset(path=dataset_path, recursive=True)
+        dataset.to_cloud()
+
     def test_error_raised_if_trying_to_download_files_from_local_dataset(self):
         """Test that an error is raised if trying to download files from a local dataset."""
         dataset = self.create_valid_dataset()


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#449](https://github.com/octue/octue-sdk-python/pull/449))

### Enhancements
- Allow `Dataset.to_cloud` to infer cloud location

### Fixes
- Use cloud paths for relative paths when possible in `Dataset.to_cloud`

### Refactoring
- Factor out cloud properties and methods common to `Dataset` and `Datafile` into new `CloudPathable` mixin

<!--- END AUTOGENERATED NOTES --->