### PR TITLE
Use `twined=^0.5.0`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1361,7 +1361,7 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 
 [[package]]
 name = "twined"
-version = "0.4.1"
+version = "0.5.0"
 description = "A library to help digital twins and data services talk to one another"
 category = "main"
 optional = false
@@ -1485,7 +1485,7 @@ hdf5 = ["h5py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "69e2d700f75fe768e01a02300447e6a9eb83d5b92a1e6bf338b6252abe96a26c"
+content-hash = "429e81ecfd8d7ab572aa08fa0961cfd4796a8421505bef30865e077782ca5896"
 
 [metadata.files]
 apache-beam = [
@@ -2554,8 +2554,8 @@ tox = [
     {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
 twined = [
-    {file = "twined-0.4.1-py3-none-any.whl", hash = "sha256:c21e55ba22f266b9d204e0876896ed6f354dc515f191be26313448c905267d3d"},
-    {file = "twined-0.4.1.tar.gz", hash = "sha256:b5d7d5cdfe0ded5082913dba4bf335257e2760ce498a4db4493f23a0c962f4b5"},
+    {file = "twined-0.5.0-py3-none-any.whl", hash = "sha256:446b753e7dc7e7561822759eb601233edb5d1ca7122a63dc9cf9363145e1ba7d"},
+    {file = "twined-0.5.0.tar.gz", hash = "sha256:f6ef8390142b1d064972f07bcbc51e6357094a9b3f841604a8dc442905cf7d31"},
 ]
 typed-ast = [
     {file = "typed_ast-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ad3b48cf2b487be140072fb86feff36801487d4abb7382bb1929aaac80638ea"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.24.0"
+version = "0.24.1"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]
@@ -34,7 +34,7 @@ python-dateutil = "^2.8"
 pyyaml = "^6"
 h5py = { version = "^3.6", optional = true }
 apache-beam = { extras = ["gcp"], version = "^2.37", optional = true }
-twined = "^0.4.1"
+twined = "^0.5.0"
 
 [tool.poetry.extras]
 hdf5 = ["h5py"]


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#454](https://github.com/octue/octue-sdk-python/pull/454))

### Dependencies
- Use `twined=^0.5.0`, which removes deprecated support for datasets provided as lists instead of as dictionaries

<!--- END AUTOGENERATED NOTES --->