### PR TITLE
Make most-used interfaces more consistent and intuitive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
           - '^dependencies/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/conventional-commits
-    rev: 0.5.3
+    rev: 0.5.5
     hooks:
       - id: check-commit-message-is-conventional
         stages: [commit-msg]

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -171,7 +171,7 @@ class DataflowDeployer(BaseDeployer):
                         "id": "Deploy Dataflow job",
                         "name": OCTUE_SDK_PYTHON_IMAGE_URI,
                         "args": [
-                            "octue-app",
+                            "octue",
                             "deploy",
                             "dataflow",
                             f"--service-id={self.service_id}",

--- a/octue/cloud/deployment/google/dataflow/setup.py
+++ b/octue/cloud/deployment/google/dataflow/setup.py
@@ -45,7 +45,7 @@ setup(
     include_package_data=True,
     entry_points="""
     [console_scripts]
-    octue-app=octue.cli:octue_cli
+    octue=octue.cli:octue_cli
     """,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/octue/cloud/deployment/google/dataflow/setup.py
+++ b/octue/cloud/deployment/google/dataflow/setup.py
@@ -31,7 +31,7 @@ setup(
         "gunicorn>=20.1,<21",
         "python-dateutil>=2.8,<3",
         "pyyaml>=6,<7",
-        "twined>=0.4,<0.5",
+        "twined>=0.5,<0.6",
     ],
     extras_require={"hdf5": ["h5py>=3.6,<4"], "dataflow": ["apache-beam[gcp]>=2.37,<3"]},
     url="https://www.github.com/octue/octue-sdk-python",

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -125,7 +125,7 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
             return
 
         for name, dataset in self.output_manifest.datasets.items():
-            dataset.to_cloud(cloud_path=storage.path.join(upload_output_datasets_to, name))
+            dataset.upload(cloud_path=storage.path.join(upload_output_datasets_to, name))
             self.output_manifest.datasets[name].path = dataset.generate_signed_url()
 
         logger.info("Uploaded output datasets to %r.", upload_output_datasets_to)

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -45,12 +45,12 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
     :param str|None local_path: If a cloud path is given as the `path` parameter, this is the path to an existing local file that is known to be in sync with the cloud object
     :param str|None cloud_path: If a local path is given for the `path` parameter, this is a cloud path to keep in sync with the local file
     :param datetime.datetime|int|float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when it was created but could relate to a relevant time point for the data
-    :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
-    :param dict|octue.resources.tag.TagDict|None tags: key-value pairs with string keys conforming to the Octue tag format (see TagDict)
-    :param iter(str)|octue.resources.label.LabelSet|None labels: Space-separated string of labels relevant to this file
     :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin `open` function)
     :param bool update_metadata: if using as a context manager and this is `True`, update the stored metadata of the datafile when the context is exited
     :param bool hypothetical: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
+    :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
+    :param dict|octue.resources.tag.TagDict|None tags: key-value pairs with string keys conforming to the Octue tag format (see `TagDict`)
+    :param iter(str)|octue.resources.label.LabelSet|None labels: Space-separated string of labels relevant to this file
     :return None:
     """
 

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -72,12 +72,12 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         local_path=None,
         cloud_path=None,
         timestamp=None,
-        id=None,
-        tags=None,
-        labels=None,
         mode="r",
         update_metadata=True,
         hypothetical=False,
+        id=None,
+        tags=None,
+        labels=None,
         **kwargs,
     ):
         super().__init__(

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -179,7 +179,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             self._cloud_path = None
 
         else:
-            self.to_cloud(cloud_path=path)
+            self.upload(cloud_path=path)
 
     @property
     def cloud_hash_value(self):
@@ -357,7 +357,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             raise TypeError(f"An object of type {type(self)} cannot be compared with {type(other)}.")
         return self.name > other.name
 
-    def to_cloud(self, cloud_path=None, update_cloud_metadata=True):
+    def upload(self, cloud_path=None, update_cloud_metadata=True):
         """Upload a datafile to Google Cloud Storage.
 
         :param str|None cloud_path: full path to cloud storage location to store datafile at (e.g. `gs://bucket_name/path/to/file.csv`)
@@ -683,7 +683,7 @@ class _DatafileContextManager:
         if any(character in self.mode for character in self.MODIFICATION_MODES):
 
             if self.datafile.exists_in_cloud:
-                self.datafile.to_cloud(update_cloud_metadata=self._update_metadata)
+                self.datafile.upload(update_cloud_metadata=self._update_metadata)
 
             elif self._update_metadata:
                 self.datafile.update_local_metadata()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -33,14 +33,14 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
     This is used to read a list of files (and their associated properties) into octue analysis, or to compile a
     list of output files (results) and their properties that will be sent back to the octue system.
 
+    :param str|None path: the path to the dataset (defaults to the current working directory if none is given)
     :param iter(dict|octue.resources.datafile.Datafile) files: the files belonging to the dataset
-    :param str|None name:
-    :param str|None id:
-    :param str|None path:
-    :param dict|octue.resources.tag.TagDict|None tags:
-    :param iter(str)|octue.resources.label.LabelSet|None labels:
     :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained within the dataset directory
     :param bool hypothetical: if `True`, ignore any metadata stored for this dataset locally or in the cloud and use whatever is given at instantiation
+    :param str|None id: an optional UUID to assign to the dataset (defaults to a random UUID if none is given)
+    :param str|None name: an optional name to give to the dataset (defaults to the dataset directory name)
+    :param dict|octue.resources.tag.TagDict|None tags: key-value pairs with string keys conforming to the Octue tag format (see `TagDict`)
+    :param iter(str)|octue.resources.label.LabelSet|None labels: space-separated string of labels relevant to the dataset
     :return None:
     """
 
@@ -54,12 +54,12 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         self,
         path=None,
         files=None,
+        recursive=False,
+        hypothetical=False,
         id=None,
         name=None,
         tags=None,
         labels=None,
-        recursive=False,
-        hypothetical=False,
     ):
         super().__init__(name=name, id=id, tags=tags, labels=labels)
         self.path = path or os.getcwd()

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -28,13 +28,12 @@ SIGNED_METADATA_DIRECTORY = ".signed_metadata_files"
 
 
 class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadata, CloudPathable):
-    """A representation of a dataset, containing files, labels, etc.
-
-    This is used to read a list of files (and their associated properties) into octue analysis, or to compile a
-    list of output files (results) and their properties that will be sent back to the octue system.
+    """A representation of a dataset. The default usage is to provide the path to a local or cloud directory and create
+    the dataset from the files it contains. Alternatively, the `files` parameter can be provided and only those files
+    are included. Either way, the `path` parameter should be explicitly set to something meaningful.
 
     :param str|None path: the path to the dataset (defaults to the current working directory if none is given)
-    :param iter(dict|octue.resources.datafile.Datafile) files: the files belonging to the dataset
+    :param iter(str|dict|octue.resources.datafile.Datafile)|None files: the files belonging to the dataset
     :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained within the dataset directory
     :param bool hypothetical: if `True`, ignore any metadata stored for this dataset locally or in the cloud and use whatever is given at instantiation
     :param str|None id: an optional UUID to assign to the dataset (defaults to a random UUID if none is given)
@@ -66,6 +65,12 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         self.files = FilterSet()
 
         if files:
+            if not isinstance(files, list) or not isinstance(files, set) or not isinstance(files, tuple):
+                raise InvalidInputException(
+                    "The `files` parameter of a `Dataset` must be an iterable of `Datafile` instances, strings, or "
+                    f"dictionaries. Received {files!r} instead."
+                )
+
             self.files = self._instantiate_datafiles(files)
             return
 

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -52,10 +52,10 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
 
     def __init__(
         self,
-        files=None,
-        name=None,
-        id=None,
         path=None,
+        files=None,
+        id=None,
+        name=None,
         tags=None,
         labels=None,
         recursive=False,

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -65,7 +65,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         self.files = FilterSet()
 
         if files:
-            if not isinstance(files, list) or not isinstance(files, set) or not isinstance(files, tuple):
+            if not any((isinstance(files, list), isinstance(files, set), isinstance(files, tuple))):
                 raise InvalidInputException(
                     "The `files` parameter of a `Dataset` must be an iterable of `Datafile` instances, strings, or "
                     f"dictionaries. Received {files!r} instead."

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -328,7 +328,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         """
         return self.files.one(labels__contains=label)
 
-    def download_all_files(self, local_directory=None):
+    def download(self, local_directory=None):
         """Download all files in the dataset into the given local directory. If no path to a local directory is given,
         the files will be downloaded to temporary locations.
 
@@ -354,7 +354,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
             local_path = os.path.abspath(os.path.join(local_directory, *path_relative_to_dataset.split("/")))
             files_and_paths.append((file, local_path))
 
-        def download(iterable_element):
+        def download_datafile(iterable_element):
             """Download a datafile to the given path.
 
             :param tuple(octue.resources.datafile.Datafile, str) iterable_element:
@@ -366,7 +366,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
 
         # Use multiple threads to significantly speed up files downloads by reducing latency.
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            for path in executor.map(download, files_and_paths):
+            for path in executor.map(download_datafile, files_and_paths):
                 logger.debug("Downloaded datafile to %r.", path)
 
         logger.info("Downloaded %r to %r.", self, local_directory)

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -171,7 +171,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         """
         self.update_metadata()
 
-    def to_cloud(self, cloud_path=None):
+    def upload(self, cloud_path=None):
         """Upload a dataset to the given cloud path.
 
         :param str|None cloud_path: cloud path to store dataset at (e.g. `gs://bucket_name/path/to/dataset`)
@@ -196,7 +196,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
                 )
             )
 
-        def upload(iterable_element):
+        def upload_datafile(iterable_element):
             """Upload a datafile to the given cloud path.
 
             :param tuple(octue.resources.datafile.Datafile, str) iterable_element:
@@ -209,7 +209,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
 
         # Use multiple threads to significantly speed up file uploads by reducing latency.
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            for path in executor.map(upload, files_and_paths):
+            for path in executor.map(upload_datafile, files_and_paths):
                 logger.debug("Uploaded datafile to %r.", path)
 
         self.path = cloud_path

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -204,7 +204,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
             """
             datafile = iterable_element[0]
             cloud_path = iterable_element[1]
-            datafile.to_cloud(cloud_path=cloud_path)
+            datafile.upload(cloud_path=cloud_path)
             return datafile.cloud_path
 
         # Use multiple threads to significantly speed up file uploads by reducing latency.
@@ -295,13 +295,13 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
             if datafile.exists_in_cloud:
 
                 if datafile.cloud_path != new_cloud_path and not datafile.cloud_path.startswith(self.path):
-                    datafile.to_cloud(new_cloud_path)
+                    datafile.upload(new_cloud_path)
 
                 self.files.add(datafile)
                 return
 
             # Add a local datafile to a cloud dataset.
-            datafile.to_cloud(new_cloud_path)
+            datafile.upload(new_cloud_path)
             self.files.add(datafile)
             return
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -25,7 +25,7 @@ class Manifest(Serialisable, Identifiable, Hashable, Metadata):
     # Paths to datasets are added to the serialisation in `Manifest.to_primitive`.
     _SERIALISE_FIELDS = (*_METADATA_ATTRIBUTES, "name")
 
-    def __init__(self, id=None, name=None, datasets=None):
+    def __init__(self, datasets=None, id=None, name=None):
         super().__init__(id=id, name=name)
         self.datasets = self._instantiate_datasets(datasets or {})
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -13,9 +13,9 @@ class Manifest(Serialisable, Identifiable, Hashable, Metadata):
     """A representation of a manifest, which can contain multiple datasets This is used to manage all files coming into
     (or leaving), a data service for an analysis at the configuration, input or output stage.
 
-    :param str|None id: the UUID of the manifest (a UUID is generated if one isn't given)
-    :param str|None path: the path the manifest exists at (defaults to the current working directory)
     :param dict(str, octue.resources.dataset.Dataset|dict|str)|None datasets: a mapping of dataset names to `Dataset` instances, serialised datasets, or paths to datasets
+    :param str|None id: the UUID of the manifest (a UUID is generated if one isn't given)
+    :param str|None name: an optional name to give to the manifest
     :return None:
     """
 

--- a/octue/utils/metadata.py
+++ b/octue/utils/metadata.py
@@ -41,4 +41,5 @@ def overwrite_local_metadata_file(data, path=METADATA_FILENAME):
     :return None:
     """
     with open(path, "w") as f:
-        json.dump(data, f, cls=OctueJSONEncoder)
+        json.dump(data, f, cls=OctueJSONEncoder, indent=4)
+        f.write("\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.24.1"
+version = "0.25.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ hdf5 = ["h5py"]
 dataflow = ["apache-beam"]
 
 [tool.poetry.scripts]
-octue-app = "octue.cli:octue_cli"
+octue = "octue.cli:octue_cli"
 
 [tool.poetry.dev-dependencies]
 # Testing

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -71,7 +71,7 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
             "id": "Deploy Dataflow job",
             "name": OCTUE_SDK_PYTHON_IMAGE_URI,
             "args": [
-                "octue-app",
+                "octue",
                 "deploy",
                 "dataflow",
                 f"--service-id={SERVICE_ID}",

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -482,11 +482,7 @@ class TestService(BaseTestCase):
         child = self.make_new_child(BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
         parent = MockService(backend=BACKEND, children={child.id: child})
 
-        files = [
-            Datafile(path="gs://my-dataset/hello.txt", project_name="blah"),
-            Datafile(path="gs://my-dataset/goodbye.csv", project_name="blah"),
-        ]
-
+        files = [Datafile(path="gs://my-dataset/hello.txt"), Datafile(path="gs://my-dataset/goodbye.csv")]
         input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files, path="gs://my-dataset")})
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):
@@ -513,11 +509,7 @@ class TestService(BaseTestCase):
         child = self.make_new_child(BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
         parent = MockService(backend=BACKEND, children={child.id: child})
 
-        files = [
-            Datafile(path="gs://my-dataset/hello.txt", project_name=TEST_PROJECT_NAME),
-            Datafile(path="gs://my-dataset/goodbye.csv", project_name=TEST_PROJECT_NAME),
-        ]
-
+        files = [Datafile(path="gs://my-dataset/hello.txt"), Datafile(path="gs://my-dataset/goodbye.csv")]
         input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files, path="gs://my-dataset")})
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -248,7 +248,7 @@ class TestDatafile(BaseTestCase):
         self.assertEqual(downloaded_datafile.size_bytes, datafile.size_bytes)
         self.assertTrue(isinstance(downloaded_datafile._last_modified, float))
 
-    def test_to_cloud_updates_cloud_metadata(self):
+    def test_upload_updates_cloud_metadata(self):
         """Test that calling Datafile.to_cloud on a datafile that is already cloud-based updates its metadata in the
         cloud.
         """
@@ -258,7 +258,7 @@ class TestDatafile(BaseTestCase):
 
         self.assertEqual(Datafile(datafile.cloud_path).labels, {"finish"})
 
-    def test_to_cloud_does_not_update_cloud_metadata_if_update_cloud_metadata_is_false(self):
+    def test_upload_does_not_update_cloud_metadata_if_update_cloud_metadata_is_false(self):
         """Test that calling Datafile.to_cloud with `update_cloud_metadata=False` doesn't update the cloud metadata."""
         datafile, _ = self.create_datafile_in_cloud(labels={"start"})
         datafile.labels = {"finish"}
@@ -269,7 +269,7 @@ class TestDatafile(BaseTestCase):
 
         self.assertEqual(Datafile(datafile.cloud_path).labels, {"start"})
 
-    def test_to_cloud_does_not_update_metadata_if_no_metadata_change_has_been_made(self):
+    def test_upload_does_not_update_metadata_if_no_metadata_change_has_been_made(self):
         """Test that Datafile.to_cloud does not try to update cloud metadata if no metadata change has been made."""
         datafile, _ = self.create_datafile_in_cloud(labels={"start"})
 
@@ -279,7 +279,7 @@ class TestDatafile(BaseTestCase):
             new_datafile.upload()
             self.assertFalse(mock.called)
 
-    def test_to_cloud_raises_error_if_no_cloud_location_provided_and_datafile_not_from_cloud(self):
+    def test_upload_raises_error_if_no_cloud_location_provided_and_datafile_not_from_cloud(self):
         """Test that trying to send a datafile to the cloud with no cloud location provided when the datafile was not
         constructed from a cloud file results in cloud location error.
         """
@@ -288,7 +288,7 @@ class TestDatafile(BaseTestCase):
         with self.assertRaises(exceptions.CloudLocationNotSpecified):
             datafile.upload()
 
-    def test_to_cloud_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
+    def test_upload_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
         """Test datafile.to_cloud works with an implicit cloud location if the cloud location has previously been
         provided.
         """
@@ -296,7 +296,7 @@ class TestDatafile(BaseTestCase):
         new_datafile = Datafile(datafile.cloud_path)
         new_datafile.upload()
 
-    def test_to_cloud_does_not_try_to_update_file_if_no_change_has_been_made_locally(self):
+    def test_upload_does_not_try_to_update_file_if_no_change_has_been_made_locally(self):
         """Test that Datafile.to_cloud does not try to update cloud file if no change has been made locally."""
         datafile, _ = self.create_datafile_in_cloud(labels={"start"})
 

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -53,7 +53,7 @@ class TestDatafile(BaseTestCase):
             temporary_file.write(contents)
 
         datafile = Datafile(path=temporary_file.name, **kwargs)
-        datafile.to_cloud(cloud_path=cloud_path)
+        datafile.upload(cloud_path=cloud_path)
         return datafile, contents
 
     def test_instantiates(self):
@@ -254,7 +254,7 @@ class TestDatafile(BaseTestCase):
         """
         datafile, _ = self.create_datafile_in_cloud(labels={"start"})
         datafile.labels = {"finish"}
-        datafile.to_cloud(cloud_path=datafile.cloud_path)
+        datafile.upload(cloud_path=datafile.cloud_path)
 
         self.assertEqual(Datafile(datafile.cloud_path).labels, {"finish"})
 
@@ -264,7 +264,7 @@ class TestDatafile(BaseTestCase):
         datafile.labels = {"finish"}
 
         with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
-            datafile.to_cloud(datafile.cloud_path, update_cloud_metadata=False)
+            datafile.upload(datafile.cloud_path, update_cloud_metadata=False)
             self.assertFalse(mock.called)
 
         self.assertEqual(Datafile(datafile.cloud_path).labels, {"start"})
@@ -276,7 +276,7 @@ class TestDatafile(BaseTestCase):
         new_datafile = Datafile(datafile.cloud_path)
 
         with patch("octue.resources.datafile.Datafile.update_cloud_metadata") as mock:
-            new_datafile.to_cloud()
+            new_datafile.upload()
             self.assertFalse(mock.called)
 
     def test_to_cloud_raises_error_if_no_cloud_location_provided_and_datafile_not_from_cloud(self):
@@ -286,7 +286,7 @@ class TestDatafile(BaseTestCase):
         datafile = Datafile(path="hello.txt")
 
         with self.assertRaises(exceptions.CloudLocationNotSpecified):
-            datafile.to_cloud()
+            datafile.upload()
 
     def test_to_cloud_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
         """Test datafile.to_cloud works with an implicit cloud location if the cloud location has previously been
@@ -294,14 +294,14 @@ class TestDatafile(BaseTestCase):
         """
         datafile, _ = self.create_datafile_in_cloud()
         new_datafile = Datafile(datafile.cloud_path)
-        new_datafile.to_cloud()
+        new_datafile.upload()
 
     def test_to_cloud_does_not_try_to_update_file_if_no_change_has_been_made_locally(self):
         """Test that Datafile.to_cloud does not try to update cloud file if no change has been made locally."""
         datafile, _ = self.create_datafile_in_cloud(labels={"start"})
 
         with patch("octue.cloud.storage.client.GoogleCloudStorageClient.upload_file") as mock:
-            datafile.to_cloud()
+            datafile.upload()
             self.assertFalse(mock.called)
 
     def test_update_cloud_metadata(self):
@@ -515,7 +515,7 @@ class TestDatafile(BaseTestCase):
                 f.write("blah\n")
 
             cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "blah.txt")
-            datafile.to_cloud(cloud_path=cloud_path)
+            datafile.upload(cloud_path=cloud_path)
 
             self.assertEqual(datafile.local_path, os.path.abspath("blah.txt"))
             self.assertEqual(datafile.cloud_path, cloud_path)
@@ -665,7 +665,7 @@ class TestDatafile(BaseTestCase):
             deserialized_datafile = Datafile.deserialise(serialized_datafile)
             self.assertEqual(deserialized_datafile.name, "name with spaces.txt")
 
-            datafile.to_cloud(cloud_path=f"gs://{TEST_BUCKET_NAME}/name with spaces.txt")
+            datafile.upload(cloud_path=f"gs://{TEST_BUCKET_NAME}/name with spaces.txt")
 
         downloaded_datafile = Datafile(path=f"gs://{TEST_BUCKET_NAME}/name with spaces.txt")
         self.assertEqual(downloaded_datafile.name, "name with spaces.txt")
@@ -700,7 +700,7 @@ class TestDatafile(BaseTestCase):
             with datafile.open("w") as f:
                 f["dataset"] = range(10)
 
-            datafile.to_cloud(cloud_path=f"gs://{TEST_BUCKET_NAME}/my-file.hdf5")
+            datafile.upload(cloud_path=f"gs://{TEST_BUCKET_NAME}/my-file.hdf5")
 
             download_path = os.path.join(temporary_directory, "downloaded-file.hdf5")
 
@@ -833,7 +833,7 @@ class TestDatafile(BaseTestCase):
             with Datafile(path=os.path.join(temporary_directory, "my-file.dat"), mode="w") as (datafile, f):
                 f.write("I will be signed")
 
-            datafile.to_cloud(storage.path.generate_gs_path(TEST_BUCKET_NAME, "directory", "my-file.dat"))
+            datafile.upload(storage.path.generate_gs_path(TEST_BUCKET_NAME, "directory", "my-file.dat"))
 
         with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
             signed_url = datafile.generate_signed_url()
@@ -851,7 +851,7 @@ class TestDatafile(BaseTestCase):
             with Datafile(path=os.path.join(temporary_directory, "my-file.dat"), mode="w") as (datafile, f):
                 f.write("I will be signed")
 
-            datafile.to_cloud(storage.path.generate_gs_path(TEST_BUCKET_NAME, "directory", "my-file.dat"))
+            datafile.upload(storage.path.generate_gs_path(TEST_BUCKET_NAME, "directory", "my-file.dat"))
 
         with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
             signed_url = datafile.generate_signed_url()

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -593,7 +593,7 @@ class TestDataset(BaseTestCase):
         dataset = self.create_valid_dataset()
 
         with self.assertRaises(exceptions.CloudLocationNotSpecified):
-            dataset.download_all_files()
+            dataset.download()
 
     def test_download_all_files(self):
         """Test that all files in a dataset can be downloaded with one command."""
@@ -612,7 +612,7 @@ class TestDataset(BaseTestCase):
         dataset = Dataset(path=f"gs://{TEST_BUCKET_NAME}/{dataset_name}")
 
         with tempfile.TemporaryDirectory() as temporary_directory:
-            dataset.download_all_files(local_directory=temporary_directory)
+            dataset.download(local_directory=temporary_directory)
 
             with open(os.path.join(temporary_directory, "file_0.txt")) as f:
                 self.assertEqual(f.read(), "[1, 2, 3]")
@@ -627,7 +627,7 @@ class TestDataset(BaseTestCase):
         dataset = Dataset(path=dataset_path, recursive=True)
 
         with tempfile.TemporaryDirectory() as temporary_directory:
-            dataset.download_all_files(local_directory=temporary_directory)
+            dataset.download(local_directory=temporary_directory)
 
             with open(os.path.join(temporary_directory, "file_0.txt")) as f:
                 self.assertEqual(f.read(), "[1, 2, 3]")
@@ -653,7 +653,7 @@ class TestDataset(BaseTestCase):
         temporary_directory = tempfile.TemporaryDirectory()
 
         with patch("tempfile.TemporaryDirectory", return_value=temporary_directory):
-            dataset.download_all_files()
+            dataset.download()
 
         with open(os.path.join(temporary_directory.name, "file_0.txt")) as f:
             self.assertEqual(f.read(), "[1, 2, 3]")

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -432,7 +432,7 @@ class TestDataset(BaseTestCase):
             dataset.tags = {"a": "b", "c": 1}
 
             cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "a_directory", dataset.name)
-            dataset.to_cloud(cloud_path)
+            dataset.upload(cloud_path)
             persisted_dataset = Dataset(path=cloud_path)
 
             self.assertEqual(persisted_dataset.path, f"gs://{TEST_BUCKET_NAME}/a_directory/{dataset.name}")
@@ -540,7 +540,7 @@ class TestDataset(BaseTestCase):
 
             output_directory = "my_datasets"
             cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, output_directory, dataset.name)
-            dataset.to_cloud(cloud_path)
+            dataset.upload(cloud_path)
 
             storage_client = GoogleCloudStorageClient()
 
@@ -564,7 +564,7 @@ class TestDataset(BaseTestCase):
             dataset = Dataset(path=temporary_directory, recursive=True)
 
             upload_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-dataset")
-            dataset.to_cloud(cloud_path=upload_path)
+            dataset.upload(cloud_path=upload_path)
 
         cloud_datafile_relative_paths = {
             blob.name.split(dataset.name)[-1].strip("/")
@@ -586,7 +586,7 @@ class TestDataset(BaseTestCase):
         """
         dataset_path = self._create_nested_cloud_dataset()
         dataset = Dataset(path=dataset_path, recursive=True)
-        dataset.to_cloud()
+        dataset.upload()
 
     def test_error_raised_if_trying_to_download_files_from_local_dataset(self):
         """Test that an error is raised if trying to download files from a local dataset."""
@@ -711,7 +711,7 @@ class TestDataset(BaseTestCase):
                 f.write("hello")
 
             dataset = Dataset(path=dataset_local_path, tags={"hello": "world"})
-            dataset.to_cloud(storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-dataset-to-sign"))
+            dataset.upload(storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-dataset-to-sign"))
 
         with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
             signed_url = dataset.generate_signed_url()

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -39,6 +39,13 @@ class TestDataset(BaseTestCase):
         iterated_files = {file for file in dataset}
         self.assertEqual(iterated_files, dataset.files)
 
+    def test_error_raised_if_files_invalid(self):
+        """Test that an error is raised if the `files` instantiation parameter is invalid."""
+        for invalid_files in ("some/path", {"some": "value"}):
+            with self.subTest(files=invalid_files):
+                with self.assertRaises(exceptions.InvalidInputException):
+                    Dataset(files=invalid_files)
+
     def test_cannot_add_non_datafiles(self):
         """Ensures that exception will be raised if adding a non-datafile object"""
 

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -532,7 +532,7 @@ class TestDataset(BaseTestCase):
         self.assertEqual(dataset.labels, dataset_reloaded.labels)
         self.assertEqual(dataset.hash_value, dataset_reloaded.hash_value)
 
-    def test_to_cloud(self):
+    def test_upload(self):
         """Test that a dataset can be uploaded to a cloud path, including all its files and the dataset's metadata."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             dataset = create_dataset_with_two_files(temporary_directory)
@@ -555,7 +555,7 @@ class TestDataset(BaseTestCase):
             persisted_dataset_metadata = dataset._get_cloud_metadata()
             self.assertEqual(persisted_dataset_metadata["tags"], dataset.tags.to_primitive())
 
-    def test_to_cloud_with_nested_dataset_preserves_nested_structure(self):
+    def test_upload_with_nested_dataset_preserves_nested_structure(self):
         """Test that uploading a dataset containing datafiles in a nested directory structure to the cloud preserves
         this structure in the cloud.
         """
@@ -580,7 +580,7 @@ class TestDataset(BaseTestCase):
 
         self.assertEqual(cloud_datafile_relative_paths, local_datafile_relative_paths)
 
-    def test_to_cloud_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
+    def test_upload_works_with_implicit_cloud_location_if_cloud_location_previously_provided(self):
         """Test `Dataset.to_cloud` works with an implicit cloud location if the cloud location has previously been
         provided.
         """
@@ -595,7 +595,7 @@ class TestDataset(BaseTestCase):
         with self.assertRaises(exceptions.CloudLocationNotSpecified):
             dataset.download()
 
-    def test_download_all_files(self):
+    def test_download(self):
         """Test that all files in a dataset can be downloaded with one command."""
         storage_client = GoogleCloudStorageClient()
 
@@ -620,7 +620,7 @@ class TestDataset(BaseTestCase):
             with open(os.path.join(temporary_directory, "file_1.txt")) as f:
                 self.assertEqual(f.read(), "[4, 5, 6]")
 
-    def test_download_all_files_from_nested_dataset(self):
+    def test_download_from_nested_dataset(self):
         """Test that all files in a nested dataset can be downloaded with one command."""
         dataset_path = self._create_nested_cloud_dataset()
 
@@ -641,7 +641,7 @@ class TestDataset(BaseTestCase):
             with open(os.path.join(temporary_directory, "sub-directory", "sub-sub-directory", "sub_sub_file.txt")) as f:
                 self.assertEqual(f.read(), "['blah', 'b', 'c']")
 
-    def test_download_all_files_from_nested_dataset_with_no_local_directory_given(self):
+    def test_download_from_nested_dataset_with_no_local_directory_given(self):
         """Test that, when downloading all files from a nested dataset and no local directory is given, the dataset
         structure is preserved in the temporary directory used.
         """

--- a/tests/resources/test_manifest.py
+++ b/tests/resources/test_manifest.py
@@ -81,7 +81,7 @@ class TestManifest(BaseTestCase):
         """Test that a manifest can be uploaded to the cloud as a serialised JSON file of the Manifest instance."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             dataset = create_dataset_with_two_files(temporary_directory)
-            dataset.to_cloud(cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-small-dataset"))
+            dataset.upload(cloud_path=storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-small-dataset"))
 
             manifest = Manifest(datasets={"my-dataset": dataset})
             cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "manifest.json")
@@ -95,7 +95,7 @@ class TestManifest(BaseTestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             dataset = create_dataset_with_two_files(temporary_directory)
             dataset_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "my_nice_dataset")
-            dataset.to_cloud(cloud_path=dataset_path)
+            dataset.upload(cloud_path=dataset_path)
 
             manifest = Manifest(datasets={"my-dataset": dataset})
             cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "my-directory", "manifest.json")


### PR DESCRIPTION
## Summary
Standardise the data resource class parameter orders and method names to provide a more consistent and intuitive interface. Also rename the `octue-app` CLI to `octue`.

<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#455](https://github.com/octue/octue-sdk-python/pull/455))
**IMPORTANT:** There are 5 breaking changes.

### Enhancements
- 💥 **BREAKING CHANGE:** Standardise the parameter order in `Datafile`, `Dataset`, and `Manifest`. The order is now:
  - `path` first
  - Any other parameters that appear explicitly in the class next
  - Any mixin kwargs after that
  
  **How to migrate**
  If you're using kwargs to provide parameters to instantiate the above classes, no change is needed. If you're using positional args, you'll need to reorder them or switch to using kwargs:
    - `Manifest`: provide the `datasets` argument first
    - `Dataset`: provide the arguments in this order, omitting any you're not already using: 
      ```
      path, files, recursive, hypothetical, id, name, tags, labels
      ```
    - `Datafile`: Provide the `id`, `tags`, and `labels` arguments in this order after all other arguments, omitting any you're not already using
- Raise error if `files` parameter is invalid in `Dataset`

### Refactoring
- 💥 **BREAKING CHANGE:** Rename `Dataset.download_all_files` to `Dataset.download`
- 💥 **BREAKING CHANGE:** Rename `Dataset.to_cloud` to `Dataset.upload`
- 💥 **BREAKING CHANGE:** Rename `Datafile.to_cloud` to `Datafile.upload`
- 💥 **BREAKING CHANGE:** Rename the CLI entrypoint from `octue-app` to `octue`

### Fixes
- Add newline to end of `.octue` JSON files

### Operations
- Use latest commit message checker in pre-commit checks

### Dependencies
- Update dataflow `setup.py` file with correct twined version

### Testing
- Remove redundant `project_name` parameter from datafiles

<!--- END AUTOGENERATED NOTES --->