### PR TITLE
 Use name-based service IDs in deployer

### DIFF
--- a/octue/cli.py
+++ b/octue/cli.py
@@ -13,7 +13,6 @@ from octue.cloud.deployment.google.cloud_run.deployer import CloudRunDeployer
 from octue.cloud.pub_sub.service import Service
 from octue.configuration import load_service_and_app_configuration
 from octue.definitions import CHILDREN_FILENAME, FOLDER_DEFAULTS, MANIFEST_FILENAME, VALUES_FILENAME
-from octue.exceptions import DeploymentError
 from octue.log_handlers import apply_log_handler, get_remote_handler
 from octue.resources import service_backends
 from octue.runner import Runner
@@ -224,15 +223,12 @@ def deploy():
     "--service-id",
     type=str,
     default=None,
-    help="A UUID to use for the service if a specific one is required (defaults to an automatically generated one).",
+    help="An ID to use for the service if a specific one is required (defaults to an automatically generated one).",
 )
 @click.option("--no-cache", is_flag=True, help="If provided, don't use the Docker cache.")
 @click.option("--update", is_flag=True, help="If provided, allow updates to an existing service.")
 def cloud_run(octue_configuration_path, service_id, update, no_cache):
     """Deploy an app as a Google Cloud Run service."""
-    if update and not service_id:
-        raise DeploymentError("If updating a service, you must also provide the `--service-id` argument.")
-
     CloudRunDeployer(octue_configuration_path, service_id=service_id).deploy(update=update, no_cache=no_cache)
 
 
@@ -248,7 +244,7 @@ def cloud_run(octue_configuration_path, service_id, update, no_cache):
     "--service-id",
     type=str,
     default=None,
-    help="A UUID to use for the service if a specific one is required (defaults to an automatically generated one).",
+    help="An ID to use for the service if a specific one is required (defaults to an automatically generated one).",
 )
 @click.option("--no-cache", is_flag=True, help="If provided, don't use the Docker cache when building the image.")
 @click.option("--update", is_flag=True, help="If provided, allow updates to an existing service.")
@@ -269,9 +265,6 @@ def dataflow(octue_configuration_path, service_id, no_cache, update, dataflow_jo
             "To use this CLI command, you must install `octue` with the `dataflow` option e.g. "
             "`pip install octue[dataflow]`"
         )
-
-    if update and not service_id:
-        raise DeploymentError("If updating a service, you must also provide the `--service-id` argument.")
 
     deployer = DataflowDeployer(octue_configuration_path, service_id=service_id)
 

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -2,7 +2,6 @@ import json
 import subprocess
 import tempfile
 import time
-import uuid
 from abc import abstractmethod
 
 import yaml
@@ -36,7 +35,7 @@ class BaseDeployer:
     ```
 
     :param str octue_configuration_path: the path to the `octue.yaml` file if it's not in the current working directory
-    :param str|None service_id: the UUID to give the service if a random one is not suitable
+    :param str|None service_id: an ID to give the service if the one generated from `octue.yaml` isn't sufficient
     :return None:
     """
 
@@ -48,12 +47,12 @@ class BaseDeployer:
         # Generated attributes.
         self.build_trigger_description = None
         self.generated_cloud_build_configuration = None
-        self.service_id = service_id or str(uuid.uuid4())
+        self.service_id = service_id or self.service_configuration.service_id
 
-        self.required_environment_variables = {
-            "SERVICE_ID": self.service_id,
-            "SERVICE_NAME": self.service_configuration.name,
-        }
+        self.required_environment_variables = {"SERVICE_NAME": self.service_configuration.name}
+
+        if service_id:
+            self.required_environment_variables["SERVICE_ID"] = service_id
 
         self.image_uri_template = image_uri_template or (
             f"{DOCKER_REGISTRY_URL}/{self.service_configuration.project_name}/"

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -47,17 +47,19 @@ class BaseDeployer:
         # Generated attributes.
         self.build_trigger_description = None
         self.generated_cloud_build_configuration = None
-        self.service_id = service_id or self.service_configuration.service_id
+        self.service_id = (service_id or self.service_configuration.service_id).replace("/", ".")
 
         self.required_environment_variables = {"SERVICE_NAME": self.service_configuration.name}
 
         if service_id:
-            self.required_environment_variables["SERVICE_ID"] = service_id
+            self.required_environment_variables["SERVICE_ID"] = self.service_id
 
         self.image_uri_template = image_uri_template or (
             f"{DOCKER_REGISTRY_URL}/{self.service_configuration.project_name}/"
             f"{self.service_configuration.repository_name}/{self.service_configuration.name}:$SHORT_SHA"
         )
+
+        self.success_message = f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {service_id!r}."
 
     @abstractmethod
     def deploy(self, no_cache=False, update=False):

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -54,7 +54,7 @@ class CloudRunDeployer(BaseDeployer):
         self._allow_unauthenticated_messages()
         self._create_eventarc_run_trigger(update=update)
 
-        print(f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {self.service_id!r}.")
+        print(self.success_message)
         return self.service_id
 
     def _generate_cloud_build_configuration(self, no_cache=False):

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -28,7 +28,7 @@ class CloudRunDeployer(BaseDeployer):
     ```
 
     :param str octue_configuration_path: the path to the `octue.yaml` file if it's not in the current working directory
-    :param str|None service_id: the UUID to give the service if a random one is not suitable
+    :param str|None service_id: an ID to give the service if the one generated from `octue.yaml` isn't sufficient
     :return None:
     """
 

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -43,7 +43,6 @@ class DataflowDeployer(BaseDeployer):
         self.build_trigger_description = (
             f"Build the {self.service_configuration.name!r} service and deploy it to Dataflow."
         )
-        self.success_message = f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {self.service_id!r}."
 
         if not self.service_configuration.temporary_files_location:
             self.service_configuration.temporary_files_location = DEFAULT_DATAFLOW_TEMPORARY_FILES_LOCATION

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -32,7 +32,7 @@ class DataflowDeployer(BaseDeployer):
     ```
 
     :param str octue_configuration_path: the path to the `octue.yaml` file if it's not in the current working directory
-    :param str|None service_id: the UUID to give the service if a random one is not suitable
+    :param str|None service_id: an ID to give the service if the one generated from `octue.yaml` isn't sufficient
     :return None:
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.26.0"
+version = "0.26.1"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployer.py
+++ b/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployer.py
@@ -22,7 +22,6 @@ OCTUE_CONFIGURATION = {
 
 SERVICE = OCTUE_CONFIGURATION["services"][0]
 GET_SUBSCRIPTIONS_METHOD_PATH = "octue.cloud.deployment.google.cloud_run.deployer.Topic.get_subscriptions"
-SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
 EXPECTED_IMAGE_NAME = f"eu.gcr.io/{SERVICE['project_name']}/{SERVICE['repository_name']}/{SERVICE['name']}:$SHORT_SHA"
 
 EXPECTED_CLOUD_BUILD_CONFIGURATION = {
@@ -60,7 +59,7 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
                 f"--region={SERVICE['region']}",
                 "--memory=128Mi",
                 "--cpu=1",
-                f"--set-env-vars=SERVICE_ID={SERVICE_ID},SERVICE_NAME={SERVICE['name']}",
+                f"--set-env-vars=SERVICE_NAME={SERVICE['name']}",
                 "--timeout=3600",
                 "--concurrency=10",
                 "--min-instances=0",
@@ -93,7 +92,7 @@ class TestCloudRunDeployer(BaseTestCase):
         """Test that a correct Google Cloud Build configuration is generated from the given `octue.yaml` file."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = CloudRunDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = CloudRunDeployer(octue_configuration_path)
             deployer._generate_cloud_build_configuration()
 
         self.assertEqual(deployer.generated_cloud_build_configuration, EXPECTED_CLOUD_BUILD_CONFIGURATION)
@@ -111,7 +110,7 @@ class TestCloudRunDeployer(BaseTestCase):
                 temporary_directory,
             )
 
-            deployer = CloudRunDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = CloudRunDeployer(octue_configuration_path)
             deployer._generate_cloud_build_configuration()
 
         # Expect the extra "Get default Octue Dockerfile" step to be absent and the given Dockerfile path to be
@@ -140,7 +139,7 @@ class TestCloudRunDeployer(BaseTestCase):
                 temporary_directory,
             )
 
-            deployer = CloudRunDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = CloudRunDeployer(octue_configuration_path)
             deployer._generate_cloud_build_configuration()
 
         expected_cloud_build_configuration = copy.deepcopy(EXPECTED_CLOUD_BUILD_CONFIGURATION)
@@ -168,7 +167,7 @@ class TestCloudRunDeployer(BaseTestCase):
         """
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = CloudRunDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = CloudRunDeployer(octue_configuration_path)
 
             with patch("subprocess.run", return_value=Mock(returncode=0)) as mock_run:
                 with patch("octue.cloud.deployment.google.cloud_run.deployer.Topic.create"):
@@ -253,7 +252,7 @@ class TestCloudRunDeployer(BaseTestCase):
                     "--matching-criteria=type=google.cloud.pubsub.topic.v1.messagePublished",
                     f"--destination-run-service={SERVICE['name']}",
                     f"--location={SERVICE['region']}",
-                    f"--transport-topic={SERVICE_ID}",
+                    f"--transport-topic=octue.services.{SERVICE['name']}",
                 ],
             )
 

--- a/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployment.py
+++ b/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployment.py
@@ -14,7 +14,7 @@ class TestCloudRunDeployment(TestCase):
     # This is the service ID of the example service deployed to Google Cloud Run.
     child = Child(
         name="example-cloud-run-service",
-        id="octue.services.afbf37e3-7650-4e79-bc8e-37c0c26eae13",
+        id="octue/example-service-cloud-run",
         backend={"name": "GCPPubSubBackend", "project_name": os.environ["TEST_PROJECT_NAME"]},
     )
 

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -72,6 +72,7 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
                 "octue",
                 "deploy",
                 "dataflow",
+                f"--service-id={SERVICE['name']}",
                 "--update",
                 "--dataflow-job-only",
                 f"--image-uri={EXPECTED_IMAGE_NAME}",

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -37,8 +37,6 @@ OCTUE_CONFIGURATION_WITH_CLOUD_BUILD_PATH = {
     "services": [{**copy.copy(SERVICE), "cloud_build_configuration_path": "cloudbuild.yaml"}]
 }
 
-SERVICE_ID = "octue.services.0df08f9f-30ad-4db3-8029-ea584b4290b7"
-
 EXPECTED_IMAGE_NAME = (
     f"eu.gcr.io/{SERVICE['project_name']}/{SERVICE['repository_name']}/" f"{SERVICE['name']}:$SHORT_SHA"
 )
@@ -57,8 +55,8 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
             "args": [
                 "-c",
                 (
-                    f"docker build '-t' {EXPECTED_IMAGE_NAME!r} --build-arg=SERVICE_ID={SERVICE_ID} "
-                    f"--build-arg=SERVICE_NAME={SERVICE['name']} . '-f' Dockerfile"
+                    f"docker build '-t' {EXPECTED_IMAGE_NAME!r} --build-arg=SERVICE_NAME={SERVICE['name']} "
+                    ". '-f' Dockerfile"
                 ),
             ],
         },
@@ -74,7 +72,6 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
                 "octue",
                 "deploy",
                 "dataflow",
-                f"--service-id={SERVICE_ID}",
                 "--update",
                 "--dataflow-job-only",
                 f"--image-uri={EXPECTED_IMAGE_NAME}",
@@ -105,7 +102,7 @@ class TestDataflowDeployer(BaseTestCase):
         """Test that a correct Google Cloud Build configuration is generated from the given `octue.yaml` file."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
         deployer._generate_cloud_build_configuration()
         self.assertEqual(deployer.generated_cloud_build_configuration, EXPECTED_CLOUD_BUILD_CONFIGURATION)
@@ -114,7 +111,7 @@ class TestDataflowDeployer(BaseTestCase):
         """Test that the build trigger creation and run are requested correctly."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
             with patch("subprocess.run", return_value=Mock(returncode=0)) as mock_run:
                 mock_build_id = "my-build-id"
@@ -174,7 +171,7 @@ class TestDataflowDeployer(BaseTestCase):
                 temporary_directory,
             )
 
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID, image_uri_template="blah")
+            deployer = DataflowDeployer(octue_configuration_path, image_uri_template="blah")
 
             with patch("subprocess.run", return_value=Mock(returncode=0)) as mock_run:
                 mock_build_id = "my-build-id"
@@ -231,7 +228,7 @@ class TestDataflowDeployer(BaseTestCase):
         """Test creating a streaming dataflow job directly."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",
@@ -258,7 +255,7 @@ class TestDataflowDeployer(BaseTestCase):
         """Test updating an existing streaming dataflow job."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",
@@ -284,7 +281,7 @@ class TestDataflowDeployer(BaseTestCase):
         """
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",
@@ -308,7 +305,7 @@ class TestDataflowDeployer(BaseTestCase):
         """Test that a deployment error is raised if a Dataflow job already exists with the same name as the service."""
         with tempfile.TemporaryDirectory() as temporary_directory:
             octue_configuration_path = self._create_octue_configuration_file(OCTUE_CONFIGURATION, temporary_directory)
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",
@@ -332,7 +329,7 @@ class TestDataflowDeployer(BaseTestCase):
                 temporary_directory,
             )
 
-            deployer = DataflowDeployer(octue_configuration_path, service_id=SERVICE_ID)
+            deployer = DataflowDeployer(octue_configuration_path)
 
             with patch(
                 "octue.cloud.deployment.google.dataflow.pipeline.Topic",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,6 @@ import yaml
 from click.testing import CliRunner
 
 from octue.cli import octue_cli
-from octue.exceptions import DeploymentError
 from tests import TESTS_DIR
 from tests.base import BaseTestCase
 from tests.cloud.pub_sub.mocks import MockService, MockSubscriber, MockSubscription, MockTopic
@@ -146,18 +145,6 @@ class TestDeployCommand(BaseTestCase):
         self.assertIn("cloud-run ", result.output)
         self.assertIn("dataflow ", result.output)
 
-    def test_deploy_cloud_run_raises_error_if_updating_without_providing_service_id(self):
-        """Test that a deployment error is raised if attempting to update a deployed Cloud Run service without providing
-        the service ID.
-        """
-        with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
-            result = CliRunner().invoke(
-                octue_cli,
-                ["deploy", "cloud-run", f"--octue-configuration-path={temporary_file.name}", "--update"],
-            )
-        self.assertEqual(result.exit_code, 1)
-        self.assertIsInstance(result.exception, DeploymentError)
-
     def test_deploy_dataflow_fails_if_apache_beam_not_available(self):
         """Test that an `ImportWarning` is raised if the `dataflow deploy` CLI command is used when `apache_beam` is
         not available.
@@ -175,15 +162,3 @@ class TestDeployCommand(BaseTestCase):
 
         self.assertEqual(result.exit_code, 1)
         self.assertIsInstance(result.exception, ImportWarning)
-
-    def test_deploy_dataflow_raises_error_if_updating_without_providing_service_id(self):
-        """Test that a deployment error is raised if attempting to update a deployed Dataflow service without providing
-        the service ID.
-        """
-        with tempfile.NamedTemporaryFile(delete=False) as temporary_file:
-            result = CliRunner().invoke(
-                octue_cli,
-                ["deploy", "dataflow", f"--octue-configuration-path={temporary_file.name}", "--update"],
-            )
-        self.assertEqual(result.exit_code, 1)
-        self.assertIsInstance(result.exception, DeploymentError)


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
## Contents ([#463](https://github.com/octue/octue-sdk-python/pull/463))

### Enhancements
- Use name-based service IDs in deployer by default

<!--- END AUTOGENERATED NOTES --->