### PR TITLE
Log a warning if child and parent SDK versions are potentially incompatible

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -6,6 +6,8 @@ import json
 import logging
 import uuid
 
+import packaging.version
+import pkg_resources
 from google import auth
 from google.api_core import retry
 from google.cloud import pubsub_v1
@@ -128,7 +130,29 @@ class Service(CoolNameable):
         :raise Exception: if any exception arises during running analysis and sending its results
         :return None:
         """
-        data, question_uuid, forward_logs = self._parse_question(question)
+        data, question_uuid, forward_logs, parent_sdk_version = self._parse_question(question)
+
+        if parent_sdk_version:
+            local_sdk_version = packaging.version.parse(pkg_resources.get_distribution("octue").version)
+
+            if (
+                local_sdk_version.major != parent_sdk_version.major
+                or local_sdk_version.minor != parent_sdk_version.minor
+            ):
+                logger.warning(
+                    "The parent's Octue SDK version %s may not be compatible with the local Octue SDK version %s. "
+                    "Update them both to the latest version (or at least a version with the same major and minor "
+                    "version numbers) if possible.",
+                    parent_sdk_version,
+                    local_sdk_version,
+                )
+
+        else:
+            logger.warning(
+                "The parent couldn't be checked for compatibility with this service because it didn't send its Octue "
+                "SDK version with its question. Please update it to the latest Octue SDK version."
+            )
+
         topic = answer_topic or self.instantiate_answer_topic(question_uuid)
         self._send_delivery_acknowledgment(topic)
 
@@ -249,6 +273,7 @@ class Service(CoolNameable):
             data=json.dumps({"input_values": input_values, "input_manifest": serialised_input_manifest}).encode(),
             question_uuid=question_uuid,
             forward_logs=str(int(subscribe_to_logs)),
+            octue_sdk_version=pkg_resources.get_distribution("octue").version,
             retry=retry.Retry(deadline=timeout),
         )
 
@@ -383,7 +408,7 @@ class Service(CoolNameable):
         """Parse a question in the Google Cloud Pub/Sub or Google Cloud Run format.
 
         :param dict|Message question:
-        :return (dict, str, bool):
+        :return (dict, str, bool, packaging.version.Version|None):
         """
         try:
             # Parse question directly from Pub/Sub or Dataflow.
@@ -401,4 +426,10 @@ class Service(CoolNameable):
 
         question_uuid = get_nested_attribute(question, "attributes.question_uuid")
         forward_logs = bool(int(get_nested_attribute(question, "attributes.forward_logs")))
-        return data, question_uuid, forward_logs
+
+        try:
+            sdk_version = packaging.version.parse(get_nested_attribute(question, "attributes.octue_sdk_version"))
+        except AttributeError:
+            sdk_version = None
+
+        return data, question_uuid, forward_logs, sdk_version

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -428,8 +428,11 @@ class Service(CoolNameable):
         forward_logs = bool(int(get_nested_attribute(question, "attributes.forward_logs")))
 
         try:
-            sdk_version = packaging.version.parse(get_nested_attribute(question, "attributes.octue_sdk_version"))
+            parent_sdk_version = get_nested_attribute(question, "attributes.octue_sdk_version")
         except AttributeError:
-            sdk_version = None
+            parent_sdk_version = None
 
-        return data, question_uuid, forward_logs, sdk_version
+        if parent_sdk_version:
+            parent_sdk_version = packaging.version.parse(parent_sdk_version)
+
+        return data, question_uuid, forward_logs, parent_sdk_version

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -132,36 +132,40 @@ class Service(CoolNameable):
         """
         data, question_uuid, forward_logs, parent_sdk_version = self._parse_question(question)
 
-        if parent_sdk_version:
-            local_sdk_version = packaging.version.parse(pkg_resources.get_distribution("octue").version)
-
-            if (
-                local_sdk_version.major != parent_sdk_version.major
-                or local_sdk_version.minor != parent_sdk_version.minor
-            ):
-                logger.warning(
-                    "The parent's Octue SDK version %s may not be compatible with the local Octue SDK version %s. "
-                    "Update them both to the latest version (or at least a version with the same major and minor "
-                    "version numbers) if possible.",
-                    parent_sdk_version,
-                    local_sdk_version,
-                )
-
-        else:
-            logger.warning(
-                "The parent couldn't be checked for compatibility with this service because it didn't send its Octue "
-                "SDK version with its question. Please update it to the latest Octue SDK version."
-            )
-
         topic = answer_topic or self.instantiate_answer_topic(question_uuid)
         self._send_delivery_acknowledgment(topic)
 
-        if forward_logs:
-            analysis_log_handler = GooglePubSubHandler(publisher=self.publisher, topic=topic, analysis_id=question_uuid)
-        else:
-            analysis_log_handler = None
-
         try:
+            if forward_logs:
+                analysis_log_handler = GooglePubSubHandler(
+                    publisher=self.publisher,
+                    topic=topic,
+                    analysis_id=question_uuid,
+                )
+            else:
+                analysis_log_handler = None
+
+            if parent_sdk_version:
+                local_sdk_version = packaging.version.parse(pkg_resources.get_distribution("octue").version)
+
+                if (
+                    local_sdk_version.major != parent_sdk_version.major
+                    or local_sdk_version.minor != parent_sdk_version.minor
+                ):
+                    logger.warning(
+                        "The parent's Octue SDK version %s may not be compatible with the local Octue SDK version %s. "
+                        "Update them both to the latest version (or at least a version with the same major and minor "
+                        "version numbers) if possible.",
+                        parent_sdk_version,
+                        local_sdk_version,
+                    )
+
+            else:
+                logger.warning(
+                    "The parent couldn't be checked for compatibility with this service because it didn't send its Octue "
+                    "SDK version with its question. Please update it to the latest Octue SDK version."
+                )
+
             analysis = self.run_function(
                 analysis_id=question_uuid,
                 input_values=data["input_values"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.26.1"
+version = "0.26.2"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 import google.api_core.exceptions
+import pkg_resources
 
 from octue.cloud.pub_sub import Subscription, Topic
 from octue.cloud.pub_sub.service import Service
@@ -248,6 +249,7 @@ class MockService(Service):
         question_uuid=None,
         push_endpoint=None,
         timeout=30,
+        parent_sdk_version=pkg_resources.get_distribution("octue").version,
     ):
         """Put the question into the messages register, register the existence of the corresponding response topic, add
         the response to the register, and return a MockFuture containing the answer subscription path.
@@ -284,6 +286,7 @@ class MockService(Service):
                     data=json.dumps({"input_values": input_values, "input_manifest": input_manifest}).encode(),
                     question_uuid=question_uuid,
                     forward_logs=subscribe_to_logs,
+                    octue_sdk_version=parent_sdk_version,
                 )
             )
         except Exception as e:  # noqa

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -58,81 +58,6 @@ class TestService(BaseTestCase):
     (GCP), or a local emulator.
     """
 
-    @staticmethod
-    def make_new_child(backend, run_function_returnee, use_mock=False):
-        """Make and return a new child service that returns the given run function returnee when its run function is
-        executed.
-
-        :param octue.resources.service_backends.ServiceBackend backend:
-        :param any run_function_returnee:
-        :param bool use_mock:
-        :return tests.cloud.pub_sub.mocks.MockService:
-        """
-        run_function = (
-            lambda analysis_id, input_values, input_manifest, analysis_log_handler, handle_monitor_message: run_function_returnee
-        )
-
-        if use_mock:
-            return MockService(backend=backend, run_function=run_function)
-
-        return Service(backend=backend, run_function=run_function)
-
-    @staticmethod
-    def ask_question_and_wait_for_answer(
-        parent,
-        child,
-        input_values,
-        input_manifest,
-        subscribe_to_logs=True,
-        allow_local_files=False,
-        service_name="my-service",
-        question_uuid=None,
-        push_endpoint=None,
-        timeout=30,
-        delivery_acknowledgement_timeout=30,
-        parent_sdk_version=None,
-    ):
-        """Get a parent service to ask a question to a child service and wait for the answer.
-
-        :param tests.cloud.pub_sub.mocks.MockService parent:
-        :param tests.cloud.pub_sub.mocks.MockService child:
-        :param dict|None input_values:
-        :param octue.resources.manifest.Manifest|None input_manifest:
-        :param bool subscribe_to_logs:
-        :return dict:
-        """
-        subscription, _ = parent.ask(
-            service_id=child.id,
-            input_values=input_values,
-            input_manifest=input_manifest,
-            subscribe_to_logs=subscribe_to_logs,
-            allow_local_files=allow_local_files,
-            question_uuid=question_uuid,
-            push_endpoint=push_endpoint,
-            timeout=timeout,
-            parent_sdk_version=parent_sdk_version,
-        )
-
-        return parent.wait_for_answer(
-            subscription=subscription,
-            service_name=service_name,
-            delivery_acknowledgement_timeout=delivery_acknowledgement_timeout,
-        )
-
-    def make_child_service_with_error(self, exception_to_raise):
-        """Make a mock child service that raises the given exception when its run function is executed.
-
-        :param Exception exception_to_raise:
-        :return tests.cloud.pub_sub.mocks.MockService:
-        """
-        child = self.make_new_child(BACKEND, run_function_returnee=None, use_mock=True)
-
-        def error_run_function(analysis_id, input_values, input_manifest, analysis_log_handler, handle_monitor_message):
-            raise exception_to_raise
-
-        child.run_function = error_run_function
-        return child
-
     def test_namespace_always_appears_in_id(self):
         """Test that the Octue service namespace always appears at the start of a service's ID whether it's explicitly
         provided or not.
@@ -599,8 +524,8 @@ class TestService(BaseTestCase):
         self.assertEqual(answer["output_values"], MockAnalysisWithOutputManifest.output_values)
         self.assertEqual(answer["output_manifest"].id, MockAnalysisWithOutputManifest.output_manifest.id)
 
-    def test_service_can_ask_multiple_questions(self):
-        """Test that a service can ask multiple questions to the same server and expect replies to them all."""
+    def test_service_can_ask_multiple_questions_to_child(self):
+        """Test that a service can ask multiple questions to the same child and expect replies to them all."""
         child = self.make_new_child(BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
         parent = MockService(backend=BACKEND, children={child.id: child})
 
@@ -627,8 +552,8 @@ class TestService(BaseTestCase):
                 {"output_values": MockAnalysis().output_values, "output_manifest": MockAnalysis().output_manifest},
             )
 
-    def test_service_can_ask_questions_to_multiple_servers(self):
-        """Test that a service can ask questions to different servers and expect replies to them all."""
+    def test_service_can_ask_questions_to_multiple_children(self):
+        """Test that a service can ask questions to different children and expect replies to them all."""
         child_1 = self.make_new_child(BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
         child_2 = self.make_new_child(BACKEND, run_function_returnee=DifferentMockAnalysis(), use_mock=True)
 
@@ -667,7 +592,7 @@ class TestService(BaseTestCase):
             },
         )
 
-    def test_server_can_ask_its_own_child_questions(self):
+    def test_child_can_ask_its_own_child_questions(self):
         """Test that a child can contact its own child while answering a question from a parent."""
         child_of_child = self.make_new_child(BACKEND, run_function_returnee=DifferentMockAnalysis(), use_mock=True)
 
@@ -709,7 +634,7 @@ class TestService(BaseTestCase):
             },
         )
 
-    def test_server_can_ask_its_own_children_questions(self):
+    def test_child_can_ask_its_own_children_questions(self):
         """Test that a child can contact more than one of its own children while answering a question from a parent."""
         first_child_of_child = self.make_new_child(
             BACKEND,
@@ -801,3 +726,78 @@ class TestService(BaseTestCase):
                                         f"with the local Octue SDK version {child_sdk_version}",
                                         logging_context.output[2],
                                     )
+
+    @staticmethod
+    def make_new_child(backend, run_function_returnee, use_mock=False):
+        """Make and return a new child service that returns the given run function returnee when its run function is
+        executed.
+
+        :param octue.resources.service_backends.ServiceBackend backend:
+        :param any run_function_returnee:
+        :param bool use_mock:
+        :return tests.cloud.pub_sub.mocks.MockService:
+        """
+        run_function = (
+            lambda analysis_id, input_values, input_manifest, analysis_log_handler, handle_monitor_message: run_function_returnee
+        )
+
+        if use_mock:
+            return MockService(backend=backend, run_function=run_function)
+
+        return Service(backend=backend, run_function=run_function)
+
+    @staticmethod
+    def ask_question_and_wait_for_answer(
+        parent,
+        child,
+        input_values,
+        input_manifest,
+        subscribe_to_logs=True,
+        allow_local_files=False,
+        service_name="my-service",
+        question_uuid=None,
+        push_endpoint=None,
+        timeout=30,
+        delivery_acknowledgement_timeout=30,
+        parent_sdk_version=None,
+    ):
+        """Get a parent service to ask a question to a child service and wait for the answer.
+
+        :param tests.cloud.pub_sub.mocks.MockService parent:
+        :param tests.cloud.pub_sub.mocks.MockService child:
+        :param dict|None input_values:
+        :param octue.resources.manifest.Manifest|None input_manifest:
+        :param bool subscribe_to_logs:
+        :return dict:
+        """
+        subscription, _ = parent.ask(
+            service_id=child.id,
+            input_values=input_values,
+            input_manifest=input_manifest,
+            subscribe_to_logs=subscribe_to_logs,
+            allow_local_files=allow_local_files,
+            question_uuid=question_uuid,
+            push_endpoint=push_endpoint,
+            timeout=timeout,
+            parent_sdk_version=parent_sdk_version,
+        )
+
+        return parent.wait_for_answer(
+            subscription=subscription,
+            service_name=service_name,
+            delivery_acknowledgement_timeout=delivery_acknowledgement_timeout,
+        )
+
+    def make_child_service_with_error(self, exception_to_raise):
+        """Make a mock child service that raises the given exception when its run function is executed.
+
+        :param Exception exception_to_raise:
+        :return tests.cloud.pub_sub.mocks.MockService:
+        """
+        child = self.make_new_child(BACKEND, run_function_returnee=None, use_mock=True)
+
+        def error_run_function(analysis_id, input_values, input_manifest, analysis_log_handler, handle_monitor_message):
+            raise exception_to_raise
+
+        child.run_function = error_run_function
+        return child

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -724,7 +724,7 @@ class TestService(BaseTestCase):
                                     self.assertIn(
                                         f"The parent's Octue SDK version {parent_sdk_version} may not be compatible "
                                         f"with the local Octue SDK version {child_sdk_version}",
-                                        logging_context.output[2],
+                                        logging_context.output[3],
                                     )
 
     @staticmethod


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#464](https://github.com/octue/octue-sdk-python/pull/464))

### Enhancements
- Log a warning if the child and parent SDK versions potentially incompatible
- Forward any errors to do with instantiating `GooglePubSubHandler` in child to parent

<!--- END AUTOGENERATED NOTES --->