### PR TITLE
Remove support for setting service UUIDs via CLI

### DIFF
--- a/octue/cli.py
+++ b/octue/cli.py
@@ -216,7 +216,6 @@ def start(service_config, timeout, rm):
         backend = service_backends.get_backend()(project_name=project_name)
 
     service = Service(
-        name=service_configuration.service_id,
         service_id=service_configuration.service_id,
         backend=backend,
         run_function=run_function,

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -176,14 +176,6 @@ def run(service_config, input_dir, output_file, output_manifest_file, monitor_me
     default="octue.yaml",
     help="The path to an `octue.yaml` file defining the service to start.",
 )
-@click.option(
-    "--service-id",
-    type=click.STRING,
-    default=None,
-    show_default=True,
-    help="A unique ID for the service (this should be unique over all time and space). If not provided, the ID is "
-    "generated from the `octue.yaml` file.",
-)
 @click.option("--timeout", type=click.INT, default=None, show_default=True, help="Timeout in seconds for serving.")
 @click.option(
     "--rm",
@@ -193,10 +185,9 @@ def run(service_config, input_dir, output_file, output_manifest_file, monitor_me
     show_default=True,
     help="Delete the Google Pub/Sub topic and subscription for the service on exit.",
 )
-def start(service_config, service_id, timeout, rm):
+def start(service_config, timeout, rm):
     """Start the service as a child to be asked questions by other services."""
     service_configuration, app_configuration = load_service_and_app_configuration(service_config)
-    service_id = service_id or service_configuration.service_id
 
     runner = Runner(
         app_src=service_configuration.app_source_path,
@@ -205,7 +196,7 @@ def start(service_config, service_id, timeout, rm):
         configuration_manifest=app_configuration.configuration_manifest,
         children=app_configuration.children,
         output_location=app_configuration.output_location,
-        service_id=service_id,
+        service_id=service_configuration.service_id,
     )
 
     run_function = functools.partial(
@@ -225,8 +216,8 @@ def start(service_config, service_id, timeout, rm):
         backend = service_backends.get_backend()(project_name=project_name)
 
     service = Service(
-        name=service_id,
-        service_id=service_id,
+        name=service_configuration.service_id,
+        service_id=service_configuration.service_id,
         backend=backend,
         run_function=run_function,
     )
@@ -248,17 +239,11 @@ def deploy():
     show_default=True,
     help="The path to an `octue.yaml` file defining the service to deploy.",
 )
-@click.option(
-    "--service-id",
-    type=str,
-    default=None,
-    help="An ID to use for the service if a specific one is required (defaults to an automatically generated one).",
-)
 @click.option("--no-cache", is_flag=True, help="If provided, don't use the Docker cache.")
 @click.option("--update", is_flag=True, help="If provided, allow updates to an existing service.")
-def cloud_run(service_config, service_id, update, no_cache):
+def cloud_run(service_config, update, no_cache):
     """Deploy an app as a Google Cloud Run service."""
-    CloudRunDeployer(service_config, service_id=service_id).deploy(update=update, no_cache=no_cache)
+    CloudRunDeployer(service_config).deploy(update=update, no_cache=no_cache)
 
 
 @deploy.command()
@@ -270,12 +255,6 @@ def cloud_run(service_config, service_id, update, no_cache):
     show_default=True,
     help="The path to an `octue.yaml` file defining the service to deploy.",
 )
-@click.option(
-    "--service-id",
-    type=str,
-    default=None,
-    help="An ID to use for the service if a specific one is required (defaults to an automatically generated one).",
-)
 @click.option("--no-cache", is_flag=True, help="If provided, don't use the Docker cache when building the image.")
 @click.option("--update", is_flag=True, help="If provided, allow updates to an existing service.")
 @click.option(
@@ -284,7 +263,7 @@ def cloud_run(service_config, service_id, update, no_cache):
     help="If provided, skip creating and running the build trigger and just deploy a pre-built image to Dataflow",
 )
 @click.option("--image-uri", type=str, default=None, help="The actual image URI to use when creating the Dataflow job.")
-def dataflow(service_config, service_id, no_cache, update, dataflow_job_only, image_uri):
+def dataflow(service_config, no_cache, update, dataflow_job_only, image_uri):
     """Deploy an app as a Google Dataflow streaming job."""
     if bool(importlib.util.find_spec("apache_beam")):
         # Import the Dataflow deployer only if the `apache-beam` package is available (due to installing `octue` with
@@ -296,7 +275,7 @@ def dataflow(service_config, service_id, no_cache, update, dataflow_job_only, im
             "`pip install octue[dataflow]`"
         )
 
-    deployer = DataflowDeployer(service_config, service_id=service_id)
+    deployer = DataflowDeployer(service_config)
 
     if dataflow_job_only:
         deployer.create_streaming_dataflow_job(image_uri=image_uri, update=update)

--- a/octue/cloud/deployment/google/answer_pub_sub_question.py
+++ b/octue/cloud/deployment/google/answer_pub_sub_question.py
@@ -26,7 +26,6 @@ def answer_question(question, project_name):
     service_id = os.environ.get("SERVICE_ID") or service_configuration.service_id
 
     service = Service(
-        name=service_id,
         service_id=service_id,
         backend=GCPPubSubBackend(project_name=project_name),
     )

--- a/octue/cloud/deployment/google/base_deployer.py
+++ b/octue/cloud/deployment/google/base_deployer.py
@@ -35,31 +35,27 @@ class BaseDeployer:
     ```
 
     :param str octue_configuration_path: the path to the `octue.yaml` file if it's not in the current working directory
-    :param str|None service_id: an ID to give the service if the one generated from `octue.yaml` isn't sufficient
     :return None:
     """
 
     TOTAL_NUMBER_OF_STAGES = None
 
-    def __init__(self, octue_configuration_path, service_id=None, image_uri_template=None):
+    def __init__(self, octue_configuration_path, image_uri_template=None):
         self.service_configuration = ServiceConfiguration.from_file(octue_configuration_path)
 
         # Generated attributes.
         self.build_trigger_description = None
         self.generated_cloud_build_configuration = None
-        self.service_id = (service_id or self.service_configuration.service_id).replace("/", ".")
+        self.service_id = self.service_configuration.service_id.replace("/", ".")
 
         self.required_environment_variables = {"SERVICE_NAME": self.service_configuration.name}
-
-        if service_id:
-            self.required_environment_variables["SERVICE_ID"] = self.service_id
 
         self.image_uri_template = image_uri_template or (
             f"{DOCKER_REGISTRY_URL}/{self.service_configuration.project_name}/"
             f"{self.service_configuration.repository_name}/{self.service_configuration.name}:$SHORT_SHA"
         )
 
-        self.success_message = f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {service_id!r}."
+        self.success_message = f"[SUCCESS] Service deployed - it can be questioned via Pub/Sub at {self.service_id!r}."
 
     @abstractmethod
     def deploy(self, no_cache=False, update=False):

--- a/octue/cloud/deployment/google/cloud_run/deployer.py
+++ b/octue/cloud/deployment/google/cloud_run/deployer.py
@@ -28,14 +28,13 @@ class CloudRunDeployer(BaseDeployer):
     ```
 
     :param str octue_configuration_path: the path to the `octue.yaml` file if it's not in the current working directory
-    :param str|None service_id: an ID to give the service if the one generated from `octue.yaml` isn't sufficient
     :return None:
     """
 
     TOTAL_NUMBER_OF_STAGES = 5
 
-    def __init__(self, octue_configuration_path, service_id=None, image_uri_template=None):
-        super().__init__(octue_configuration_path, service_id, image_uri_template)
+    def __init__(self, octue_configuration_path, image_uri_template=None):
+        super().__init__(octue_configuration_path, image_uri_template)
         self.build_trigger_description = (
             f"Build the {self.service_configuration.name!r} service and deploy it to Cloud Run."
         )

--- a/octue/cloud/deployment/google/dataflow/deployer.py
+++ b/octue/cloud/deployment/google/dataflow/deployer.py
@@ -32,14 +32,13 @@ class DataflowDeployer(BaseDeployer):
     ```
 
     :param str octue_configuration_path: the path to the `octue.yaml` file if it's not in the current working directory
-    :param str|None service_id: an ID to give the service if the one generated from `octue.yaml` isn't sufficient
     :return None:
     """
 
     TOTAL_NUMBER_OF_STAGES = 3
 
-    def __init__(self, octue_configuration_path, service_id=None, image_uri_template=None):
-        super().__init__(octue_configuration_path, service_id, image_uri_template)
+    def __init__(self, octue_configuration_path, image_uri_template=None):
+        super().__init__(octue_configuration_path, image_uri_template)
         self.build_trigger_description = (
             f"Build the {self.service_configuration.name!r} service and deploy it to Dataflow."
         )
@@ -173,7 +172,6 @@ class DataflowDeployer(BaseDeployer):
                             "octue",
                             "deploy",
                             "dataflow",
-                            f"--service-id={self.service_id}",
                             "--update",
                             "--dataflow-job-only",
                             f"--image-uri={self.image_uri_template}",

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -58,6 +58,7 @@ class Service(CoolNameable):
             else:
                 self.id = f"{OCTUE_NAMESPACE}.{service_id}"
 
+            self.name = kwargs.get("name") or self.id
             self.id = self._clean_service_id(self.id)
 
         self.backend = backend

--- a/octue/templates/template-child-services/elevation_service/octue.yaml
+++ b/octue/templates/template-child-services/elevation_service/octue.yaml
@@ -1,4 +1,3 @@
 services:
   - name: elevation-service
-    organisation: template-child-services
     app_configuration_path: app_configuration.json

--- a/octue/templates/template-child-services/wind_speed_service/octue.yaml
+++ b/octue/templates/template-child-services/wind_speed_service/octue.yaml
@@ -1,4 +1,3 @@
 services:
   - name: wind-speed-service
-    organisation: template-child-services
     app_configuration_path: app_configuration.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.27.0"
+version = "0.28.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Thomas Clark <support@octue.com>", "cortadocodes <cortado.codes@protonmail.com>"]

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployer.py
@@ -72,7 +72,6 @@ EXPECTED_CLOUD_BUILD_CONFIGURATION = {
                 "octue",
                 "deploy",
                 "dataflow",
-                f"--service-id={SERVICE['name']}",
                 "--update",
                 "--dataflow-job-only",
                 f"--image-uri={EXPECTED_IMAGE_NAME}",


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Upgrade instructions
**IMPORTANT:** There is 1 breaking change.

**Remove `--service-id` option from CLI**
Services should now be given meaningful names for IDs instead of UUIDs. Set the "name" and "organisation" fields in your `octue.yaml` file - the service will then use an ID of `<organisation>/<name>`.

## Contents ([#472](https://github.com/octue/octue-sdk-python/pull/472))

### Enhancements
- 💥 **BREAKING CHANGE:** Remove `--service-id` option from CLI
- Name `Service` instances by their given service IDs

<!--- END AUTOGENERATED NOTES --->