### PR TITLE
 Ensure Datafile instances have correct open mode in context manager

### DIFF
--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -646,6 +646,9 @@ class _DatafileContextManager:
         self.kwargs = kwargs
         self._fp = None
 
+        # Update the open mode on the datafile as it's used in `Datafile` methods.
+        self.datafile._open_attributes["mode"] = self.mode
+
     def __enter__(self):
         """Open the datafile, first downloading it from the cloud if necessary.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.27.1"
+version = "0.27.2"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -382,8 +382,14 @@ class TestDatafile(BaseTestCase):
         with datafile.open("w") as f:
             f.write("hello")
 
+        # Test that the datafile's "open attributes" are updated.
+        self.assertEqual(datafile._open_attributes["mode"], "w")
+
         with datafile.open() as f:
             self.assertEqual(f.read(), "hello")
+
+        # Test that the datafile's "open attributes" are updated.
+        self.assertEqual(datafile._open_attributes["mode"], "r")
 
     def test_open_with_reading_cloud_file(self):
         """Test that a cloud datafile can be opened for reading."""
@@ -405,6 +411,9 @@ class TestDatafile(BaseTestCase):
 
             # Check that the cloud file isn't updated until the context manager is closed.
             self.assertEqual(GoogleCloudStorageClient().download_as_string(datafile.cloud_path), original_contents)
+
+            # Test that the datafile's "open attributes" are updated.
+            self.assertEqual(new_datafile._open_attributes["mode"], "w")
 
         # Check that the cloud file has now been updated.
         self.assertEqual(GoogleCloudStorageClient().download_as_string(datafile.cloud_path), new_file_contents)


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
## Contents ([#476](https://github.com/octue/octue-sdk-python/pull/476))

### Fixes
- Ensure `Datafile` instances have the correct open mode when the `Datafile.open` context manager is used

<!--- END AUTOGENERATED NOTES --->