### PR TITLE
Fix poetry/importlib-metadata dependency resolution failure for docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
       - id: build-docs
         language_version: python3
         additional_dependencies:
+          - 'git+https://github.com/python-poetry/poetry.git@master'
           - 'Sphinx>=4,<5'
           - 'sphinx-rtd-theme>=1,<2'
           - 'sphinx-tabs>=3,<4'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: build-docs
         language_version: python3
         additional_dependencies:
-          - 'git+https://github.com/python-poetry/poetry.git@master'
+          - 'git+https://github.com/python-poetry/poetry.git@1.2.0b2'
           - 'Sphinx>=4,<5'
           - 'sphinx-rtd-theme>=1,<2'
           - 'sphinx-tabs>=3,<4'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: build-docs
         language_version: python3
         additional_dependencies:
-          - 'git+https://github.com/python-poetry/poetry.git@1.2.0b2'
+          - 'poetry==1.2.0b2'
           - 'Sphinx>=4,<5'
           - 'sphinx-rtd-theme>=1,<2'
           - 'sphinx-tabs>=3,<4'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 # Required by the python script for building documentation
+git+https://github.com/python-poetry/poetry.git@master
 Sphinx>=4,<5
 sphinx-rtd-theme>=1,<2
 sphinx-tabs>=3,<4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Required by the python script for building documentation
-git+https://github.com/python-poetry/poetry.git@master
+git+https://github.com/python-poetry/poetry.git@1.2.0b2
 Sphinx>=4,<5
 sphinx-rtd-theme>=1,<2
 sphinx-tabs>=3,<4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 # Required by the python script for building documentation
-poetry>=1.1,<2
 Sphinx>=4,<5
 sphinx-rtd-theme>=1,<2
 sphinx-tabs>=3,<4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Required by the python script for building documentation
-git+https://github.com/python-poetry/poetry.git@1.2.0b2
+poetry==1.2.0b2
 Sphinx>=4,<5
 sphinx-rtd-theme>=1,<2
 sphinx-tabs>=3,<4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.29.0"
+version = "0.29.1"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#484](https://github.com/octue/octue-sdk-python/pull/484))

### Dependencies
- Use `poetry` pre-release `1.2.0b2` in docs requirements to avoid `importlib-metadata` dependency resolution failure

<!--- END AUTOGENERATED NOTES --->