### PR TITLE
Avoid h5py ImportError when not using HDF5 files

### DIFF
--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -18,7 +18,7 @@ from octue.resources.tag import TagDict
 
 try:
     import h5py
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     pass
 
 from octue.cloud import storage

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -16,6 +16,8 @@ from octue.resources.label import LabelSet
 from octue.resources.tag import TagDict
 
 
+# The `h5py` package is only needed if dealing with HDF5 files. It's only available if the `hdf5` extra is provided
+# during installation of `octue`.
 try:
     import h5py
 except (ModuleNotFoundError, ImportError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.29.1"
+version = "0.29.2"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#485](https://github.com/octue/octue-sdk-python/pull/485))

### Fixes
- Except `ImportError` if `h5py` package is missing

<!--- END AUTOGENERATED NOTES --->