### PR TITLE
Ensure children can always access input datasets 

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -256,7 +256,9 @@ class Service(CoolNameable):
         answer_subscription.create(allow_existing=True)
 
         serialised_input_manifest = None
+
         if input_manifest is not None:
+            input_manifest.use_signed_urls_for_datasets()
             serialised_input_manifest = input_manifest.serialise()
 
         self.publisher.publish(

--- a/octue/resources/analysis.py
+++ b/octue/resources/analysis.py
@@ -127,7 +127,8 @@ class Analysis(Identifiable, Serialisable, Labelable, Taggable):
 
         for name, dataset in self.output_manifest.datasets.items():
             dataset.upload(cloud_path=storage.path.join(upload_output_datasets_to, name))
-            self.output_manifest.datasets[name].path = dataset.generate_signed_url()
+
+        self.output_manifest.use_signed_urls_for_datasets()
 
         logger.info("Uploaded output datasets to %r.", upload_output_datasets_to)
 

--- a/octue/resources/manifest.py
+++ b/octue/resources/manifest.py
@@ -65,7 +65,7 @@ class Manifest(Serialisable, Identifiable, Hashable, Metadata):
             if dataset.exists_in_cloud:
                 self.datasets[name].path = dataset.generate_signed_url()
 
-        logger.debug("Cloud paths (cloud URIs) replaced with signed URLs in %r.", self)
+        logger.debug("Cloud paths (cloud URIs) for datasets replaced with signed URLs in %r.", self)
 
     def to_cloud(self, cloud_path):
         """Upload a manifest to a cloud location, optionally uploading its datasets into the same directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.29.3"
+version = "0.29.4"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -773,6 +773,13 @@ class TestService(BaseTestCase):
         :param dict|None input_values:
         :param octue.resources.manifest.Manifest|None input_manifest:
         :param bool subscribe_to_logs:
+        :param bool allow_local_files:
+        :param str service_name:
+        :param str|None question_uuid:
+        :param callable|None push_endpoint:
+        :param int|float timeout:
+        :param int|float delivery_acknowledgement_timeout:
+        :param str|None parent_sdk_version:
         :return dict:
         """
         subscription, _ = parent.ask(

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -9,7 +9,7 @@ from octue.cloud.pub_sub.service import Service
 from octue.exceptions import InvalidMonitorMessage
 from octue.resources import Datafile, Dataset, Manifest
 from octue.resources.service_backends import GCPPubSubBackend
-from tests import TEST_PROJECT_NAME
+from tests import TEST_BUCKET_NAME, TEST_PROJECT_NAME
 from tests.base import BaseTestCase
 from tests.cloud.pub_sub.mocks import (
     DifferentMockAnalysis,
@@ -403,14 +403,22 @@ class TestService(BaseTestCase):
         )
 
     def test_ask_with_input_manifest(self):
-        """Test that a service can ask a question including an input_manifest to another service that is serving and
+        """Test that a service can ask a question including an input manifest to another service that is serving and
         receive an answer.
         """
         child = self.make_new_child(BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
         parent = MockService(backend=BACKEND, children={child.id: child})
 
-        files = [Datafile(path="gs://my-dataset/hello.txt"), Datafile(path="gs://my-dataset/goodbye.csv")]
-        input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files, path="gs://my-dataset")})
+        dataset_path = f"gs://{TEST_BUCKET_NAME}/my-dataset"
+
+        input_manifest = Manifest(
+            datasets={
+                "my-dataset": Dataset(
+                    files=[f"{dataset_path}/hello.txt", f"{dataset_path}/goodbye.csv"],
+                    path=dataset_path,
+                )
+            }
+        )
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):
             with patch("octue.cloud.pub_sub.service.Subscription", new=MockSubscription):
@@ -436,8 +444,16 @@ class TestService(BaseTestCase):
         child = self.make_new_child(BACKEND, run_function_returnee=MockAnalysis(), use_mock=True)
         parent = MockService(backend=BACKEND, children={child.id: child})
 
-        files = [Datafile(path="gs://my-dataset/hello.txt"), Datafile(path="gs://my-dataset/goodbye.csv")]
-        input_manifest = Manifest(datasets={"my-dataset": Dataset(files=files, path="gs://my-dataset")})
+        dataset_path = f"gs://{TEST_BUCKET_NAME}/my-dataset"
+
+        input_manifest = Manifest(
+            datasets={
+                "my-dataset": Dataset(
+                    files=[f"{dataset_path}/hello.txt", f"{dataset_path}/goodbye.csv"],
+                    path=dataset_path,
+                )
+            }
+        )
 
         with patch("octue.cloud.pub_sub.service.Topic", new=MockTopic):
             with patch("octue.cloud.pub_sub.service.Subscription", new=MockSubscription):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -144,7 +144,6 @@ class TestService(BaseTestCase):
                             parent=parent,
                             child=child,
                             input_values={},
-                            input_manifest=None,
                         )
 
         self.assertIn("'met_mast_id' is a required property", context.exception.args[0])
@@ -166,7 +165,6 @@ class TestService(BaseTestCase):
                             parent=parent,
                             child=child,
                             input_values={},
-                            input_manifest=None,
                         )
 
         self.assertIn("[Errno 2] No such file or directory: 'blah'", format(context.exception))
@@ -190,7 +188,6 @@ class TestService(BaseTestCase):
                             parent=parent,
                             child=child,
                             input_values={},
-                            input_manifest=None,
                         )
 
         self.assertEqual(type(context.exception).__name__, "AnUnknownException")
@@ -214,7 +211,6 @@ class TestService(BaseTestCase):
                             parent=parent,
                             child=child,
                             input_values={},
-                            input_manifest=None,
                             subscribe_to_logs=False,
                         )
 
@@ -243,7 +239,6 @@ class TestService(BaseTestCase):
                             parent=parent,
                             child=child,
                             input_values={},
-                            input_manifest=None,
                             subscribe_to_logs=True,
                             service_name="my-super-service",
                         )
@@ -298,7 +293,6 @@ class TestService(BaseTestCase):
                             parent=parent,
                             child=child,
                             input_values={},
-                            input_manifest=None,
                             subscribe_to_logs=True,
                             service_name="my-super-service",
                         )
@@ -466,7 +460,6 @@ class TestService(BaseTestCase):
                         answer = self.ask_question_and_wait_for_answer(
                             parent=parent,
                             child=child,
-                            input_values=None,
                             input_manifest=input_manifest,
                         )
 
@@ -537,7 +530,6 @@ class TestService(BaseTestCase):
                         parent=parent,
                         child=child,
                         input_values={},
-                        input_manifest=None,
                     )
 
         self.assertEqual(answer["output_values"], MockAnalysisWithOutputManifest.output_values)
@@ -561,7 +553,6 @@ class TestService(BaseTestCase):
                                 parent=parent,
                                 child=child,
                                 input_values={},
-                                input_manifest=None,
                             )
                         )
 
@@ -588,14 +579,12 @@ class TestService(BaseTestCase):
                         parent=parent,
                         child=child_1,
                         input_values={},
-                        input_manifest=None,
                     )
 
                     answer_2 = self.ask_question_and_wait_for_answer(
                         parent=parent,
                         child=child_2,
                         input_values={},
-                        input_manifest=None,
                     )
 
         self.assertEqual(
@@ -637,7 +626,6 @@ class TestService(BaseTestCase):
                         parent=parent,
                         child=child,
                         input_values={"question": "What does the child of the child say?"},
-                        input_manifest=None,
                     )
 
         self.assertEqual(
@@ -693,7 +681,6 @@ class TestService(BaseTestCase):
                         parent=parent,
                         child=child,
                         input_values={"question": "What does the child of the child say?"},
-                        input_manifest=None,
                     )
 
         self.assertEqual(
@@ -736,7 +723,6 @@ class TestService(BaseTestCase):
                                         parent=parent,
                                         child=child,
                                         input_values={"question": "What does the child of the child say?"},
-                                        input_manifest=None,
                                         parent_sdk_version=parent_sdk_version,
                                     )
 
@@ -769,8 +755,8 @@ class TestService(BaseTestCase):
     def ask_question_and_wait_for_answer(
         parent,
         child,
-        input_values,
-        input_manifest,
+        input_values=None,
+        input_manifest=None,
         subscribe_to_logs=True,
         allow_local_files=False,
         service_name="my-service",

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import twined.exceptions
 from octue import Runner, exceptions
+from octue.cloud.emulators import mock_generate_signed_url
 from octue.cloud.pub_sub.service import Service
 from octue.exceptions import InvalidMonitorMessage
 from octue.resources import Datafile, Dataset, Manifest
@@ -425,12 +426,13 @@ class TestService(BaseTestCase):
                 with patch("google.cloud.pubsub_v1.SubscriberClient", new=MockSubscriber):
                     child.serve()
 
-                    answer = self.ask_question_and_wait_for_answer(
-                        parent=parent,
-                        child=child,
-                        input_values={},
-                        input_manifest=input_manifest,
-                    )
+                    with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
+                        answer = self.ask_question_and_wait_for_answer(
+                            parent=parent,
+                            child=child,
+                            input_values={},
+                            input_manifest=input_manifest,
+                        )
 
         self.assertEqual(
             answer,
@@ -460,12 +462,13 @@ class TestService(BaseTestCase):
                 with patch("google.cloud.pubsub_v1.SubscriberClient", new=MockSubscriber):
                     child.serve()
 
-                    answer = self.ask_question_and_wait_for_answer(
-                        parent=parent,
-                        child=child,
-                        input_values=None,
-                        input_manifest=input_manifest,
-                    )
+                    with patch("google.cloud.storage.blob.Blob.generate_signed_url", new=mock_generate_signed_url):
+                        answer = self.ask_question_and_wait_for_answer(
+                            parent=parent,
+                            child=child,
+                            input_values=None,
+                            input_manifest=input_manifest,
+                        )
 
         self.assertEqual(
             answer,

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -11,6 +11,7 @@ from octue.cloud import storage
 from octue.cloud.emulators import mock_generate_signed_url
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.resources import Datafile, Dataset
+from octue.resources.dataset import SIGNED_METADATA_DIRECTORY
 from octue.resources.filter_containers import FilterSet
 from tests import TEST_BUCKET_NAME
 from tests.base import BaseTestCase
@@ -582,7 +583,8 @@ class TestDataset(BaseTestCase):
         cloud_datafile_relative_paths = {
             blob.name.split(dataset.name)[-1].strip("/")
             for blob in GoogleCloudStorageClient().scandir(
-                upload_path, filter=lambda blob: not blob.name.endswith(".octue")
+                upload_path,
+                filter=lambda blob: not blob.name.endswith(".octue") and SIGNED_METADATA_DIRECTORY not in blob.name,
             )
         }
 


### PR DESCRIPTION
# Summary
Use signed URLs to point to cloud datasets in input manifests when sending them to children for processing. This means the children will always be able to access the input datasets - not just in the special case of the parent and child having access to the same buckets.

<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#491](https://github.com/octue/octue-sdk-python/pull/491))

### Fixes
- Use signed URLs when sending input manifests to services

### Refactoring
- Factor out dataset URL signing to new `Manifest` method

### Testing
- Simplify service tests' arguments
- Update test method docstring
- Ignore irrelevant files in test
<!--- END AUTOGENERATED NOTES --->