### PR TITLE
Miscellaneous improvements

### DIFF
--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -209,7 +209,7 @@ class Service(CoolNameable):
         allow_local_files=False,
         question_uuid=None,
         push_endpoint=None,
-        timeout=30,
+        timeout=86400,
     ):
         """Ask a child a question (i.e. send it input values for it to analyse and produce output values for) and return
         a subscription to receive its answer on. The input values and manifest must conform to the schemas in the

--- a/octue/resources/child.py
+++ b/octue/resources/child.py
@@ -44,7 +44,7 @@ class Child:
         allow_local_files=False,
         handle_monitor_message=None,
         question_uuid=None,
-        timeout=20,
+        timeout=86400,
     ):
         """Ask the child a question and wait for its answer - i.e. send it input values and/or an input manifest and
         wait for it to analyse them and return output values and/or an output manifest. The input values and manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.29.8"
+version = "0.29.9"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/cloud/deployment/google/dataflow/test_dataflow_deployment.py
+++ b/tests/cloud/deployment/google/dataflow/test_dataflow_deployment.py
@@ -19,5 +19,11 @@ class TestDataflowDeployment(BaseTestCase):
             backend={"name": "GCPPubSubBackend", "project_name": os.environ["TEST_PROJECT_NAME"]},
         )
 
-        answer = child.ask(input_values={"n_iterations": 3})
-        self.assertEqual(answer, {"output_values": [1, 2, 3, 4, 5], "output_manifest": None})
+        answer = child.ask(input_values={"n_iterations": 3}, timeout=60)
+
+        # Check the output values.
+        self.assertEqual(answer["output_values"], [1, 2, 3, 4, 5])
+
+        # Check that the output dataset and its files can be accessed.
+        with answer["output_manifest"].datasets["example_dataset"].files.one() as (datafile, f):
+            self.assertEqual(f.read(), "This is some example service output.")

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -248,7 +248,7 @@ class MockService(Service):
         allow_local_files=False,
         question_uuid=None,
         push_endpoint=None,
-        timeout=30,
+        timeout=86400,
         parent_sdk_version=pkg_resources.get_distribution("octue").version,
     ):
         """Put the question into the messages register, register the existence of the corresponding response topic, add

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -566,8 +566,8 @@ class TestDataset(BaseTestCase):
             self.assertEqual(persisted_file_1, "1")
 
             # Check its metadata has been uploaded.
-            persisted_dataset_metadata = dataset._get_cloud_metadata()
-            self.assertEqual(persisted_dataset_metadata["tags"], dataset.tags.to_primitive())
+            dataset._get_cloud_metadata()
+            self.assertEqual(dataset._cloud_metadata["tags"], dataset.tags.to_primitive())
 
     def test_upload_with_nested_dataset_preserves_nested_structure(self):
         """Test that uploading a dataset containing datafiles in a nested directory structure to the cloud preserves


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#500](https://github.com/octue/octue-sdk-python/pull/500))

### Enhancements
- Set default question timeout to 1 day
- Allow dataset upload without metadata change
- Cache dataset cloud metadata privately on instance
- Only update dataset cloud metadata if it's changed

### Testing
- Update dataflow deployment test

<!--- END AUTOGENERATED NOTES --->