### PR TITLE
Fix bugs in cloud path parsing and improve dataset validation feedback

### DIFF
--- a/octue/cloud/storage/client.py
+++ b/octue/cloud/storage/client.py
@@ -215,7 +215,7 @@ class GoogleCloudStorageClient:
 
         bucket, directory_path = self._get_bucket_and_path_in_bucket(cloud_path)
 
-        if not directory_path.endswith("/"):
+        if len(directory_path) > 0 and not directory_path.endswith("/"):
             directory_path += "/"
 
         if recursive:

--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -103,12 +103,12 @@ def relpath(path, start):
 
 def split(path):
     """Split a path into its head and tail. `storage.path.split` (this function) is the analogue of `os.path.split` for
-    Google Cloud Storage paths.
+    Google Cloud Storage paths. Trailing slashes are ignored.
 
     :param str path:
     :return (str, str):
     """
-    paths = path.split("/")
+    paths = path.strip("/").split("/")
     return join(*paths[:-1]), paths[-1]
 
 

--- a/octue/cloud/storage/path.py
+++ b/octue/cloud/storage/path.py
@@ -70,10 +70,10 @@ def split_bucket_name_from_cloud_path(path):
     :return (str, str): the bucket name and the path within the bucket
     """
     if is_cloud_uri(path):
-        path = strip_protocol_from_path(path).split("/")
+        path = strip_protocol_from_path(path).strip("/").split("/")
         return path[0], join(*path[1:])
 
-    path = urlparse(path).path.split("/")
+    path = urlparse(path).path.strip("/").split("/")
     return path[1], join(*path[2:])
 
 

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -91,7 +91,7 @@ class Runner:
 
         :param str|None analysis_id: UUID of analysis
         :param str|dict|None input_values: the input_values strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
-        :param str|octue.resources.manifest.Manifest|None input_manifest: The input_manifest strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
+        :param str|dict|octue.resources.manifest.Manifest|None input_manifest: The input_manifest strand data. Can be expressed as a string path of a *.json file (relative or absolute), as an open file-like object (containing json data), as a string of json data or as an already-parsed dict.
         :param str analysis_log_level: the level below which to ignore log messages
         :param logging.Handler|None analysis_log_handler: the logging.Handler instance which will be used to handle logs for this analysis run. Handlers can be created as per the logging cookbook https://docs.python.org/3/howto/logging-cookbook.html but should use the format defined above in LOG_FORMAT.
         :param callable|None handle_monitor_message: a function that sends monitor messages to the parent that requested the analysis
@@ -249,7 +249,12 @@ class Runner:
                 try:
                     jsonschema_validate(instance=dict(file.tags), schema=file_tags_template)
                 except ValidationError as e:
-                    raise twined.exceptions.invalid_contents_map[manifest_kind](str(e))
+                    message = (
+                        e.message + f" for files in the {dataset_name!r} dataset. The affected datafile is "
+                        f"{file.path!r}. Add the property to the datafile as a tag to fix this."
+                    )
+
+                    raise twined.exceptions.invalid_contents_map[manifest_kind](message)
 
 
 def unwrap(fcn):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.29.9"
+version = "0.29.10"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/cloud/storage/test_path.py
+++ b/tests/cloud/storage/test_path.py
@@ -81,6 +81,12 @@ class TestStorage(BaseTestCase):
         """Test that cloud paths can be split properly."""
         self.assertEqual(storage.path.split("my-bucket/a/b/c.txt"), ("my-bucket/a/b", "c.txt"))
 
+    def test_split_with_trailing_slash(self):
+        """Test that a trailing forward slash doesn't affect splitting of paths."""
+        expected_splitting = ("my-bucket/a", "b")
+        self.assertEqual(storage.path.split("my-bucket/a/b"), expected_splitting)
+        self.assertEqual(storage.path.split("my-bucket/a/b/"), expected_splitting)
+
     def test_dirname(self):
         """Test that the name of the directory of the given path can be found."""
         self.assertEqual(storage.path.dirname("a/b/c"), "a/b")

--- a/tests/cloud/storage/test_path.py
+++ b/tests/cloud/storage/test_path.py
@@ -27,6 +27,9 @@ class TestStorage(BaseTestCase):
         )
         self.assertEqual(storage.path.split_bucket_name_from_cloud_path("gs://my-bucket"), ("my-bucket", ""))
 
+        # Ensure trailing slashes don't affect the result.
+        self.assertEqual(storage.path.split_bucket_name_from_cloud_path("gs://my-bucket/"), ("my-bucket", ""))
+
     def test_strip_protocol_from_path(self):
         """Test that the `gs://` protocol can be stripped from a path."""
         self.assertEqual(storage.path.strip_protocol_from_path("gs://my-bucket"), "my-bucket")

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -842,6 +842,12 @@ class TestDataset(BaseTestCase):
         dataset.update_metadata()
         self.assertEqual(Dataset(path=dataset.path).tags, {"hello": "world"})
 
+    def test_name_of_dataset_with_trailing_slash_is_correct(self):
+        """Test that the name of a dataset with a trailing slash is correct."""
+        cloud_path = self._create_nested_cloud_dataset("my-dataset")
+        dataset = Dataset(cloud_path + "/")
+        self.assertEqual(dataset.name, "my-dataset")
+
     def _create_nested_cloud_dataset(self, dataset_name=None):
         """Create a dataset in cloud storage with the given name containing a nested set of files.
 


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#506](https://github.com/octue/octue-sdk-python/pull/506))

### Enhancements
- Give specifics in the error raised when a datafile fails dataset file tag template validation

### Fixes
- Ignore trailing slashes when splitting/parsing cloud paths
- Ensure the `Dataset.name` property works for datasets with a cloud path ending in a forward slash
- Ensure `GoogleCloudStorageClient.scandir` works on the root directory of a bucket

<!--- END AUTOGENERATED NOTES --->