### PR TITLE
Allow Service to be instantiated without Google Cloud credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.29.10"
+version = "0.29.11"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/cloud/pub_sub/mocks.py
+++ b/tests/cloud/pub_sub/mocks.py
@@ -236,8 +236,12 @@ class MockService(Service):
     def __init__(self, backend, service_id=None, run_function=None, children=None, *args, **kwargs):
         super().__init__(backend, service_id, run_function, *args, **kwargs)
         self.children = children or {}
-        self.publisher = MockPublisher()
+        self._publisher = MockPublisher()
         self.subscriber = MockSubscriber()
+
+    @property
+    def publisher(self):
+        return self._publisher
 
     def ask(
         self,

--- a/tests/cloud/pub_sub/test_subscription.py
+++ b/tests/cloud/pub_sub/test_subscription.py
@@ -71,7 +71,7 @@ class TestSubscription(BaseTestCase):
             topic=topic,
             namespace="hello",
             project_name=project_name,
-            subscriber=SubscriberClient(credentials=service._credentials),
+            subscriber=SubscriberClient(credentials=service.credentials),
         )
 
         with patch("google.pubsub_v1.SubscriberClient.create_subscription", new=MockSubscriptionCreationResponse):
@@ -94,7 +94,7 @@ class TestSubscription(BaseTestCase):
             topic=topic,
             namespace="hello",
             project_name=project_name,
-            subscriber=SubscriberClient(credentials=service._credentials),
+            subscriber=SubscriberClient(credentials=service.credentials),
             push_endpoint="https://example.com/endpoint",
         )
 

--- a/tests/resources/test_child.py
+++ b/tests/resources/test_child.py
@@ -1,4 +1,7 @@
+import os
 from unittest.mock import patch
+
+from google.auth.exceptions import DefaultCredentialsError
 
 from octue.resources.child import Child
 from octue.resources.service_backends import GCPPubSubBackend
@@ -7,6 +10,30 @@ from tests.cloud.pub_sub.mocks import MockAnalysis, MockService, MockSubscriber,
 
 
 class TestChild(BaseTestCase):
+    def test_instantiating_child_without_credentials(self):
+        """Test that a child can be instantiated without Google Cloud credentials."""
+        with patch.dict(os.environ, clear=True):
+            Child(
+                id="my-child",
+                backend={"name": "GCPPubSubBackend", "project_name": "blah"},
+            )
+
+    def test_child_cannot_be_asked_question_without_credentials(self):
+        """Test that a child cannot be asked a question without Google Cloud credentials being available."""
+        with patch.dict(os.environ, clear=True):
+            with patch("octue.cloud.pub_sub.service.Topic"):
+                with patch("octue.cloud.pub_sub.service.Subscription", new=MockSubscription):
+                    with patch("octue.resources.child.BACKEND_TO_SERVICE_MAPPING", {"GCPPubSubBackend": MockService}):
+                        with patch("google.cloud.pubsub_v1.SubscriberClient", new=MockSubscriber):
+
+                            child = Child(
+                                id="my-child",
+                                backend={"name": "GCPPubSubBackend", "project_name": "blah"},
+                            )
+
+                            with self.assertRaises(DefaultCredentialsError):
+                                child.ask({"some": "input"})
+
     def test_child_can_be_asked_multiple_questions(self):
         """Test that a child can be asked multiple questions."""
         backend = GCPPubSubBackend(project_name="blah")


### PR DESCRIPTION
# Summary
Lazily load Google Cloud credentials for `Service` and `Child` instances, allowing apps that don't always contact their children in an analysis to work without the credentials available when they don't need them (instead of failing as currently happens).

<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#509](https://github.com/octue/octue-sdk-python/pull/509))

### Fixes
- Allow `Service` to be instantiated without Google Cloud credentials

<!--- END AUTOGENERATED NOTES --->