### PR TITLE
Send heartbeats from children to parents

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -76,11 +76,10 @@ jobs:
         run: tox -vv -e py
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: coverage.xml
+          files: coverage.xml
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-publish:
     if: "!contains(github.event.head_commit.message, 'skipci')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,10 @@ jobs:
         run: tox -vv -e py
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: coverage.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: true
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   release:
     runs-on: ubuntu-latest

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -236,6 +236,11 @@ def start(service_config, timeout, rm):
 
     service.serve(timeout=timeout, delete_topic_and_subscription_on_exit=rm)
 
+    logger.info(
+        "You can now ask this service questions at %r using the `octue.resources.Child` class.",
+        service_configuration.service_id,
+    )
+
 
 @octue_cli.command()
 @click.argument(

--- a/octue/cloud/emulators/child.py
+++ b/octue/cloud/emulators/child.py
@@ -43,6 +43,7 @@ class ChildEmulator:
 
         self._message_handlers = {
             "delivery_acknowledgement": self._handle_delivery_acknowledgement,
+            "heartbeat": self._handle_heartbeat,
             "log_record": self._handle_log_record,
             "monitor_message": self._handle_monitor_message,
             "exception": self._handle_exception,
@@ -203,6 +204,15 @@ class ChildEmulator:
         :return None:
         """
         logger.warning("Delivery acknowledgement messages are ignored by the ChildEmulator.")
+
+    def _handle_heartbeat(self, message, **kwargs):
+        """A no-operation handler for heartbeat messages (these messages are ignored by the child emulator).
+
+        :param dict message: a dictionary containing the key "time"
+        :param kwargs: this should be empty
+        :return None:
+        """
+        logger.warning("Heartbeat messages are ignored by the ChildEmulator.")
 
     def _handle_log_record(self, message, **kwargs):
         """Convert the given message into a log record and pass it to the log handler.

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -155,10 +155,7 @@ class OrderedMessageHandler:
         """
         acceptable_interval = timedelta(seconds=acceptable_interval)
 
-        if (
-            self._last_heartbeat
-            and datetime.now() - datetime.fromisoformat(self._last_heartbeat) <= acceptable_interval
-        ):
+        if self._last_heartbeat and (datetime.now() - self._last_heartbeat <= acceptable_interval):
             self._alive = True
             return
 
@@ -245,12 +242,12 @@ class OrderedMessageHandler:
         logger.info("%r's question was delivered at %s.", self.subscription.topic.service, message["delivery_time"])
 
     def _handle_heartbeat(self, message):
-        """Record the heartbeat time.
+        """Record the time the heartbeat was received.
 
         :param dict message:
         :return None:
         """
-        self._last_heartbeat = message["time"]
+        self._last_heartbeat = datetime.now()
         logger.debug("Heartbeat received.")
 
     def _handle_monitor_message(self, message):

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -125,6 +125,7 @@ class OrderedMessageHandler:
                     result = self._handle_message(message)
 
                     if result is not None:
+                        heartbeat_checker.cancel()
                         return result
 
             except KeyError:

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -72,6 +72,17 @@ class OrderedMessageHandler:
 
         self._log_message_colours = [COLOUR_PALETTE[1], *COLOUR_PALETTE[3:]]
 
+    @property
+    def _time_since_last_heartbeat(self):
+        """Get the time period since the last heartbeat was received.
+
+        :return datetime.timedelta|None:
+        """
+        if not self._last_heartbeat:
+            return None
+
+        return datetime.now() - self._last_heartbeat
+
     def handle_messages(self, timeout=60, delivery_acknowledgement_timeout=120, acceptable_heartbeat_interval=300):
         """Pull messages and handle them in the order they were sent until a result is returned by a message handler,
         then return that result.
@@ -158,7 +169,7 @@ class OrderedMessageHandler:
         """
         acceptable_interval = timedelta(seconds=acceptable_interval)
 
-        if self._last_heartbeat and (datetime.now() - self._last_heartbeat <= acceptable_interval):
+        if self._last_heartbeat and self._time_since_last_heartbeat <= acceptable_interval:
             self._alive = True
             return
 

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -51,12 +51,14 @@ class OrderedMessageHandler:
         self.service_name = service_name
 
         self.received_delivery_acknowledgement = None
+        self._last_heartbeat = None
         self._start_time = time.perf_counter()
         self._waiting_messages = None
         self._previous_message_number = -1
 
         self._message_handlers = message_handlers or {
             "delivery_acknowledgement": self._handle_delivery_acknowledgement,
+            "heartbeat": self._handle_heartbeat,
             "monitor_message": self._handle_monitor_message,
             "log_record": self._handle_log_message,
             "exception": self._handle_exception,
@@ -204,6 +206,15 @@ class OrderedMessageHandler:
         """
         self.received_delivery_acknowledgement = True
         logger.info("%r's question was delivered at %s.", self.subscription.topic.service, message["delivery_time"])
+
+    def _handle_heartbeat(self, message):
+        """Record the heartbeat time.
+
+        :param dict message:
+        :return None:
+        """
+        self._last_heartbeat = message["time"]
+        logger.debug("Heartbeat received.")
 
     def _handle_monitor_message(self, message):
         """Send a monitor message to the handler if one has been provided.

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -248,7 +248,7 @@ class OrderedMessageHandler:
         :return None:
         """
         self._last_heartbeat = datetime.now()
-        logger.debug("Heartbeat received.")
+        logger.info("Heartbeat received from service %r.", self.service_name)
 
     def _handle_monitor_message(self, message):
         """Send a monitor message to the handler if one has been provided.

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -149,9 +149,9 @@ class OrderedMessageHandler:
             f"No heartbeat has been received within the acceptable interval of {acceptable_heartbeat_interval}s."
         )
 
-    def _monitor_heartbeat(self, acceptable_interval=300):
-        """Change the alive status to `False` if a heartbeat hasn't been received within the acceptable past time
-        interval measured from the moment of calling.
+    def _monitor_heartbeat(self, acceptable_interval):
+        """Change the alive status to `False` and cancel the heartbeat checker if a heartbeat hasn't been received
+        within the acceptable past time interval measured from the moment of calling.
 
         :param float|int acceptable_interval: the acceptable time interval in seconds
         :return None:
@@ -163,6 +163,7 @@ class OrderedMessageHandler:
             return
 
         self._alive = False
+        self._heartbeat_checker.cancel()
 
     def _pull_message(self, timeout, delivery_acknowledgement_timeout):
         """Pull a message from the subscription, raising a `TimeoutError` if the timeout is exceeded before succeeding.

--- a/octue/cloud/pub_sub/message_handler.py
+++ b/octue/cloud/pub_sub/message_handler.py
@@ -76,7 +76,7 @@ class OrderedMessageHandler:
 
         :param float|None timeout: how long to wait for an answer before raising a `TimeoutError`
         :param float delivery_acknowledgement_timeout: how long to wait for a delivery acknowledgement before raising `QuestionNotDelivered`
-        :param int|float acceptable_heartbeat_interval:
+        :param int|float acceptable_heartbeat_interval: the maximum acceptable amount of time (in seconds) between child heartbeats before an error is raised
         :raise TimeoutError: if the timeout is exceeded before receiving the final message
         :return dict:
         """
@@ -147,8 +147,8 @@ class OrderedMessageHandler:
         )
 
     def _monitor_heartbeat(self, acceptable_interval=300):
-        """Raise an error if a heartbeat hasn't been received within the acceptable past time interval measured from the
-        moment of calling.
+        """Change the alive status to `False` if a heartbeat hasn't been received within the acceptable past time
+        interval measured from the moment of calling.
 
         :param float|int acceptable_interval: the acceptable time interval in seconds
         :return None:

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -321,7 +321,6 @@ class Service(CoolNameable):
             topic=question_topic,
             question_uuid=question_uuid,
             forward_logs=subscribe_to_logs,
-            octue_sdk_version=self.local_sdk_version,
             allow_save_diagnostics_data_on_crash=allow_save_diagnostics_data_on_crash,
         )
 

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -346,6 +346,7 @@ class Service(CoolNameable):
         :param str service_name: a name by which to refer to the child subscribed to (used for labelling its log messages if subscribed to)
         :param float|None timeout: how long in seconds to wait for an answer before raising a `TimeoutError`
         :param float delivery_acknowledgement_timeout: how long in seconds to wait for a delivery acknowledgement before aborting
+        :param float|int acceptable_heartbeat_interval: the maximum acceptable amount of time (in seconds) between child heartbeats before an error is raised
         :raise TimeoutError: if the timeout is exceeded
         :raise octue.exceptions.QuestionNotDelivered: if a delivery acknowledgement is not received in time
         :return dict: dictionary containing the keys "output_values" and "output_manifest"

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -65,6 +65,7 @@ class Service(CoolNameable):
 
         self.backend = backend
         self.run_function = run_function
+        self.local_sdk_version = pkg_resources.get_distribution("octue").version
         self._record_sent_messages = False
         self._sent_messages = []
         self._publisher = None
@@ -198,7 +199,7 @@ class Service(CoolNameable):
                 analysis_log_handler = None
 
             if parent_sdk_version:
-                local_sdk_version = packaging.version.parse(pkg_resources.get_distribution("octue").version)
+                local_sdk_version = packaging.version.parse(self.local_sdk_version)
 
                 if (
                     local_sdk_version.major != parent_sdk_version.major
@@ -320,7 +321,7 @@ class Service(CoolNameable):
             topic=question_topic,
             question_uuid=question_uuid,
             forward_logs=subscribe_to_logs,
-            octue_sdk_version=pkg_resources.get_distribution("octue").version,
+            octue_sdk_version=self.local_sdk_version,
             allow_save_diagnostics_data_on_crash=allow_save_diagnostics_data_on_crash,
         )
 
@@ -428,6 +429,7 @@ class Service(CoolNameable):
         :param attributes: key-value pairs to attach to the message - the values must be strings or bytes
         :return None:
         """
+        attributes["octue_sdk_version"] = self.local_sdk_version
         converted_attributes = {}
 
         for key, value in attributes.items():

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -244,6 +244,7 @@ class Service(CoolNameable):
                 timeout=timeout,
             )
 
+            heartbeater.cancel()
             logger.info("%r answered question %r.", self, question_uuid)
 
         except BaseException as error:  # noqa

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -336,7 +336,7 @@ class Service(CoolNameable):
         service_name="REMOTE",
         timeout=60,
         delivery_acknowledgement_timeout=120,
-        acceptable_heartbeat_interval=300,
+        maximum_heartbeat_interval=300,
     ):
         """Wait for an answer to a question on the given subscription, deleting the subscription and its topic once
         the answer is received.
@@ -347,7 +347,7 @@ class Service(CoolNameable):
         :param str service_name: a name by which to refer to the child subscribed to (used for labelling its log messages if subscribed to)
         :param float|None timeout: how long in seconds to wait for an answer before raising a `TimeoutError`
         :param float delivery_acknowledgement_timeout: how long in seconds to wait for a delivery acknowledgement before aborting
-        :param float|int acceptable_heartbeat_interval: the maximum acceptable amount of time (in seconds) between child heartbeats before an error is raised
+        :param float|int maximum_heartbeat_interval: the maximum amount of time (in seconds) allowed between child heartbeats before an error is raised
         :raise TimeoutError: if the timeout is exceeded
         :raise octue.exceptions.QuestionNotDelivered: if a delivery acknowledgement is not received in time
         :return dict: dictionary containing the keys "output_values" and "output_manifest"
@@ -371,7 +371,7 @@ class Service(CoolNameable):
             return message_handler.handle_messages(
                 timeout=timeout,
                 delivery_acknowledgement_timeout=delivery_acknowledgement_timeout,
-                acceptable_heartbeat_interval=acceptable_heartbeat_interval,
+                maximum_heartbeat_interval=maximum_heartbeat_interval,
             )
         finally:
             subscription.delete()

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -177,7 +177,7 @@ class Service(CoolNameable):
         topic = answer_topic or self.instantiate_answer_topic(question_uuid)
         self._send_delivery_acknowledgment(topic)
 
-        heartbeater = RepeatingTimer(interval=120, function=self._send_heartbeat, kwargs={"topic": answer_topic})
+        heartbeater = RepeatingTimer(interval=120, function=self._send_heartbeat, kwargs={"topic": topic})
         heartbeater.daemon = True
         heartbeater.start()
 

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -463,8 +463,6 @@ class Service(CoolNameable):
         :param float timeout: time in seconds after which to give up sending
         :return None:
         """
-        logger.debug("Heartbeat sent.")
-
         self._send_message(
             {
                 "type": "heartbeat",
@@ -474,6 +472,8 @@ class Service(CoolNameable):
             topic=topic,
             timeout=timeout,
         )
+
+        logger.debug("Heartbeat sent.")
 
     def _send_monitor_message(self, data, topic, timeout=30):
         """Send a monitor message to the parent.

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -335,6 +335,7 @@ class Service(CoolNameable):
         service_name="REMOTE",
         timeout=60,
         delivery_acknowledgement_timeout=120,
+        acceptable_heartbeat_interval=300,
     ):
         """Wait for an answer to a question on the given subscription, deleting the subscription and its topic once
         the answer is received.
@@ -368,6 +369,7 @@ class Service(CoolNameable):
             return message_handler.handle_messages(
                 timeout=timeout,
                 delivery_acknowledgement_timeout=delivery_acknowledgement_timeout,
+                acceptable_heartbeat_interval=acceptable_heartbeat_interval,
             )
         finally:
             subscription.delete()

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -65,7 +65,8 @@ class Service(CoolNameable):
 
         self.backend = backend
         self.run_function = run_function
-        self.local_sdk_version = pkg_resources.get_distribution("octue").version
+        self._raw_local_sdk_version = pkg_resources.get_distribution("octue").version
+        self._parsed_local_sdk_version = packaging.version.parse(self._raw_local_sdk_version)
         self._record_sent_messages = False
         self._sent_messages = []
         self._publisher = None
@@ -199,18 +200,16 @@ class Service(CoolNameable):
                 analysis_log_handler = None
 
             if parent_sdk_version:
-                local_sdk_version = packaging.version.parse(self.local_sdk_version)
-
                 if (
-                    local_sdk_version.major != parent_sdk_version.major
-                    or local_sdk_version.minor != parent_sdk_version.minor
+                    self._parsed_local_sdk_version.major != parent_sdk_version.major
+                    or self._parsed_local_sdk_version.minor != parent_sdk_version.minor
                 ):
                     logger.warning(
                         "The parent's Octue SDK version %s may not be compatible with the local Octue SDK version %s. "
                         "Update them both to the latest version (or at least a version with the same major and minor "
                         "version numbers) if possible.",
                         parent_sdk_version,
-                        local_sdk_version,
+                        self._parsed_local_sdk_version,
                     )
 
             else:
@@ -428,7 +427,7 @@ class Service(CoolNameable):
         :param attributes: key-value pairs to attach to the message - the values must be strings or bytes
         :return None:
         """
-        attributes["octue_sdk_version"] = self.local_sdk_version
+        attributes["octue_sdk_version"] = self._raw_local_sdk_version
         converted_attributes = {}
 
         for key, value in attributes.items():

--- a/octue/runner.py
+++ b/octue/runner.py
@@ -186,15 +186,15 @@ class Runner:
                 elif hasattr(self.app_source, "run"):
                     self.app_source.run(analysis)
 
-                # App as a string path to a module containing a class named "App" or a function named "run". The same other
-                # specifications apply as described above.
+                # App as a string path to a module containing a class named "App" or a function named "run". The same
+                # other specifications apply as described above.
                 elif isinstance(self.app_source, str):
 
                     with AppFrom(self.app_source) as app:
                         if hasattr(app.app_module, "App"):
                             app.app_module.App(analysis).run()
                         else:
-                            app.run(analysis)
+                            app.app_module.run(analysis)
 
                 # App as a function that takes "analysis" as an argument.
                 else:
@@ -331,13 +331,6 @@ class Runner:
         )
 
 
-def unwrap(fcn):
-    """Recurse through wrapping to get the raw function without decorators."""
-    if hasattr(fcn, "__wrapped__"):
-        return unwrap(fcn.__wrapped__)
-    return fcn
-
-
 class AppFrom:
     """A context manager that imports the module "app" from a file named "app.py" in the given directory on entry (by
     making a temporary addition to the system path) and unloads it (by deleting it from `sys.modules`) on exit. It will
@@ -392,11 +385,6 @@ class AppFrom:
                 f"Module 'app' was already removed from the system path prior to exiting the {context_manager_name} "
                 f"context manager. Using the {context_manager_name} context may yield unexpected results."
             )
-
-    @property
-    def run(self):
-        """Get the unwrapped run function from app.py in the application's root directory."""
-        return unwrap(self.app_module.run)
 
 
 class AnalysisLogHandlerSwitcher:

--- a/octue/utils/processes.py
+++ b/octue/utils/processes.py
@@ -1,7 +1,3 @@
-from subprocess import PIPE, STDOUT, CalledProcessError, Popen
-from threading import Thread
-
-
 class ProcessesContextManager:
     """A context manager that kills any processes given to it on exit from its context."""
 
@@ -14,35 +10,3 @@ class ProcessesContextManager:
     def __exit__(self, exc_type, exc_val, exc_tb):
         for process in self.processes:
             process.kill()
-
-
-def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", *args, **kwargs):
-    """Run a subprocess, sending its stdout and stderr output to the given logger. Extra `args` and `kwargs` are
-    provided to the `subprocess.Popen` instance used.
-
-    :param iter(str) command: command to run
-    :param logging.Logger logger: logger to use to log stdout and stderr
-    :param str log_level: level to log output at
-    :raise CalledProcessError: if the subprocess fails (i.e. if it doesn't exit with a 0 return code)
-    :return subprocess.CompletedProcess:
-    """
-
-    def _log_lines_from_stream(stream, logger):
-        """Log lines from the given stream.
-
-        :param io.BufferedReader stream:
-        :param logging.Logger logger:
-        :return None:
-        """
-        with stream:
-            for line in iter(stream.readline, b""):
-                getattr(logger, log_level.lower())(line.decode().strip())
-
-    process = Popen(command, stdout=PIPE, stderr=STDOUT, *args, **kwargs)
-    Thread(target=_log_lines_from_stream, args=[process.stdout, logger]).start()
-    process.wait()
-
-    if process.returncode != 0:
-        raise CalledProcessError(returncode=process.returncode, cmd=" ".join(command))
-
-    return process

--- a/octue/utils/threads.py
+++ b/octue/utils/threads.py
@@ -7,8 +7,8 @@ class RepeatingTimer(Timer):
 
     def run(self):
         while not self.finished.is_set():
-            self.function(*self.args, **self.kwargs)
             self.finished.wait(self.interval)
+            self.function(*self.args, **self.kwargs)
 
 
 def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", *args, **kwargs):

--- a/octue/utils/threads.py
+++ b/octue/utils/threads.py
@@ -1,3 +1,4 @@
+import time
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 from threading import Thread, Timer
 
@@ -7,7 +8,7 @@ class RepeatingTimer(Timer):
 
     def run(self):
         while not self.finished.is_set():
-            self.finished.wait(self.interval)
+            time.sleep(self.interval)
             self.function(*self.args, **self.kwargs)
 
 

--- a/octue/utils/threads.py
+++ b/octue/utils/threads.py
@@ -12,7 +12,7 @@ class RepeatingTimer(Timer):
             self.function(*self.args, **self.kwargs)
 
 
-def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", *args, **kwargs):
+def run_logged_subprocess(command, logger, log_level="info", *args, **kwargs):
     """Run a subprocess, sending its stdout and stderr output to the given logger. Extra `args` and `kwargs` are
     provided to the `subprocess.Popen` instance used.
 

--- a/octue/utils/threads.py
+++ b/octue/utils/threads.py
@@ -1,5 +1,14 @@
 from subprocess import PIPE, STDOUT, CalledProcessError, Popen
-from threading import Thread
+from threading import Thread, Timer
+
+
+class RepeatingTimer(Timer):
+    """A repeating version of the `threading.Timer` class."""
+
+    def run(self):
+        while not self.finished.is_set():
+            self.function(*self.args, **self.kwargs)
+            self.finished.wait(self.interval)
 
 
 def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", *args, **kwargs):

--- a/octue/utils/threads.py
+++ b/octue/utils/threads.py
@@ -1,0 +1,34 @@
+from subprocess import PIPE, STDOUT, CalledProcessError, Popen
+from threading import Thread
+
+
+def run_subprocess_and_log_stdout_and_stderr(command, logger, log_level="info", *args, **kwargs):
+    """Run a subprocess, sending its stdout and stderr output to the given logger. Extra `args` and `kwargs` are
+    provided to the `subprocess.Popen` instance used.
+
+    :param iter(str) command: command to run
+    :param logging.Logger logger: logger to use to log stdout and stderr
+    :param str log_level: level to log output at
+    :raise CalledProcessError: if the subprocess fails (i.e. if it doesn't exit with a 0 return code)
+    :return subprocess.CompletedProcess:
+    """
+
+    def _log_lines_from_stream(stream, logger):
+        """Log lines from the given stream.
+
+        :param io.BufferedReader stream:
+        :param logging.Logger logger:
+        :return None:
+        """
+        with stream:
+            for line in iter(stream.readline, b""):
+                getattr(logger, log_level.lower())(line.decode().strip())
+
+    process = Popen(command, stdout=PIPE, stderr=STDOUT, *args, **kwargs)
+    Thread(target=_log_lines_from_stream, args=[process.stdout, logger]).start()
+    process.wait()
+
+    if process.returncode != 0:
+        raise CalledProcessError(returncode=process.returncode, cmd=" ".join(command))
+
+    return process

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.33.0"
+version = "0.34.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/cloud/pub_sub/test_message_handler.py
+++ b/tests/cloud/pub_sub/test_message_handler.py
@@ -247,3 +247,32 @@ class TestOrderedMessageHandler(BaseTestCase):
             message_handler.handle_messages(acceptable_heartbeat_interval=0)
 
         self.assertIn("heartbeat", error.exception.args[0])
+
+    def test_error_not_raised_if_heartbeat_has_been_received_in_acceptable_period(self):
+        """Test that an error is not raised if a heartbeat has been received in the acceptable period."""
+        message_handler = OrderedMessageHandler(subscriber=MockSubscriber(), subscription=self.mock_subscription)
+        message_handler._last_heartbeat = datetime.datetime.now()
+
+        with patch(
+            "octue.cloud.pub_sub.service.OrderedMessageHandler._pull_message",
+            new=MockMessagePuller(
+                [
+                    {
+                        "type": "delivery_acknowledgement",
+                        "delivery_time": "2021-11-17 17:33:59.717428",
+                        "message_number": 0,
+                    },
+                    {"type": "result", "output_values": None, "output_manifest": None, "message_number": 1},
+                ]
+            ).pull,
+        ):
+            with patch(
+                "octue.cloud.pub_sub.message_handler.OrderedMessageHandler._time_since_last_heartbeat",
+                datetime.timedelta(seconds=0),
+            ):
+                message_handler.handle_messages(acceptable_heartbeat_interval=0)
+
+    def test_time_since_last_heartbeat_is_none_if_no_heartbeat_received_yet(self):
+        """Test that the time since the last heartbeat is `None` if no heartbeat has been received yet."""
+        message_handler = OrderedMessageHandler(subscriber=MockSubscriber(), subscription=self.mock_subscription)
+        self.assertIsNone(message_handler._time_since_last_heartbeat)

--- a/tests/cloud/pub_sub/test_message_handler.py
+++ b/tests/cloud/pub_sub/test_message_handler.py
@@ -234,22 +234,22 @@ class TestOrderedMessageHandler(BaseTestCase):
         message_handler = OrderedMessageHandler(subscriber=MockSubscriber(), subscription=self.mock_subscription)
 
         with self.assertRaises(TimeoutError) as error:
-            message_handler.handle_messages(acceptable_heartbeat_interval=0)
+            message_handler.handle_messages(maximum_heartbeat_interval=0)
 
         self.assertIn("heartbeat", error.exception.args[0])
 
     def test_error_raised_if_heartbeats_stop_being_received(self):
-        """Test that an error is raised if heartbeats stop being received within the acceptable interval."""
+        """Test that an error is raised if heartbeats stop being received within the maximum interval."""
         message_handler = OrderedMessageHandler(subscriber=MockSubscriber(), subscription=self.mock_subscription)
         message_handler._last_heartbeat = datetime.datetime.now() - datetime.timedelta(seconds=30)
 
         with self.assertRaises(TimeoutError) as error:
-            message_handler.handle_messages(acceptable_heartbeat_interval=0)
+            message_handler.handle_messages(maximum_heartbeat_interval=0)
 
         self.assertIn("heartbeat", error.exception.args[0])
 
-    def test_error_not_raised_if_heartbeat_has_been_received_in_acceptable_period(self):
-        """Test that an error is not raised if a heartbeat has been received in the acceptable period."""
+    def test_error_not_raised_if_heartbeat_has_been_received_in_maximum_allowed_interval(self):
+        """Test that an error is not raised if a heartbeat has been received in the maximum allowed interval."""
         message_handler = OrderedMessageHandler(subscriber=MockSubscriber(), subscription=self.mock_subscription)
         message_handler._last_heartbeat = datetime.datetime.now()
 
@@ -270,7 +270,7 @@ class TestOrderedMessageHandler(BaseTestCase):
                 "octue.cloud.pub_sub.message_handler.OrderedMessageHandler._time_since_last_heartbeat",
                 datetime.timedelta(seconds=0),
             ):
-                message_handler.handle_messages(acceptable_heartbeat_interval=0)
+                message_handler.handle_messages(maximum_heartbeat_interval=0)
 
     def test_time_since_last_heartbeat_is_none_if_no_heartbeat_received_yet(self):
         """Test that the time since the last heartbeat is `None` if no heartbeat has been received yet."""

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -789,6 +789,7 @@ class TestService(BaseTestCase):
 
     def test_child_sends_heartbeat_messages_at_expected_regular_intervals(self):
         """Test that children send heartbeat messages at the expected regular intervals."""
+        expected_interval = 0.05
 
         def run_function(*args, **kwargs):
             time.sleep(0.3)
@@ -802,7 +803,7 @@ class TestService(BaseTestCase):
 
             with patch(
                 "octue.cloud.emulators._pub_sub.MockService.answer",
-                functools.partial(child.answer, heartbeat_interval=0.1),
+                functools.partial(child.answer, heartbeat_interval=expected_interval),
             ):
                 self.ask_question_and_wait_for_answer(
                     parent=parent,
@@ -821,7 +822,7 @@ class TestService(BaseTestCase):
 
         self.assertAlmostEqual(
             second_heartbeat_time - first_heartbeat_time,
-            datetime.timedelta(seconds=0.1),
+            datetime.timedelta(seconds=expected_interval),
             delta=datetime.timedelta(0.05),
         )
 

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -5,7 +5,7 @@ import logging
 import tempfile
 import time
 import uuid
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import twined.exceptions
 from octue import Runner, exceptions
@@ -825,20 +825,6 @@ class TestService(BaseTestCase):
             datetime.timedelta(seconds=expected_interval),
             delta=datetime.timedelta(0.05),
         )
-
-    def test_parent_raises_error_if_heartbeat_not_received_in_time(self):
-        """Test that a parent will raise an error if a heartbeat isn't received within the acceptable time interval."""
-        parent = MockService(backend=BACKEND)
-
-        with self.service_patcher:
-            with self.assertRaises(TimeoutError) as error:
-                parent.wait_for_answer(
-                    subscription=Mock(is_push_subscription=False),
-                    delivery_acknowledgement_timeout=100,
-                    acceptable_heartbeat_interval=0,
-                )
-
-            self.assertIn("heartbeat", error.exception.args[0])
 
     @staticmethod
     def make_new_child(backend, run_function_returnee):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -648,12 +648,7 @@ class TestService(BaseTestCase):
 
     def test_warning_issued_if_child_and_parent_sdk_versions_incompatible(self):
         """Test that a warning is logged if the parent and child's Octue SDK versions are potentially incompatible."""
-        child = self.make_new_child(backend=BACKEND, run_function_returnee=MockAnalysis())
-        parent = MockService(backend=BACKEND, children={child.id: child})
-
         with self.service_patcher:
-            child.serve()
-
             for parent_sdk_version, child_sdk_version in (
                 ("0.1.0", "0.2.0"),
                 ("0.2.0", "0.1.0"),
@@ -662,6 +657,11 @@ class TestService(BaseTestCase):
             ):
                 with self.subTest(parent_sdk_version=parent_sdk_version, child_sdk_version=child_sdk_version):
                     with patch("pkg_resources.Distribution.version", child_sdk_version):
+
+                        child = self.make_new_child(backend=BACKEND, run_function_returnee=MockAnalysis())
+                        parent = MockService(backend=BACKEND, children={child.id: child})
+                        child.serve()
+
                         with self.assertLogs() as logging_context:
                             self.ask_question_and_wait_for_answer(
                                 parent=parent,

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -784,8 +784,8 @@ class TestService(BaseTestCase):
 
         # Check that the child's messages have been recorded by the parent.
         self.assertEqual(recorded_messages[0]["type"], "delivery_acknowledgement")
-        self.assertEqual(recorded_messages[2]["type"], "exception")
-        self.assertIn("Oh no.", recorded_messages[2]["exception_message"])
+        self.assertEqual(recorded_messages[1]["type"], "exception")
+        self.assertIn("Oh no.", recorded_messages[1]["exception_message"])
 
     def test_heartbeat_messages_are_sent_at_expected_regular_intervals(self):
         """Test that heartbeat messages are sent at the expected regular intervals."""

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -670,7 +670,7 @@ class TestService(BaseTestCase):
                             self.assertIn(
                                 f"The parent's Octue SDK version {parent_sdk_version} may not be compatible "
                                 f"with the local Octue SDK version {child_sdk_version}",
-                                logging_context.output[4],
+                                logging_context.output[3],
                             )
 
     def test_messages_sent_to_parent_are_not_recorded_by_child_if_crash_diagnostics_not_allowed(self):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -670,7 +670,7 @@ class TestService(BaseTestCase):
                             self.assertIn(
                                 f"The parent's Octue SDK version {parent_sdk_version} may not be compatible "
                                 f"with the local Octue SDK version {child_sdk_version}",
-                                logging_context.output[3],
+                                logging_context.output[4],
                             )
 
     def test_messages_sent_to_parent_are_not_recorded_by_child_if_crash_diagnostics_not_allowed(self):
@@ -716,13 +716,13 @@ class TestService(BaseTestCase):
 
         # Check that the child's messages have been recorded.
         self.assertEqual(child._sent_messages[0]["type"], "delivery_acknowledgement")
-        self.assertEqual(child._sent_messages[1]["type"], "log_record")
         self.assertEqual(child._sent_messages[2]["type"], "log_record")
         self.assertEqual(child._sent_messages[3]["type"], "log_record")
+        self.assertEqual(child._sent_messages[4]["type"], "log_record")
 
         self.assertEqual(
-            child._sent_messages[4],
-            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 4},
+            child._sent_messages[5],
+            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 5},
         )
 
     def test_child_messages_can_be_recorded_by_parent(self):
@@ -748,13 +748,13 @@ class TestService(BaseTestCase):
 
         # Check that the child's messages have been recorded by the parent.
         self.assertEqual(recorded_messages[0]["type"], "delivery_acknowledgement")
-        self.assertEqual(recorded_messages[1]["type"], "log_record")
         self.assertEqual(recorded_messages[2]["type"], "log_record")
         self.assertEqual(recorded_messages[3]["type"], "log_record")
+        self.assertEqual(recorded_messages[4]["type"], "log_record")
 
         self.assertEqual(
-            recorded_messages[4],
-            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 4},
+            recorded_messages[5],
+            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 5},
         )
 
     def test_child_exception_message_can_be_recorded_by_parent(self):
@@ -781,8 +781,8 @@ class TestService(BaseTestCase):
 
         # Check that the child's messages have been recorded by the parent.
         self.assertEqual(recorded_messages[0]["type"], "delivery_acknowledgement")
-        self.assertEqual(recorded_messages[1]["type"], "exception")
-        self.assertIn("Oh no.", recorded_messages[1]["exception_message"])
+        self.assertEqual(recorded_messages[2]["type"], "exception")
+        self.assertIn("Oh no.", recorded_messages[2]["exception_message"])
 
     @staticmethod
     def make_new_child(backend, run_function_returnee):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -867,7 +867,7 @@ class TestService(BaseTestCase):
         timeout=30,
         delivery_acknowledgement_timeout=30,
         parent_sdk_version=None,
-        acceptable_heartbeat_interval=300,
+        maximum_heartbeat_interval=300,
     ):
         """Get a parent service to ask a question to a child service and wait for the answer.
 
@@ -885,7 +885,7 @@ class TestService(BaseTestCase):
         :param int|float timeout:
         :param int|float delivery_acknowledgement_timeout:
         :param str|None parent_sdk_version:
-        :param int|float acceptable_heartbeat_interval:
+        :param int|float maximum_heartbeat_interval:
         :return dict:
         """
         subscription, _ = parent.ask(
@@ -906,7 +906,7 @@ class TestService(BaseTestCase):
             record_messages_to=record_messages_to,
             service_name=service_name,
             delivery_acknowledgement_timeout=delivery_acknowledgement_timeout,
-            acceptable_heartbeat_interval=acceptable_heartbeat_interval,
+            maximum_heartbeat_interval=maximum_heartbeat_interval,
         )
 
     @staticmethod

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -716,13 +716,13 @@ class TestService(BaseTestCase):
 
         # Check that the child's messages have been recorded.
         self.assertEqual(child._sent_messages[0]["type"], "delivery_acknowledgement")
+        self.assertEqual(child._sent_messages[1]["type"], "log_record")
         self.assertEqual(child._sent_messages[2]["type"], "log_record")
         self.assertEqual(child._sent_messages[3]["type"], "log_record")
-        self.assertEqual(child._sent_messages[4]["type"], "log_record")
 
         self.assertEqual(
-            child._sent_messages[5],
-            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 5},
+            child._sent_messages[4],
+            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 4},
         )
 
     def test_child_messages_can_be_recorded_by_parent(self):
@@ -748,13 +748,13 @@ class TestService(BaseTestCase):
 
         # Check that the child's messages have been recorded by the parent.
         self.assertEqual(recorded_messages[0]["type"], "delivery_acknowledgement")
+        self.assertEqual(recorded_messages[1]["type"], "log_record")
         self.assertEqual(recorded_messages[2]["type"], "log_record")
         self.assertEqual(recorded_messages[3]["type"], "log_record")
-        self.assertEqual(recorded_messages[4]["type"], "log_record")
 
         self.assertEqual(
-            recorded_messages[5],
-            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 5},
+            recorded_messages[4],
+            {"type": "result", "output_values": "Hello! It worked!", "output_manifest": None, "message_number": 4},
         )
 
     def test_child_exception_message_can_be_recorded_by_parent(self):

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -798,16 +798,20 @@ class TestService(BaseTestCase):
         parent = MockService(backend=BACKEND, children={child.id: child})
 
         with self.service_patcher:
-            child.serve(callback=functools.partial(child.answer, heartbeat_interval=0.1))
+            child.serve()
 
-            self.ask_question_and_wait_for_answer(
-                parent=parent,
-                child=child,
-                input_values={},
-                subscribe_to_logs=True,
-                allow_save_diagnostics_data_on_crash=True,
-                service_name="my-super-service",
-            )
+            with patch(
+                "octue.cloud.emulators._pub_sub.MockService.answer",
+                functools.partial(child.answer, heartbeat_interval=0.1),
+            ):
+                self.ask_question_and_wait_for_answer(
+                    parent=parent,
+                    child=child,
+                    input_values={},
+                    subscribe_to_logs=True,
+                    allow_save_diagnostics_data_on_crash=True,
+                    service_name="my-super-service",
+                )
 
         self.assertEqual(child._sent_messages[1]["type"], "heartbeat")
         self.assertEqual(child._sent_messages[2]["type"], "heartbeat")

--- a/tests/utils/test_threads.py
+++ b/tests/utils/test_threads.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 from unittest.mock import Mock, patch
 
-from octue.utils.processes import run_subprocess_and_log_stdout_and_stderr
+from octue.utils.threads import run_subprocess_and_log_stdout_and_stderr
 from tests.base import BaseTestCase
 
 

--- a/tests/utils/test_threads.py
+++ b/tests/utils/test_threads.py
@@ -18,7 +18,7 @@ class TestRepeatingTimer(TestCase):
         time.sleep(1)
         timer.cancel()
 
-        self.assertEqual(mock_function.call_count, 9)
+        self.assertGreater(mock_function.call_count, 4)
 
     def test_calls_function_at_correct_intervals(self):
         """Test that the timer calls the function at the near-correct time interval."""
@@ -41,7 +41,7 @@ class TestRepeatingTimer(TestCase):
             intervals.append(timestamp - times[i - 1])
 
         for interval in intervals:
-            self.assertAlmostEqual(interval, intended_interval, delta=0.05)
+            self.assertAlmostEqual(interval, intended_interval, delta=0.2)
 
     def test_does_not_call_function_if_cancelled_before_interval(self):
         """Test that the function is not called if the timer is cancelled before the time interval is first reached."""

--- a/tests/utils/test_threads.py
+++ b/tests/utils/test_threads.py
@@ -4,7 +4,7 @@ import time
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from octue.utils.threads import RepeatingTimer, run_subprocess_and_log_stdout_and_stderr
+from octue.utils.threads import RepeatingTimer, run_logged_subprocess
 
 
 class TestRepeatingTimer(TestCase):
@@ -55,7 +55,7 @@ class TestRepeatingTimer(TestCase):
         mock_function.assert_not_called()
 
 
-class TestRunSubprocessAndLogStdoutAndStderr(TestCase):
+class TestRunLoggedSubprocess(TestCase):
     def test_error_raised_if_process_fails(self):
         """Test that an error is raised if the subprocess fails."""
         with self.assertRaises(subprocess.CalledProcessError):
@@ -63,7 +63,7 @@ class TestRunSubprocessAndLogStdoutAndStderr(TestCase):
                 "octue.utils.threads.Popen",
                 return_value=MockPopen(stdout_messages=[b"bash: blah: command not found"], return_code=1),
             ):
-                run_subprocess_and_log_stdout_and_stderr(command=["blah"], logger=logging.getLogger(), shell=True)
+                run_logged_subprocess(command=["blah"], logger=logging.getLogger(), shell=True)
 
     def test_stdout_is_logged(self):
         """Test that any output to stdout from a subprocess is logged."""
@@ -72,9 +72,7 @@ class TestRunSubprocessAndLogStdoutAndStderr(TestCase):
         with patch(
             "octue.utils.threads.Popen", return_value=MockPopen(stdout_messages=[b"hello", b"goodbye"], return_code=0)
         ):
-            process = run_subprocess_and_log_stdout_and_stderr(
-                command=["echo hello && echo goodbye"], logger=mock_logger, shell=True
-            )
+            process = run_logged_subprocess(command=["echo hello && echo goodbye"], logger=mock_logger, shell=True)
 
         self.assertEqual(process.returncode, 0)
         self.assertEqual(mock_logger.info.call_args_list[0][0][0], "hello")


### PR DESCRIPTION
# Summary
This release upgrades children to send heartbeats to parents. This allows the parent to know that a child it's asked a question to is still alive and hasn't crashed. In the event of a crash, heartbeats stop being received and the parent aborts the questions, avoiding large waits for nothing.

<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#514](https://github.com/octue/octue-sdk-python/pull/514))
**IMPORTANT:** There are 2 breaking changes.

### New features
- Send heartbeat messages to parents from children
- Raise error in parent if child heartbeats aren't received for too long an interval

### Enhancements
- Tell user how to question a service after using `octue start` CLI command

### Refactoring
- 💥 **BREAKING CHANGE:** Rename `run_subprocess_and_log_stdout_and_stderr` to `run_logged_subprocess`
- Split thread and process utilities into separate modules
- Remove redundant extra `while` loop in `OrderedMessageHandler`
- Remove redundant `unwrap` function and `AppFrom.run` method from `runner` module

### Operations
- Use non-deprecated/latest Codecov action in workflows

### Testing
- Increase `ChildEmulator` test coverage


---
# Upgrade instructions
<details>
<summary>💥 <b>Rename run_subprocess_and_log_stdout_and_stderr to run_logged_subprocess</b></summary>

Use `octue.utils.threads.run_logged_subprocess` instead.
</details>

<!--- END AUTOGENERATED NOTES --->