### PR TITLE
Remove metadata warning from datafiles and datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
           - '^dependencies/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
 
   - repo: https://github.com/octue/conventional-commits
-    rev: 0.6.3
+    rev: 0.6.4
     hooks:
       - id: check-commit-message-is-conventional
         stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We use [Poetry](https://python-poetry.org/) as our package manager. For developm
 repository root, which will editably install the package:
 
 ```shell
-poetry install -E dataflow -E hdf5
+poetry install --all-extras
 ```
 
 Then run the tests to check everything's working.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,7 +38,7 @@ We use continuous deployment and semantic versioning for our releases:
   pyenv virtualenv 3.9 myenv                                    # Makes a virtual environment for you to install the dev tools into. Use any python >= 3.8
   pyenv activate myenv                                          # Activates the virtual environment so you don't affect other installations
   pip install poetry                                            # Installs the poetry package manager
-  poetry install -E hdf5 -E dataflow                            # Installs the package editably, including developer dependencies (e.g. testing and code formatting utilities)
+  poetry install --all-extras                                   # Installs the package editably, including developer dependencies (e.g. testing and code formatting utilities)
   pre-commit install && pre-commit install -t commit-msg        # Installs the pre-commit hooks in the git repo
   tox                                                           # Runs the tests
   ```

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -11,9 +11,6 @@ import pkg_resources
 import requests
 from google_crc32c import Checksum
 
-from octue.resources.label import LabelSet
-from octue.resources.tag import TagDict
-
 
 # The `h5py` package is only needed if dealing with HDF5 files. It's only available if the `hdf5` extra is provided
 # during installation of `octue`.
@@ -99,21 +96,6 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
             self._instantiate_from_cloud_object(path, local_path, ignore_stored_metadata=hypothetical)
         else:
             self._instantiate_from_local_path(path, cloud_path, ignore_stored_metadata=hypothetical)
-
-        if hypothetical:
-            logger.debug("Ignored stored metadata for %r.", self)
-        else:
-            if self.metadata(use_octue_namespace=False, include_sdk_version=False) != {
-                "id": id or self.id,
-                "timestamp": timestamp,
-                "tags": TagDict(tags),
-                "labels": LabelSet(labels),
-            }:
-                logger.warning(
-                    "Overriding metadata given at instantiation with stored metadata for %r - set `hypothetical` to "
-                    "`True` at instantiation to avoid this.",
-                    self,
-                )
 
     @classmethod
     def deserialise(cls, serialised_datafile, from_string=False):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -94,8 +94,9 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
 
         if storage.path.is_cloud_path(path):
             self._instantiate_from_cloud_object(path, local_path, ignore_stored_metadata=ignore_stored_metadata)
-        else:
-            self._instantiate_from_local_path(path, cloud_path, ignore_stored_metadata=ignore_stored_metadata)
+            return
+
+        self._instantiate_from_local_path(path, cloud_path, ignore_stored_metadata=ignore_stored_metadata)
 
     @classmethod
     def deserialise(cls, serialised_datafile, from_string=False):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -37,7 +37,8 @@ OCTUE_METADATA_NAMESPACE = "octue"
 class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filterable, Metadata, CloudPathable):
     """A representation of a data file on the Octue system. Metadata for the file is obtained from its corresponding
     cloud object or a local `.octue` metadata file, if present. If no stored metadata is available, it can be set during
-    or after instantiation.
+    or after instantiation. If `ignore_stored_metadata` is `False`, any stored metadata takes priority over metadata
+    passed in during instantiation (`id`, `timestamp`, `tags`, and `labels`).
 
     :param str|None path: The path of this file locally or in the cloud, which may include folders or subfolders, within the dataset
     :param str|None local_path: If a cloud path is given as the `path` parameter, this is the path to an existing local file that is known to be in sync with the cloud object

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -45,7 +45,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
     :param datetime.datetime|int|float|None timestamp: A posix timestamp associated with the file, in seconds since epoch, typically when it was created but could relate to a relevant time point for the data
     :param str mode: if using as a context manager, open the datafile for reading/editing in this mode (the mode options are the same as for the builtin `open` function)
     :param bool update_metadata: if using as a context manager and this is `True`, update the stored metadata of the datafile when the context is exited
-    :param bool hypothetical: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
+    :param bool ignore_stored_metadata: if `True`, ignore any metadata stored for this datafile locally or in the cloud and use whatever is given at instantiation
     :param str id: The Universally Unique ID of this file (checked to be valid if not None, generated if None)
     :param dict|octue.resources.tag.TagDict|None tags: key-value pairs with string keys conforming to the Octue tag format (see `TagDict`)
     :param iter(str)|octue.resources.label.LabelSet|None labels: Space-separated string of labels relevant to this file
@@ -72,7 +72,7 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         timestamp=None,
         mode="r",
         update_metadata=True,
-        hypothetical=False,
+        ignore_stored_metadata=False,
         id=None,
         tags=None,
         labels=None,
@@ -93,9 +93,9 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         self._cloud_metadata = {}
 
         if storage.path.is_cloud_path(path):
-            self._instantiate_from_cloud_object(path, local_path, ignore_stored_metadata=hypothetical)
+            self._instantiate_from_cloud_object(path, local_path, ignore_stored_metadata=ignore_stored_metadata)
         else:
-            self._instantiate_from_local_path(path, cloud_path, ignore_stored_metadata=hypothetical)
+            self._instantiate_from_local_path(path, cloud_path, ignore_stored_metadata=ignore_stored_metadata)
 
     @classmethod
     def deserialise(cls, serialised_datafile, from_string=False):

--- a/octue/resources/datafile.py
+++ b/octue/resources/datafile.py
@@ -35,10 +35,14 @@ OCTUE_METADATA_NAMESPACE = "octue"
 
 
 class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filterable, Metadata, CloudPathable):
-    """A representation of a data file on the Octue system. Metadata for the file is obtained from its corresponding
-    cloud object or a local `.octue` metadata file, if present. If no stored metadata is available, it can be set during
-    or after instantiation. If `ignore_stored_metadata` is `False`, any stored metadata takes priority over metadata
-    passed in during instantiation (`id`, `timestamp`, `tags`, and `labels`).
+    """A representation of a data file with metadata.
+
+    Metadata consists of `id`, `timestamp`, `tags`, and `labels`, available as attributes on the instance. On
+    instantiation, metadata for the file is obtained from its stored location (the corresponding cloud object metadata
+    or a local `.octue` metadata file) if present. Metadata values can alternatively be passed as arguments at
+    instantiation but will only be used if stored metadata cannot be found - i.e. stored metadata always takes
+    precedence (use the `ignore_stored_metadata` parameter to override this behaviour). Stored metadata can be updated
+    after instantiation using the `update_metadata` method.
 
     :param str|None path: The path of this file locally or in the cloud, which may include folders or subfolders, within the dataset
     :param str|None local_path: If a cloud path is given as the `path` parameter, this is the path to an existing local file that is known to be in sync with the cloud object
@@ -441,7 +445,8 @@ class Datafile(Labelable, Taggable, Serialisable, Identifiable, Hashable, Filter
         return {f"{OCTUE_METADATA_NAMESPACE}__{key}": value for key, value in metadata.items()}
 
     def update_metadata(self):
-        """If the datafile is cloud-based, update its cloud metadata; otherwise, update its local metadata.
+        """Using the datafile instance's in-memory metadata, update its cloud metadata (if the datafile is cloud-based)
+        or its local metadata file (if the datafile is local).
 
         :return None:
         """

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -26,14 +26,18 @@ SIGNED_METADATA_DIRECTORY = ".signed_metadata_files"
 
 
 class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadata, CloudPathable):
-    """A representation of a dataset. The default usage is to provide the path to a local or cloud directory and create
-    the dataset from the files it contains. Alternatively, the `files` parameter can be provided and only those files
-    are included. Either way, the `path` parameter should be explicitly set to something meaningful.
+    """A representation of a dataset with metadata.
 
-    Metadata for the dataset is obtained from its corresponding cloud object or a local `.octue` metadata file, if
-    present. If no stored metadata is available, it can be set during or after instantiation. If
-    `ignore_stored_metadata` is `False`, any stored metadata takes priority over metadata passed in during instantiation
-    (`id`, `name`, `tags`, and `labels`).
+    The default usage is to provide the path to a local or cloud directory and create the dataset from the files it
+    contains. Alternatively, the `files` parameter can be provided and only those files are included. Either way, the
+    `path` parameter should be explicitly set to something meaningful.
+
+    Metadata consists of `id`, `name`, `tags`, and `labels`, available as attributes on the instance. On instantiation,
+    metadata for the dataset is obtained from its stored location (the corresponding cloud object metadata
+    or a local `.octue` metadata file) if present. Metadata values can alternatively be passed as arguments at
+    instantiation but will only be used if stored metadata cannot be found - i.e. stored metadata always takes
+    precedence (use the `ignore_stored_metadata` parameter to override this behaviour). Stored metadata can be updated
+    after instantiation using the `update_metadata` method.
 
     :param str|None path: the path to the dataset (defaults to the current working directory if none is given)
     :param iter(str|dict|octue.resources.datafile.Datafile)|None files: the files belonging to the dataset
@@ -214,7 +218,8 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
         return cloud_path
 
     def update_metadata(self):
-        """If the dataset is cloud-based, update its cloud metadata; otherwise, update its local metadata.
+        """Using the dataset instance's in-memory metadata, update its cloud metadata (if the dataset is cloud-based)
+        or its local metadata file (if the dataset is local).
 
         :return None:
         """

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -77,8 +77,9 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
 
         if storage.path.is_cloud_path(self.path):
             self._instantiate_from_cloud(path=self.path)
-        else:
-            self._instantiate_from_local_directory(path=self.path)
+            return
+
+        self._instantiate_from_local_directory(path=self.path)
 
     @property
     def name(self):

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -30,6 +30,11 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
     the dataset from the files it contains. Alternatively, the `files` parameter can be provided and only those files
     are included. Either way, the `path` parameter should be explicitly set to something meaningful.
 
+    Metadata for the dataset is obtained from its corresponding cloud object or a local `.octue` metadata file, if
+    present. If no stored metadata is available, it can be set during or after instantiation. If
+    `ignore_stored_metadata` is `False`, any stored metadata takes priority over metadata passed in during instantiation
+    (`id`, `name`, `tags`, and `labels`).
+
     :param str|None path: the path to the dataset (defaults to the current working directory if none is given)
     :param iter(str|dict|octue.resources.datafile.Datafile)|None files: the files belonging to the dataset
     :param bool recursive: if `True`, include in the dataset all files in the subdirectories recursively contained within the dataset directory

--- a/octue/resources/dataset.py
+++ b/octue/resources/dataset.py
@@ -407,7 +407,10 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
             bucket_name = storage.path.split_bucket_name_from_cloud_path(path)[0]
 
             self.files = FilterSet(
-                Datafile(path=storage.path.generate_gs_path(bucket_name, blob.name), hypothetical=self._hypothetical)
+                Datafile(
+                    path=storage.path.generate_gs_path(bucket_name, blob.name),
+                    ignore_stored_metadata=self._hypothetical,
+                )
                 for blob in GoogleCloudStorageClient().scandir(
                     path,
                     recursive=self._recursive,
@@ -436,7 +439,9 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
                 if not self._recursive and level > 0:
                     break
 
-                self.files.add(Datafile(path=os.path.join(directory_path, filename), hypothetical=self._hypothetical))
+                self.files.add(
+                    Datafile(path=os.path.join(directory_path, filename), ignore_stored_metadata=self._hypothetical)
+                )
 
         if not self._hypothetical:
             self._use_local_metadata()
@@ -460,7 +465,7 @@ class Dataset(Labelable, Taggable, Serialisable, Identifiable, Hashable, Metadat
             return file
 
         if isinstance(file, str):
-            return Datafile(path=file, hypothetical=self._hypothetical)
+            return Datafile(path=file, ignore_stored_metadata=self._hypothetical)
 
         return Datafile.deserialise(file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octue"
-version = "0.34.1"
+version = "0.35.0"
 description = "A package providing template applications for data services, and a python SDK to the Octue API."
 readme = "README.md"
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>", "Thomas Clark <support@octue.com>"]

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -858,11 +858,8 @@ class TestDatafile(BaseTestCase):
 
         # Load it separately from the cloud object and check that the stored metadata is used instead of the
         # instantiation metadata.
-        with self.assertLogs() as logging_context:
-            reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"})
-
+        reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"})
         self.assertEqual(reloaded_datafile.tags, {"existing": True})
-        self.assertIn("Overriding metadata given at instantiation with stored metadata", logging_context.output[0])
 
     def test_instantiation_metadata_used_if_not_hypothetical_but_no_stored_metadata(self):
         """Test that instantiation metadata is used if `hypothetical` is `False` but there's no stored metadata."""

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -877,7 +877,7 @@ class TestDatafile(BaseTestCase):
 
         # Load it separately from the cloud object and check that the instantiation metadata is used instead of the
         # stored metadata.
-        reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"}, hypothetical=True)
+        reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"}, ignore_stored_metadata=True)
         self.assertEqual(reloaded_datafile.tags, {"new": "tag"})
 
     def test_error_raised_if_attempting_to_generate_signed_url_for_local_datafile(self):

--- a/tests/resources/test_datafile.py
+++ b/tests/resources/test_datafile.py
@@ -848,8 +848,8 @@ class TestDatafile(BaseTestCase):
         self.assertEqual(datafile.id, unpickled_datafile.id)
         self.assertEqual(datafile.hash_value, unpickled_datafile.hash_value)
 
-    def test_stored_metadata_has_priority_over_instantiation_metadata_if_not_hypothetical(self):
-        """Test that stored metadata is used instead of instantiation metadata if `hypothetical` is `False`."""
+    def test_stored_metadata_has_priority_over_instantiation_metadata_if_not_ignoring_stored_metadata(self):
+        """Test that stored metadata is used instead of instantiation metadata if `ignore_stored_metadata` is `False`."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "existing_datafile.dat")
 
         # Create a datafile in the cloud and set some metadata on it.
@@ -861,14 +861,14 @@ class TestDatafile(BaseTestCase):
         reloaded_datafile = Datafile(cloud_path, tags={"new": "tag"})
         self.assertEqual(reloaded_datafile.tags, {"existing": True})
 
-    def test_instantiation_metadata_used_if_not_hypothetical_but_no_stored_metadata(self):
-        """Test that instantiation metadata is used if `hypothetical` is `False` but there's no stored metadata."""
+    def test_instantiation_metadata_used_if_not_ignoring_stored_metadata_but_no_stored_metadata(self):
+        """Test that instantiation metadata is used if `ignore_stored_metadata` is `False` but there's no stored metadata."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "non_existing_datafile.dat")
         datafile = Datafile(cloud_path, tags={"new": "tag"})
         self.assertEqual(datafile.tags, {"new": "tag"})
 
-    def test_stored_metadata_ignored_if_hypothetical_is_true(self):
-        """Test that instantiation metadata is used instead of stored metadata if `hypothetical` is `True`."""
+    def test_stored_metadata_ignored_if_ignoring_stored_metadata_is_true(self):
+        """Test that instantiation metadata is used instead of stored metadata if `ignore_stored_metadata` is `True`."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "existing_datafile.dat")
 
         # Create a datafile in the cloud and set some metadata on it.

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -800,11 +800,8 @@ class TestDataset(BaseTestCase):
 
         # Load it separately from the cloud object and check that the stored metadata is used instead of the
         # instantiation metadata.
-        with self.assertLogs() as logging_context:
-            reloaded_dataset = Dataset(path=cloud_path, tags={"new": "tag"})
-
+        reloaded_dataset = Dataset(path=cloud_path, tags={"new": "tag"})
         self.assertEqual(reloaded_dataset.tags, {"existing": True})
-        self.assertIn("Overriding metadata given at instantiation with stored metadata", logging_context.output[0])
 
     def test_instantiation_metadata_used_if_not_hypothetical_but_no_stored_metadata(self):
         """Test that instantiation metadata is used if `hypothetical` is `False` but there's no stored metadata."""
@@ -822,7 +819,7 @@ class TestDataset(BaseTestCase):
 
         # Load it separately from the cloud object and check that the instantiation metadata is used instead of the
         # stored metadata.
-        reloaded_datafile = Dataset(path=cloud_path, tags={"new": "tag"}, hypothetical=True)
+        reloaded_datafile = Dataset(path=cloud_path, tags={"new": "tag"}, ignore_stored_metadata=True)
         self.assertEqual(reloaded_datafile.tags, {"new": "tag"})
 
     def test_update_metadata_with_local_dataset(self):

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -790,8 +790,8 @@ class TestDataset(BaseTestCase):
         self.assertEqual(reloaded_dataset.tags, {"cat": "dog"})
         self.assertEqual(reloaded_dataset.labels, {"animals"})
 
-    def test_stored_metadata_has_priority_over_instantiation_metadata_if_not_hypothetical(self):
-        """Test that stored metadata is used instead of instantiation metadata if `hypothetical` is `False`."""
+    def test_stored_metadata_has_priority_over_instantiation_metadata_if_not_ignoring_stored_metadata(self):
+        """Test that stored metadata is used instead of instantiation metadata if `ignore_stored_metadata` is `False`."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "existing_dataset")
 
         # Create a dataset in the cloud and set some metadata on it.
@@ -803,14 +803,14 @@ class TestDataset(BaseTestCase):
         reloaded_dataset = Dataset(path=cloud_path, tags={"new": "tag"})
         self.assertEqual(reloaded_dataset.tags, {"existing": True})
 
-    def test_instantiation_metadata_used_if_not_hypothetical_but_no_stored_metadata(self):
-        """Test that instantiation metadata is used if `hypothetical` is `False` but there's no stored metadata."""
+    def test_instantiation_metadata_used_if_not_ignoring_stored_metadata_but_no_stored_metadata(self):
+        """Test that instantiation metadata is used if `ignore_stored_metadata` is `False` but there's no stored metadata."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "non_existing_dataset")
         dataset = Dataset(path=cloud_path, tags={"new": "tag"})
         self.assertEqual(dataset.tags, {"new": "tag"})
 
-    def test_stored_metadata_ignored_if_hypothetical_is_true(self):
-        """Test that instantiation metadata is used instead of stored metadata if `hypothetical` is `True`."""
+    def test_stored_metadata_ignored_if_ignoring_stored_metadata(self):
+        """Test that instantiation metadata is used instead of stored metadata if `ignore_stored_metadata` is `True`."""
         cloud_path = storage.path.generate_gs_path(TEST_BUCKET_NAME, "existing_dataset")
 
         # Create a dataset in the cloud and set some metadata on it.

--- a/tests/resources/test_dataset.py
+++ b/tests/resources/test_dataset.py
@@ -370,7 +370,7 @@ class TestDataset(BaseTestCase):
     def test_metadata_hash_is_same_for_different_datasets_with_the_same_metadata(self):
         """Test that the metadata hash is the same for datasets with different files but the same metadata."""
         first_dataset = Dataset(labels={"a", "b", "c"})
-        second_dataset = Dataset(files={Datafile(path="blah", hypothetical=True)}, labels={"a", "b", "c"})
+        second_dataset = Dataset(files={Datafile(path="blah", ignore_stored_metadata=True)}, labels={"a", "b", "c"})
         self.assertEqual(first_dataset.metadata_hash_value, second_dataset.metadata_hash_value)
 
     def test_metadata_hash_is_different_for_same_dataset_but_different_metadata(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv = GOOGLE_APPLICATION_CREDENTIALS GOOGLE_CLOUD_PROJECT TEST_PROJECT_NAME
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/octue
 commands =
-    poetry install -E dataflow -E hdf5 -v
+    poetry install --all-extras -v
     poetry run coverage run --source octue -m unittest discover
     poetry run coverage report --show-missing
     poetry run coverage xml


### PR DESCRIPTION
# Summary
Remove confusing warnings about instantiation metadata vs. stored metadata when instantiating datafiles and datasets. Clarify the resolution order when both instantiation metadata and stored metadata are present.

<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#518](https://github.com/octue/octue-sdk-python/pull/518))

**IMPORTANT:** There are 2 breaking changes.

### Fixes
- Remove misleading metadata override warnings from `Datafile` and `Dataset`

### Operations
- Use newer poetry syntax for installing extras

### Refactoring
- 💥 **BREAKING CHANGE:** Rename Datafile `hypothetical` parameter to `ignore_stored_metadata`
- 💥 **BREAKING CHANGE:** Rename Dataset `hypothetical` parameter to `ignore_stored_metadata`

### Operations
- Use latest commit message checker

---
# Upgrade instructions
<details>
<summary>💥 <b>Rename Datafile `hypothetical` parameter</b></summary>

Replace `hypothetical` with `ignore_stored_metadata`.
</details>

<details>
<summary>💥 <b>Rename Dataset `hypothetical` parameter</b></summary>

Replace `hypothetical` with `ignore_stored_metadata`.
</details>

<!--- END AUTOGENERATED NOTES --->