### PR TITLE
Use single topic per workspace

### DIFF
--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -7,7 +7,7 @@ from .runner import Runner
 __all__ = ("Runner",)
 
 
-OCTUE_SERVICES_NAMESPACE = "octue.services"
+DEFAULT_OCTUE_SERVICES_NAMESPACE = "octue.services"
 REPOSITORY_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -7,7 +7,6 @@ from .runner import Runner
 __all__ = ("Runner",)
 
 
-DEFAULT_OCTUE_SERVICES_NAMESPACE = "octue.services"
 REPOSITORY_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 

--- a/octue/__init__.py
+++ b/octue/__init__.py
@@ -6,6 +6,8 @@ from .runner import Runner
 
 __all__ = ("Runner",)
 
+
+OCTUE_SERVICES_NAMESPACE = "octue.services"
 REPOSITORY_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
 

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -10,7 +10,6 @@ import sys
 import click
 from google import auth
 
-from octue import DEFAULT_OCTUE_SERVICES_NAMESPACE
 from octue.cloud import pub_sub, storage
 from octue.cloud.pub_sub.service import Service
 from octue.cloud.service_id import create_sruid, get_sruid_parts
@@ -358,13 +357,6 @@ def deploy():
     help="The service revision tag (e.g. 1.0.7). If this option isn't given, a random 'cool name' tag is generated e.g"
     ". 'curious-capybara'.",
 )
-@click.option(
-    "--services-namespace",
-    is_flag=False,
-    default=DEFAULT_OCTUE_SERVICES_NAMESPACE,
-    show_default=True,
-    help="The services namespace to subscribe to.",
-)
 def create_push_subscription(
     project_name,
     service_namespace,
@@ -372,7 +364,6 @@ def create_push_subscription(
     push_endpoint,
     expiration_time,
     revision_tag,
-    services_namespace,
 ):
     """Create a Google Pub/Sub push subscription for an Octue service for it to receive questions from parents. The
     subscription name is printed on completion.
@@ -394,7 +385,6 @@ def create_push_subscription(
         push_endpoint,
         expiration_time=expiration_time,
         subscription_filter=f'attributes.recipient = "{sruid}" AND attributes.sender_type = "PARENT"',
-        services_namespace=services_namespace,
     )
 
     click.echo(sruid)

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -10,6 +10,7 @@ import sys
 import click
 from google import auth
 
+from octue import DEFAULT_OCTUE_SERVICES_NAMESPACE
 from octue.cloud import pub_sub, storage
 from octue.cloud.pub_sub.service import Service
 from octue.cloud.service_id import create_sruid, get_sruid_parts
@@ -358,21 +359,11 @@ def deploy():
     ". 'curious-capybara'.",
 )
 @click.option(
-    "--filter",
+    "--services-namespace",
     is_flag=False,
-    default='attributes.sender_type = "PARENT"',
+    default=DEFAULT_OCTUE_SERVICES_NAMESPACE,
     show_default=True,
-    help="An optional filter to apply to the subscription (see "
-    "https://cloud.google.com/pubsub/docs/subscription-message-filter). If not provided, the default filter is applied."
-    " To disable filtering, provide an empty string.",
-)
-@click.option(
-    "--subscription-suffix",
-    is_flag=False,
-    default=None,
-    show_default=True,
-    help="An optional suffix to add to the end of the subscription name. This is useful when needing to create "
-    "multiple subscriptions for the same topic (subscription names are unique).",
+    help="The services namespace to emit and consume events from.",
 )
 def create_push_subscription(
     project_name,
@@ -381,11 +372,10 @@ def create_push_subscription(
     push_endpoint,
     expiration_time,
     revision_tag,
-    filter,
-    subscription_suffix,
+    services_namespace,
 ):
-    """Create a Google Pub/Sub push subscription for an Octue service for it to receive questions from parents. If a
-    corresponding topic doesn't exist, it will be created first. The subscription name is printed on completion.
+    """Create a Google Pub/Sub push subscription for an Octue service for it to receive questions from parents. The
+    subscription name is printed on completion.
 
     PROJECT_NAME is the name of the Google Cloud project in which the subscription will be created
 
@@ -403,8 +393,8 @@ def create_push_subscription(
         sruid,
         push_endpoint,
         expiration_time=expiration_time,
-        subscription_filter=filter or None,
-        subscription_suffix=subscription_suffix,
+        subscription_filter=f'attributes.recipient = "{sruid}" AND attributes.sender_type = "PARENT"',
+        services_namespace=services_namespace,
     )
 
     click.echo(sruid)

--- a/octue/cli.py
+++ b/octue/cli.py
@@ -363,7 +363,7 @@ def deploy():
     is_flag=False,
     default=DEFAULT_OCTUE_SERVICES_NAMESPACE,
     show_default=True,
-    help="The services namespace to emit and consume events from.",
+    help="The services namespace to subscribe to.",
 )
 def create_push_subscription(
     project_name,

--- a/octue/cloud/deployment/google/answer_pub_sub_question.py
+++ b/octue/cloud/deployment/google/answer_pub_sub_question.py
@@ -1,8 +1,7 @@
 import logging
 
-from octue.cloud.pub_sub import Topic
 from octue.cloud.pub_sub.service import Service
-from octue.cloud.service_id import convert_service_id_to_pub_sub_form, create_sruid, get_sruid_parts
+from octue.cloud.service_id import create_sruid, get_sruid_parts
 from octue.configuration import load_service_and_app_configuration
 from octue.resources.service_backends import GCPPubSubBackend
 from octue.runner import Runner
@@ -47,9 +46,5 @@ def answer_question(question, project_name):
         logger.info("Analysis successfully run and response sent for question %r.", question_uuid)
 
     except BaseException as error:  # noqa
-        service.send_exception(
-            topic=Topic(name=convert_service_id_to_pub_sub_form(service_sruid), project_name=project_name),
-            question_uuid=question_uuid,
-        )
-
+        service.send_exception(question_uuid=question_uuid, originator="UNKNOWN")
         logger.exception(error)

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -6,7 +6,7 @@ import google.api_core
 
 from octue.cloud.pub_sub import Subscription, Topic
 from octue.cloud.pub_sub.service import ANSWERS_NAMESPACE, PARENT_SENDER_TYPE, Service
-from octue.cloud.service_id import convert_service_id_to_pub_sub_form, split_service_id
+from octue.cloud.service_id import convert_service_id_to_pub_sub_form
 from octue.resources import Manifest
 from octue.utils.dictionaries import make_minimal_dictionary
 from octue.utils.encoders import OctueJSONEncoder
@@ -366,9 +366,6 @@ class MockService(Service):
         if input_manifest is not None:
             question["input_manifest"] = input_manifest.to_primitive()
 
-        originator_namespace, originator_name, originator_revision_tag = split_service_id(self.id)
-        recipient_namespace, recipient_name, recipient_revision_tag = split_service_id(service_id)
-
         try:
             self.children[service_id].answer(
                 MockMessage.from_primitive(
@@ -376,19 +373,13 @@ class MockService(Service):
                     attributes={
                         "question_uuid": question_uuid,
                         "forward_logs": subscribe_to_logs,
-                        "sender_sdk_version": parent_sdk_version,
                         "save_diagnostics": save_diagnostics,
                         "order": 0,
-                        "originator_namespace": originator_namespace,
-                        "originator_name": originator_name,
-                        "originator_revision_tag": originator_revision_tag,
-                        "sender_namespace": originator_namespace,
-                        "sender_name": originator_name,
-                        "sender_revision_tag": originator_revision_tag,
+                        "originator": self.id,
+                        "sender": self.id,
                         "sender_type": PARENT_SENDER_TYPE,
-                        "recipient_namespace": recipient_namespace,
-                        "recipient_name": recipient_name,
-                        "recipient_revision_tag": recipient_revision_tag,
+                        "sender_sdk_version": parent_sdk_version,
+                        "recipient": service_id,
                     },
                 )
             )

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -376,7 +376,7 @@ class MockService(Service):
                     attributes={
                         "question_uuid": question_uuid,
                         "forward_logs": subscribe_to_logs,
-                        "version": parent_sdk_version,
+                        "sender_sdk_version": parent_sdk_version,
                         "save_diagnostics": save_diagnostics,
                         "order": 0,
                         "originator_namespace": originator_namespace,

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -376,7 +376,7 @@ class MockService(Service):
                         "forward_logs": subscribe_to_logs,
                         "version": parent_sdk_version,
                         "save_diagnostics": save_diagnostics,
-                        "message_number": 0,
+                        "ordering_key": 0,
                         "sender": service_id,
                         "originator": service_id,
                     },

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -1,12 +1,12 @@
 import importlib.metadata
 import json
 import logging
+from collections import defaultdict
 
 import google.api_core
 
 from octue.cloud.pub_sub import Subscription, Topic
-from octue.cloud.pub_sub.service import ANSWERS_NAMESPACE, PARENT_SENDER_TYPE, Service
-from octue.cloud.service_id import convert_service_id_to_pub_sub_form
+from octue.cloud.pub_sub.service import PARENT_SENDER_TYPE, Service
 from octue.resources import Manifest
 from octue.utils.dictionaries import make_minimal_dictionary
 from octue.utils.encoders import OctueJSONEncoder
@@ -14,8 +14,9 @@ from octue.utils.encoders import OctueJSONEncoder
 
 logger = logging.getLogger(__name__)
 
-TOPICS = {}
-SUBSCRIPTIONS = {}
+TOPICS = set()
+SUBSCRIPTIONS = set()
+MESSAGES = defaultdict(list)
 
 
 class MockTopic(Topic):
@@ -33,7 +34,7 @@ class MockTopic(Topic):
                 raise google.api_core.exceptions.AlreadyExists(f"Topic {self.path!r} already exists.")
 
         if not self.exists():
-            TOPICS[self.name] = []
+            TOPICS.add(self.name)
             self._created = True
 
     def delete(self):
@@ -42,7 +43,7 @@ class MockTopic(Topic):
         :return None:
         """
         try:
-            del TOPICS[self.name]
+            TOPICS.remove(self.name)
         except KeyError:
             pass
 
@@ -73,7 +74,7 @@ class MockSubscription(Subscription):
                 raise google.api_core.exceptions.AlreadyExists(f"Subscription {self.path!r} already exists.")
 
         if not self.exists():
-            SUBSCRIPTIONS[self.name] = []
+            SUBSCRIPTIONS.add(self.name)
             self._created = True
 
     def delete(self):
@@ -146,8 +147,7 @@ class MockPublisher:
         :param google.api_core.retry.Retry|None retry:
         :return MockFuture:
         """
-        subscription_name = ".".join((get_pub_sub_resource_name(topic), ANSWERS_NAMESPACE, attributes["question_uuid"]))
-        SUBSCRIPTIONS[subscription_name].append(MockMessage(data=data, attributes=attributes))
+        MESSAGES[attributes["question_uuid"]].append(MockMessage(data=data, attributes=attributes))
         return MockFuture()
 
 
@@ -191,12 +191,12 @@ class MockSubscriber:
         if self.closed:
             raise ValueError("ValueError: Cannot invoke RPC: Channel closed!")
 
-        subscription_name = get_pub_sub_resource_name(request["subscription"])
+        question_uuid = request["subscription"].split(".")[-1]
 
         try:
             return MockPullResponse(
                 received_messages=[
-                    MockMessageWrapper(message=SUBSCRIPTIONS[subscription_name].pop(0)),
+                    MockMessageWrapper(message=MESSAGES[question_uuid].pop(0)),
                 ]
             )
 
@@ -356,8 +356,7 @@ class MockService(Service):
 
         # Delete question from messages sent to subscription so the parent doesn't pick it up as a response message. We
         # do this as subscription filtering isn't implemented in this set of mocks.
-        subscription_name = ".".join((convert_service_id_to_pub_sub_form(service_id), ANSWERS_NAMESPACE, question_uuid))
-        SUBSCRIPTIONS["octue.services." + subscription_name].pop(0)
+        MESSAGES[question_uuid].pop(0)
 
         question = make_minimal_dictionary(kind="question", input_values=input_values, children=children)
 

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -6,7 +6,7 @@ import google.api_core
 
 from octue.cloud.pub_sub import Subscription, Topic
 from octue.cloud.pub_sub.service import ANSWERS_NAMESPACE, PARENT_SENDER_TYPE, Service
-from octue.cloud.service_id import convert_service_id_to_pub_sub_form
+from octue.cloud.service_id import convert_service_id_to_pub_sub_form, split_service_id
 from octue.resources import Manifest
 from octue.utils.dictionaries import make_minimal_dictionary
 from octue.utils.encoders import OctueJSONEncoder
@@ -366,19 +366,29 @@ class MockService(Service):
         if input_manifest is not None:
             question["input_manifest"] = input_manifest.to_primitive()
 
+        originator_namespace, originator_name, originator_revision_tag = split_service_id(self.id)
+        recipient_namespace, recipient_name, recipient_revision_tag = split_service_id(service_id)
+
         try:
             self.children[service_id].answer(
                 MockMessage.from_primitive(
                     data=question,
                     attributes={
-                        "sender_type": PARENT_SENDER_TYPE,
                         "question_uuid": question_uuid,
                         "forward_logs": subscribe_to_logs,
                         "version": parent_sdk_version,
                         "save_diagnostics": save_diagnostics,
                         "ordering_key": 0,
-                        "sender": service_id,
-                        "originator": service_id,
+                        "originator_namespace": originator_namespace,
+                        "originator_name": originator_name,
+                        "originator_revision_tag": originator_revision_tag,
+                        "sender_namespace": originator_namespace,
+                        "sender_name": originator_name,
+                        "sender_revision_tag": originator_revision_tag,
+                        "sender_type": PARENT_SENDER_TYPE,
+                        "recipient_namespace": recipient_namespace,
+                        "recipient_name": recipient_name,
+                        "recipient_revision_tag": recipient_revision_tag,
                     },
                 )
             )

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -378,7 +378,7 @@ class MockService(Service):
                         "forward_logs": subscribe_to_logs,
                         "version": parent_sdk_version,
                         "save_diagnostics": save_diagnostics,
-                        "ordering_key": 0,
+                        "order": 0,
                         "originator_namespace": originator_namespace,
                         "originator_name": originator_name,
                         "originator_revision_tag": originator_revision_tag,

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -242,6 +242,13 @@ class MockMessageWrapper:
         self.message = message
         self.ack_id = None
 
+    def __repr__(self):
+        """Represent the mock message as a string.
+
+        :return str:
+        """
+        return f"<{type(self).__name__}(message={self.message})>"
+
 
 class MockMessage:
     """A mock Pub/Sub message containing serialised data and any number of attributes.

--- a/octue/cloud/emulators/_pub_sub.py
+++ b/octue/cloud/emulators/_pub_sub.py
@@ -378,6 +378,7 @@ class MockService(Service):
                         "save_diagnostics": save_diagnostics,
                         "message_number": 0,
                         "sender": service_id,
+                        "originator": service_id,
                     },
                 )
             )

--- a/octue/cloud/events/__init__.py
+++ b/octue/cloud/events/__init__.py
@@ -1,0 +1,1 @@
+OCTUE_SERVICES_PREFIX = "octue.services"

--- a/octue/cloud/events/counter.py
+++ b/octue/cloud/events/counter.py
@@ -1,0 +1,35 @@
+class EventCounter:
+    """A mutable counter for keeping track of the emission order of events. This is used in the `Service` class instead
+    of an integer because it is mutable and can be passed to the `Service._send_message` method and incremented as
+    events are emitted.
+
+    :return None:
+    """
+
+    def __init__(self):
+        self.count = 0
+
+    def __iadd__(self, other):
+        """Increment the counter by an integer.
+
+        :return octue.cloud.events.counter.EventCounter: the event counter with its count updated
+        """
+        if not isinstance(other, int):
+            raise ValueError(f"Event counters can only be incremented by an integer; received {other!r}.")
+
+        self.count += other
+        return self
+
+    def __int__(self):
+        """Get the counter as an integer.
+
+        :return int: the counter as an integer
+        """
+        return int(self.count)
+
+    def __repr__(self):
+        """Represent the counter as a string.
+
+        :return str: the counter represented as a string.
+        """
+        return f"<{type(self).__name__}(count={self.count})"

--- a/octue/cloud/events/counter.py
+++ b/octue/cloud/events/counter.py
@@ -1,6 +1,6 @@
 class EventCounter:
     """A mutable counter for keeping track of the emission order of events. This is used in the `Service` class instead
-    of an integer because it is mutable and can be passed to the `Service._send_message` method and incremented as
+    of an integer because it is mutable and can be passed to the `Service._emit_event` method and incremented as
     events are emitted.
 
     :return None:

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -138,17 +138,17 @@ class AbstractEventHandler:
             self.child_sruid = attributes.get("sender", "REMOTE")
 
         logger.debug("%r received an event related to question %r.", self.receiving_service, self.question_uuid)
-        event_number = attributes["message_number"]
+        ordering_key = attributes["ordering_key"]
 
-        if event_number in self.waiting_events:
+        if ordering_key in self.waiting_events:
             logger.warning(
-                "%r: Event with duplicate event number %d received for question %s - overwriting original event.",
+                "%r: Event with duplicate ordering key %d received for question %s - overwriting original event.",
                 self.receiving_service,
-                event_number,
+                ordering_key,
                 self.question_uuid,
             )
 
-        self.waiting_events[event_number] = event
+        self.waiting_events[ordering_key] = event
 
     def _attempt_to_handle_waiting_events(self):
         """Attempt to handle events waiting in `self.waiting_events`. If these events aren't consecutive to the

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -125,7 +125,7 @@ class AbstractEventHandler:
             attributes=attributes,
             receiving_service=self.receiving_service,
             parent_sdk_version=PARENT_SDK_VERSION,
-            child_sdk_version=attributes.get("version"),
+            child_sdk_version=attributes["sender_sdk_version"],
             schema=self.schema,
         ):
             return
@@ -139,7 +139,7 @@ class AbstractEventHandler:
             )
 
             self.question_uuid = attributes.get("question_uuid")
-            self._child_sdk_version = attributes["version"]
+            self._child_sdk_version = attributes["sender_sdk_version"]
 
         logger.debug("%r received an event related to question %r.", self.receiving_service, self.question_uuid)
         order = attributes["order"]

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -138,7 +138,7 @@ class AbstractEventHandler:
                 revision_tag=attributes["sender_revision_tag"],
             )
 
-            self.question_uuid = attributes.get("question_uuid")
+            self.question_uuid = attributes["question_uuid"]
             self._child_sdk_version = attributes["sender_sdk_version"]
 
         logger.debug("%r received an event related to question %r.", self.receiving_service, self.question_uuid)

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -31,7 +31,7 @@ class AbstractEventHandler:
     """An abstract event handler. Inherit from this and add the `handle_events` and `_extract_event_and_attributes`
     methods to handle events from a specific source synchronously or asynchronously.
 
-    :param octue.cloud.pub_sub.service.Service receiving_service: the service that's receiving the events
+    :param octue.cloud.pub_sub.service.Service recipient: the service that's receiving the events
     :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive
     :param bool record_events: if `True`, record received events in the `received_events` attribute
     :param dict|None event_handlers: a mapping of event type names to callables that handle each type of event. The handlers should not mutate the events.
@@ -43,7 +43,7 @@ class AbstractEventHandler:
 
     def __init__(
         self,
-        receiving_service,
+        recipient,
         handle_monitor_message=None,
         record_events=True,
         event_handlers=None,
@@ -51,7 +51,7 @@ class AbstractEventHandler:
         skip_missing_events_after=10,
         only_handle_result=False,
     ):
-        self.receiving_service = receiving_service
+        self.recipient = recipient
         self.handle_monitor_message = handle_monitor_message
         self.record_events = record_events
         self.schema = schema
@@ -122,7 +122,7 @@ class AbstractEventHandler:
         if not is_event_valid(
             event=event,
             attributes=attributes,
-            receiving_service=self.receiving_service,
+            recipient=self.recipient,
             parent_sdk_version=PARENT_SDK_VERSION,
             child_sdk_version=attributes["sender_sdk_version"],
             schema=self.schema,
@@ -135,13 +135,13 @@ class AbstractEventHandler:
             self.question_uuid = attributes["question_uuid"]
             self._child_sdk_version = attributes["sender_sdk_version"]
 
-        logger.debug("%r received an event related to question %r.", self.receiving_service, self.question_uuid)
+        logger.debug("%r received an event related to question %r.", self.recipient, self.question_uuid)
         order = attributes["order"]
 
         if order in self.waiting_events:
             logger.warning(
                 "%r: Event with duplicate order %d received for question %s - overwriting original event.",
-                self.receiving_service,
+                self.recipient,
                 order,
                 self.question_uuid,
             )
@@ -202,7 +202,7 @@ class AbstractEventHandler:
         logger.warning(
             "%r: %d consecutive events missing for question %r after %ds - skipping to next earliest waiting event "
             "(event %d).",
-            self.receiving_service,
+            self.recipient,
             number_of_missing_events,
             self.question_uuid,
             self.skip_missing_events_after,
@@ -234,7 +234,7 @@ class AbstractEventHandler:
         :param dict event:
         :return None:
         """
-        logger.info("%r's question was delivered at %s.", self.receiving_service, event["datetime"])
+        logger.info("%r's question was delivered at %s.", self.recipient, event["datetime"])
 
     def _handle_heartbeat(self, event):
         """Record the time the heartbeat was received.
@@ -251,7 +251,7 @@ class AbstractEventHandler:
         :param dict event:
         :return None:
         """
-        logger.debug("%r received a monitor message.", self.receiving_service)
+        logger.debug("%r received a monitor message.", self.recipient)
 
         if self.handle_monitor_message is not None:
             self.handle_monitor_message(event["data"])
@@ -315,7 +315,7 @@ class AbstractEventHandler:
         :param dict event:
         :return dict:
         """
-        logger.info("%r received an answer to question %r.", self.receiving_service, self.question_uuid)
+        logger.info("%r received an answer to question %r.", self.recipient, self.question_uuid)
 
         if event.get("output_manifest"):
             output_manifest = Manifest.deserialise(event["output_manifest"])

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -142,17 +142,17 @@ class AbstractEventHandler:
             self._child_sdk_version = attributes["version"]
 
         logger.debug("%r received an event related to question %r.", self.receiving_service, self.question_uuid)
-        ordering_key = attributes["ordering_key"]
+        order = attributes["order"]
 
-        if ordering_key in self.waiting_events:
+        if order in self.waiting_events:
             logger.warning(
-                "%r: Event with duplicate ordering key %d received for question %s - overwriting original event.",
+                "%r: Event with duplicate order %d received for question %s - overwriting original event.",
                 self.receiving_service,
-                ordering_key,
+                order,
                 self.question_uuid,
             )
 
-        self.waiting_events[ordering_key] = event
+        self.waiting_events[order] = event
 
     def _attempt_to_handle_waiting_events(self):
         """Attempt to handle events waiting in `self.waiting_events`. If these events aren't consecutive to the

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from octue.cloud import EXCEPTIONS_MAPPING
 from octue.cloud.events.validation import SERVICE_COMMUNICATION_SCHEMA, is_event_valid
+from octue.cloud.service_id import create_sruid
 from octue.definitions import GOOGLE_COMPUTE_PROVIDERS
 from octue.log_handlers import COLOUR_PALETTE
 from octue.resources.manifest import Manifest
@@ -131,11 +132,14 @@ class AbstractEventHandler:
 
         # Get the child's SRUID and Octue SDK version from the first event.
         if not self._child_sdk_version:
+            self.child_sruid = create_sruid(
+                namespace=attributes["sender_namespace"],
+                name=attributes["sender_name"],
+                revision_tag=attributes["sender_revision_tag"],
+            )
+
             self.question_uuid = attributes.get("question_uuid")
             self._child_sdk_version = attributes["version"]
-
-            # Backwards-compatible with previous event schema versions.
-            self.child_sruid = attributes.get("sender", "REMOTE")
 
         logger.debug("%r received an event related to question %r.", self.receiving_service, self.question_uuid)
         ordering_key = attributes["ordering_key"]

--- a/octue/cloud/events/handler.py
+++ b/octue/cloud/events/handler.py
@@ -9,7 +9,6 @@ from datetime import datetime
 
 from octue.cloud import EXCEPTIONS_MAPPING
 from octue.cloud.events.validation import SERVICE_COMMUNICATION_SCHEMA, is_event_valid
-from octue.cloud.service_id import create_sruid
 from octue.definitions import GOOGLE_COMPUTE_PROVIDERS
 from octue.log_handlers import COLOUR_PALETTE
 from octue.resources.manifest import Manifest
@@ -132,12 +131,7 @@ class AbstractEventHandler:
 
         # Get the child's SRUID and Octue SDK version from the first event.
         if not self._child_sdk_version:
-            self.child_sruid = create_sruid(
-                namespace=attributes["sender_namespace"],
-                name=attributes["sender_name"],
-                revision_tag=attributes["sender_revision_tag"],
-            )
-
+            self.child_sruid = attributes["sender"]
             self.question_uuid = attributes["question_uuid"]
             self._child_sdk_version = attributes["sender_sdk_version"]
 

--- a/octue/cloud/events/replayer.py
+++ b/octue/cloud/events/replayer.py
@@ -60,5 +60,5 @@ class EventReplayer(AbstractEventHandler):
         :param dict container: the container of the event
         :return (any, dict): the event and its attributes
         """
-        container["attributes"]["message_number"] = int(container["attributes"]["message_number"])
+        container["attributes"]["ordering_key"] = int(container["attributes"]["ordering_key"])
         return container["event"], container["attributes"]

--- a/octue/cloud/events/replayer.py
+++ b/octue/cloud/events/replayer.py
@@ -60,5 +60,5 @@ class EventReplayer(AbstractEventHandler):
         :param dict container: the container of the event
         :return (any, dict): the event and its attributes
         """
-        container["attributes"]["ordering_key"] = int(container["attributes"]["ordering_key"])
+        container["attributes"]["order"] = int(container["attributes"]["order"])
         return container["event"], container["attributes"]

--- a/octue/cloud/events/replayer.py
+++ b/octue/cloud/events/replayer.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class EventReplayer(AbstractEventHandler):
     """A replayer for events retrieved asynchronously from some kind of storage.
 
-    :param octue.cloud.pub_sub.service.Service receiving_service: the service that's receiving the events
+    :param octue.cloud.pub_sub.service.Service recipient: the service that's receiving the events
     :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive
     :param bool record_events: if `True`, record received events in the `received_events` attribute
     :param dict|None event_handlers: a mapping of event type names to callables that handle each type of event. The handlers should not mutate the events.
@@ -23,7 +23,7 @@ class EventReplayer(AbstractEventHandler):
 
     def __init__(
         self,
-        receiving_service=None,
+        recipient=None,
         handle_monitor_message=None,
         record_events=True,
         event_handlers=None,
@@ -31,7 +31,7 @@ class EventReplayer(AbstractEventHandler):
         only_handle_result=False,
     ):
         super().__init__(
-            receiving_service or Service(backend=ServiceBackend(), service_id="local/local:local"),
+            recipient or Service(backend=ServiceBackend(), service_id="local/local:local"),
             handle_monitor_message=handle_monitor_message,
             record_events=record_events,
             event_handlers=event_handlers,

--- a/octue/cloud/events/replayer.py
+++ b/octue/cloud/events/replayer.py
@@ -51,8 +51,10 @@ class EventReplayer(AbstractEventHandler):
         for event in events:
             self._extract_and_enqueue_event(event)
 
-        self._earliest_waiting_event_number = min(self.waiting_events.keys())
-        return self._attempt_to_handle_waiting_events()
+        # Handle the case where no events (or no valid events) have been received.
+        if self.waiting_events:
+            self._earliest_waiting_event_number = min(self.waiting_events.keys())
+            return self._attempt_to_handle_waiting_events()
 
     def _extract_event_and_attributes(self, container):
         """Extract an event and its attributes from the event container.

--- a/octue/cloud/events/validation.py
+++ b/octue/cloud/events/validation.py
@@ -8,7 +8,7 @@ from octue.compatibility import warn_if_incompatible
 
 logger = logging.getLogger(__name__)
 
-SERVICE_COMMUNICATION_SCHEMA = {"$ref": "https://jsonschema.registry.octue.com/octue/service-communication/0.8.3.json"}
+SERVICE_COMMUNICATION_SCHEMA = {"$ref": "https://jsonschema.registry.octue.com/octue/service-communication/0.9.0.json"}
 SERVICE_COMMUNICATION_SCHEMA_INFO_URL = "https://strands.octue.com/octue/service-communication"
 SERVICE_COMMUNICATION_SCHEMA_VERSION = os.path.splitext(SERVICE_COMMUNICATION_SCHEMA["$ref"])[0].split("/")[-1]
 

--- a/octue/cloud/events/validation.py
+++ b/octue/cloud/events/validation.py
@@ -18,12 +18,12 @@ jsonschema.Draft202012Validator.check_schema(SERVICE_COMMUNICATION_SCHEMA)
 jsonschema_validator = jsonschema.Draft202012Validator(SERVICE_COMMUNICATION_SCHEMA)
 
 
-def is_event_valid(event, attributes, receiving_service, parent_sdk_version, child_sdk_version, schema=None):
+def is_event_valid(event, attributes, recipient, parent_sdk_version, child_sdk_version, schema=None):
     """Check if the event and its attributes are valid according to the Octue services communication schema.
 
     :param dict event: the event to validate
     :param dict attributes: the attributes of the event to validate
-    :param octue.cloud.pub_sub.service.Service receiving_service: the service receiving and validating the event
+    :param octue.cloud.pub_sub.service.Service recipient: the service receiving and validating the event
     :param str parent_sdk_version: the semantic version of Octue SDK running on the parent
     :param str child_sdk_version: the semantic version of Octue SDK running on the child
     :param dict|None schema: the schema to validate the event and its attributes against; if `None`, this defaults to the service communication schema used in this version of Octue SDK
@@ -33,7 +33,7 @@ def is_event_valid(event, attributes, receiving_service, parent_sdk_version, chi
         raise_if_event_is_invalid(
             event,
             attributes,
-            receiving_service,
+            recipient,
             parent_sdk_version,
             child_sdk_version,
             schema=schema,
@@ -44,19 +44,12 @@ def is_event_valid(event, attributes, receiving_service, parent_sdk_version, chi
     return True
 
 
-def raise_if_event_is_invalid(
-    event,
-    attributes,
-    receiving_service,
-    parent_sdk_version,
-    child_sdk_version,
-    schema=None,
-):
+def raise_if_event_is_invalid(event, attributes, recipient, parent_sdk_version, child_sdk_version, schema=None):
     """Raise an error if the event or its attributes aren't valid according to the Octue services communication schema.
 
     :param dict event: the event to validate
     :param dict attributes: the attributes of the event to validate
-    :param octue.cloud.pub_sub.service.Service receiving_service: the service receiving and validating the event
+    :param octue.cloud.pub_sub.service.Service recipient: the service receiving and validating the event
     :param str parent_sdk_version: the semantic version of Octue SDK running on the parent
     :param str child_sdk_version: the semantic version of Octue SDK running on the child
     :param dict|None schema: the schema to validate the event and its attributes against; if `None`, this defaults to the service communication schema used in this version of Octue SDK
@@ -82,7 +75,7 @@ def raise_if_event_is_invalid(
 
         logger.exception(
             "%r received an event that doesn't conform with version %s of the service communication schema (%s): %r.",
-            receiving_service,
+            recipient,
             SERVICE_COMMUNICATION_SCHEMA_VERSION,
             SERVICE_COMMUNICATION_SCHEMA_INFO_URL,
             event,

--- a/octue/cloud/pub_sub/__init__.py
+++ b/octue/cloud/pub_sub/__init__.py
@@ -13,7 +13,7 @@ def create_push_subscription(
     push_endpoint,
     subscription_filter=None,
     expiration_time=None,
-    subscription_suffix=None,
+    services_namespace="octue.services",
 ):
     """Create a Google Pub/Sub push subscription for an Octue service for it to receive questions from parents. If a
     corresponding topic doesn't exist, it will be created first.
@@ -23,28 +23,17 @@ def create_push_subscription(
     :param str push_endpoint: the HTTP/HTTPS endpoint of the service to push to. It should be fully formed and include the 'https://' prefix
     :param str|None subscription_filter: if specified, the filter to apply to the subscription; otherwise, no filter is applied
     :param float|None expiration_time: the number of seconds of inactivity after which the subscription should expire. If not provided, no expiration time is applied to the subscription
-    :param str|None subscription_suffix: if provided, add a suffix to the end of the subscription name. This is useful when needing to create multiple subscriptions for the same topic (subscription names are unique).
+    :param str services_namespace: the services namespace to emit and consume events from
     :return None:
     """
-    topic_name = convert_service_id_to_pub_sub_form(sruid)
-
-    if subscription_suffix:
-        subscription_name = topic_name + subscription_suffix
-    else:
-        subscription_name = topic_name
-
-    topic = Topic(name=topic_name, project_name=project_name)
-    topic.create(allow_existing=True)
-
     if expiration_time:
         expiration_time = float(expiration_time)
     else:
         expiration_time = None
 
     subscription = Subscription(
-        name=subscription_name,
-        topic=topic,
-        project_name=project_name,
+        name=convert_service_id_to_pub_sub_form(sruid),
+        topic=Topic(name=services_namespace, project_name=project_name),
         filter=subscription_filter,
         expiration_time=expiration_time,
         push_endpoint=push_endpoint,

--- a/octue/cloud/pub_sub/__init__.py
+++ b/octue/cloud/pub_sub/__init__.py
@@ -23,7 +23,7 @@ def create_push_subscription(
     :param str push_endpoint: the HTTP/HTTPS endpoint of the service to push to. It should be fully formed and include the 'https://' prefix
     :param str|None subscription_filter: if specified, the filter to apply to the subscription; otherwise, no filter is applied
     :param float|None expiration_time: the number of seconds of inactivity after which the subscription should expire. If not provided, no expiration time is applied to the subscription
-    :param str services_namespace: the services namespace to emit and consume events from
+    :param str services_namespace: the services namespace to subscribe to
     :return None:
     """
     if expiration_time:

--- a/octue/cloud/pub_sub/__init__.py
+++ b/octue/cloud/pub_sub/__init__.py
@@ -1,3 +1,4 @@
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.cloud.service_id import convert_service_id_to_pub_sub_form
 
 from .subscription import Subscription
@@ -13,7 +14,6 @@ def create_push_subscription(
     push_endpoint,
     subscription_filter=None,
     expiration_time=None,
-    services_namespace="octue.services",
 ):
     """Create a Google Pub/Sub push subscription for an Octue service for it to receive questions from parents. If a
     corresponding topic doesn't exist, it will be created first.
@@ -23,7 +23,6 @@ def create_push_subscription(
     :param str push_endpoint: the HTTP/HTTPS endpoint of the service to push to. It should be fully formed and include the 'https://' prefix
     :param str|None subscription_filter: if specified, the filter to apply to the subscription; otherwise, no filter is applied
     :param float|None expiration_time: the number of seconds of inactivity after which the subscription should expire. If not provided, no expiration time is applied to the subscription
-    :param str services_namespace: the services namespace to subscribe to
     :return None:
     """
     if expiration_time:
@@ -33,7 +32,7 @@ def create_push_subscription(
 
     subscription = Subscription(
         name=convert_service_id_to_pub_sub_form(sruid),
-        topic=Topic(name=services_namespace, project_name=project_name),
+        topic=Topic(name=OCTUE_SERVICES_PREFIX, project_name=project_name),
         filter=subscription_filter,
         expiration_time=expiration_time,
         push_endpoint=push_endpoint,

--- a/octue/cloud/pub_sub/bigquery.py
+++ b/octue/cloud/pub_sub/bigquery.py
@@ -58,7 +58,7 @@ def get_events(table_id, question_uuid, kind=None, limit=1000, include_pub_sub_m
     if isinstance(messages.at[0, "attributes"], str):
         messages["attributes"] = messages["attributes"].map(json.loads)
 
-    # Order messages by the ordering key.
-    messages = messages.iloc[messages["attributes"].str.get("ordering_key").astype(str).argsort()]
+    # Order messages.
+    messages = messages.iloc[messages["attributes"].str.get("order").astype(str).argsort()]
     messages.rename(columns={"data": "event"}, inplace=True)
     return messages.to_dict(orient="records")

--- a/octue/cloud/pub_sub/bigquery.py
+++ b/octue/cloud/pub_sub/bigquery.py
@@ -58,7 +58,7 @@ def get_events(table_id, question_uuid, kind=None, limit=1000, include_pub_sub_m
     if isinstance(messages.at[0, "attributes"], str):
         messages["attributes"] = messages["attributes"].map(json.loads)
 
-    # Order messages by the message number.
-    messages = messages.iloc[messages["attributes"].str.get("message_number").astype(str).argsort()]
+    # Order messages by the ordering key.
+    messages = messages.iloc[messages["attributes"].str.get("ordering_key").astype(str).argsort()]
     messages.rename(columns={"data": "event"}, inplace=True)
     return messages.to_dict(orient="records")

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -31,6 +31,7 @@ def extract_event_and_attributes_from_pub_sub_message(message):
     # Cast attributes to a dictionary to avoid defaultdict-like behaviour from Pub/Sub message attributes container.
     attributes = dict(getattr_or_subscribe(message, "attributes"))
 
+    # Required for all events.
     converted_attributes = {
         "sender_type": attributes["sender_type"],
         "question_uuid": attributes["question_uuid"],
@@ -40,11 +41,14 @@ def extract_event_and_attributes_from_pub_sub_message(message):
         "originator": attributes["originator"],
     }
 
-    if "forward_logs" in attributes:
-        converted_attributes["forward_logs"] = bool(int(attributes["forward_logs"]))
-
-    if "save_diagnostics" in attributes:
-        converted_attributes["save_diagnostics"] = attributes["save_diagnostics"]
+    # Required for question events.
+    if attributes["sender_type"] == "PARENT":
+        converted_attributes.update(
+            {
+                "forward_logs": bool(int(attributes["forward_logs"])),
+                "save_diagnostics": attributes["save_diagnostics"],
+            }
+        )
 
     try:
         # Parse event directly from Pub/Sub or Dataflow.

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -37,6 +37,7 @@ def extract_event_and_attributes_from_pub_sub_message(message):
         "message_number": int(attributes["message_number"]),
         "version": attributes["version"],
         "sender": attributes.get("sender", "REMOTE"),  # Backwards-compatible with previous event schema versions.
+        "originator": attributes["originator"],
     }
 
     if "forward_logs" in attributes:

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -35,7 +35,7 @@ def extract_event_and_attributes_from_pub_sub_message(message):
     converted_attributes = {
         "question_uuid": attributes["question_uuid"],
         "order": int(attributes["order"]),
-        "version": attributes["version"],
+        "sender_sdk_version": attributes["sender_sdk_version"],
         "originator_namespace": attributes["originator_namespace"],
         "originator_name": attributes["originator_name"],
         "originator_revision_tag": attributes["originator_revision_tag"],

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -35,7 +35,7 @@ def extract_event_and_attributes_from_pub_sub_message(message):
     converted_attributes = {
         "sender_type": attributes["sender_type"],
         "question_uuid": attributes["question_uuid"],
-        "message_number": int(attributes["message_number"]),
+        "ordering_key": int(attributes["ordering_key"]),
         "version": attributes["version"],
         "sender": attributes.get("sender", "REMOTE"),  # Backwards-compatible with previous event schema versions.
         "originator": attributes["originator"],

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -35,17 +35,11 @@ def extract_event_and_attributes_from_pub_sub_message(message):
     converted_attributes = {
         "question_uuid": attributes["question_uuid"],
         "order": int(attributes["order"]),
-        "sender_sdk_version": attributes["sender_sdk_version"],
-        "originator_namespace": attributes["originator_namespace"],
-        "originator_name": attributes["originator_name"],
-        "originator_revision_tag": attributes["originator_revision_tag"],
-        "sender_namespace": attributes["sender_namespace"],
-        "sender_name": attributes["sender_name"],
-        "sender_revision_tag": attributes["sender_revision_tag"],
+        "originator": attributes["originator"],
+        "sender": attributes["sender"],
         "sender_type": attributes["sender_type"],
-        "recipient_namespace": attributes["recipient_namespace"],
-        "recipient_name": attributes["recipient_name"],
-        "recipient_revision_tag": attributes["recipient_revision_tag"],
+        "sender_sdk_version": attributes["sender_sdk_version"],
+        "recipient": attributes["recipient"],
     }
 
     # Required for question events.

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -65,7 +65,7 @@ class GoogleCloudPubSubEventHandler(AbstractEventHandler):
     """A synchronous handler for events received as Google Pub/Sub messages from a pull subscription.
 
     :param octue.cloud.pub_sub.subscription.Subscription subscription: the subscription messages are pulled from
-    :param octue.cloud.pub_sub.service.Service receiving_service: the service that's receiving the events
+    :param octue.cloud.pub_sub.service.Service recipient: the service that's receiving the events
     :param callable|None handle_monitor_message: a function to handle monitor messages (e.g. send them to an endpoint for plotting or displaying) - this function should take a single JSON-compatible python primitive
     :param bool record_events: if `True`, record received events in the `received_events` attribute
     :param dict|None event_handlers: a mapping of event type names to callables that handle each type of event. The handlers should not mutate the events.
@@ -77,7 +77,7 @@ class GoogleCloudPubSubEventHandler(AbstractEventHandler):
     def __init__(
         self,
         subscription,
-        receiving_service,
+        recipient,
         handle_monitor_message=None,
         record_events=True,
         event_handlers=None,
@@ -87,7 +87,7 @@ class GoogleCloudPubSubEventHandler(AbstractEventHandler):
         self.subscription = subscription
 
         super().__init__(
-            receiving_service,
+            recipient,
             handle_monitor_message=handle_monitor_message,
             record_events=record_events,
             event_handlers=event_handlers,

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -34,7 +34,7 @@ def extract_event_and_attributes_from_pub_sub_message(message):
     # Required for all events.
     converted_attributes = {
         "question_uuid": attributes["question_uuid"],
-        "ordering_key": int(attributes["ordering_key"]),
+        "order": int(attributes["order"]),
         "version": attributes["version"],
         "originator_namespace": attributes["originator_namespace"],
         "originator_name": attributes["originator_name"],

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -245,7 +245,8 @@ class GoogleCloudPubSubEventHandler(AbstractEventHandler):
         for event in pull_response.received_messages:
             self._extract_and_enqueue_event(event)
 
-        self._earliest_waiting_event_number = min(self.waiting_events.keys())
+        if self.waiting_events:
+            self._earliest_waiting_event_number = min(self.waiting_events.keys())
 
     def _extract_event_and_attributes(self, container):
         """Extract an event and its attributes from the Pub/Sub message.

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -33,12 +33,19 @@ def extract_event_and_attributes_from_pub_sub_message(message):
 
     # Required for all events.
     converted_attributes = {
-        "sender_type": attributes["sender_type"],
         "question_uuid": attributes["question_uuid"],
         "ordering_key": int(attributes["ordering_key"]),
         "version": attributes["version"],
-        "sender": attributes.get("sender", "REMOTE"),  # Backwards-compatible with previous event schema versions.
-        "originator": attributes["originator"],
+        "originator_namespace": attributes["originator_namespace"],
+        "originator_name": attributes["originator_name"],
+        "originator_revision_tag": attributes["originator_revision_tag"],
+        "sender_namespace": attributes["sender_namespace"],
+        "sender_name": attributes["sender_name"],
+        "sender_revision_tag": attributes["sender_revision_tag"],
+        "sender_type": attributes["sender_type"],
+        "recipient_namespace": attributes["recipient_namespace"],
+        "recipient_name": attributes["recipient_name"],
+        "recipient_revision_tag": attributes["recipient_revision_tag"],
     }
 
     # Required for question events.

--- a/octue/cloud/pub_sub/events.py
+++ b/octue/cloud/pub_sub/events.py
@@ -252,6 +252,7 @@ class GoogleCloudPubSubEventHandler(AbstractEventHandler):
         for event in pull_response.received_messages:
             self._extract_and_enqueue_event(event)
 
+        # Handle the case where no events (or no valid events) have been received.
         if self.waiting_events:
             self._earliest_waiting_event_number = min(self.waiting_events.keys())
 

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -12,15 +12,17 @@ class GoogleCloudPubSubHandler(logging.Handler):
     :param octue.cloud.pub_sub.topic.Topic topic: topic to publish log records to
     :param str question_uuid: the UUID of the question to handle log records for
     :param str originator: the SRUID of the service that asked the question these log records are related to
+    :param str recipient: the SRUID of the service to send these log records to
     :param float timeout: timeout in seconds for attempting to publish each log record
     :return None:
     """
 
-    def __init__(self, message_sender, topic, question_uuid, originator, timeout=60, *args, **kwargs):
+    def __init__(self, message_sender, topic, question_uuid, originator, recipient, timeout=60, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.topic = topic
         self.question_uuid = question_uuid
         self.originator = originator
+        self.recipient = recipient
         self.timeout = timeout
         self._send_message = message_sender
 
@@ -38,6 +40,7 @@ class GoogleCloudPubSubHandler(logging.Handler):
                 },
                 topic=self.topic,
                 originator=self.originator,
+                recipient=self.recipient,
                 attributes={
                     "question_uuid": self.question_uuid,
                     "sender_type": "CHILD",  # The sender type is repeated here as a string to avoid a circular import.

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -11,6 +11,7 @@ class GoogleCloudPubSubHandler(logging.Handler):
     :param callable message_sender: the `_send_message` method of the service that instantiated this instance
     :param octue.cloud.pub_sub.topic.Topic topic: topic to publish log records to
     :param str question_uuid: the UUID of the question to handle log records for
+    :param str originator: the SRUID of the service that asked the question these log records are related to
     :param float timeout: timeout in seconds for attempting to publish each log record
     :return None:
     """
@@ -36,10 +37,10 @@ class GoogleCloudPubSubHandler(logging.Handler):
                     "log_record": self._convert_log_record_to_primitives(record),
                 },
                 topic=self.topic,
+                originator=self.originator,
                 attributes={
                     "question_uuid": self.question_uuid,
                     "sender_type": "CHILD",  # The sender type is repeated here as a string to avoid a circular import.
-                    "originator": self.originator,
                 },
             )
 

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -8,7 +8,7 @@ ANSI_ESCAPE_SEQUENCES_PATTERN = r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])"
 class GoogleCloudPubSubHandler(logging.Handler):
     """A log handler that publishes log records to a Google Cloud Pub/Sub topic.
 
-    :param callable message_sender: the `_send_message` method of the service that instantiated this instance
+    :param callable event_emitter: the `_emit_event` method of the service that instantiated this instance
     :param str question_uuid: the UUID of the question to handle log records for
     :param str originator: the SRUID of the service that asked the question these log records are related to
     :param str recipient: the SRUID of the service to send these log records to
@@ -17,14 +17,14 @@ class GoogleCloudPubSubHandler(logging.Handler):
     :return None:
     """
 
-    def __init__(self, message_sender, question_uuid, originator, recipient, order, timeout=60, *args, **kwargs):
+    def __init__(self, event_emitter, question_uuid, originator, recipient, order, timeout=60, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.question_uuid = question_uuid
         self.originator = originator
         self.recipient = recipient
         self.order = order
         self.timeout = timeout
-        self._send_message = message_sender
+        self._emit_event = event_emitter
 
     def emit(self, record):
         """Serialise the log record as a dictionary and publish it to the topic.
@@ -33,7 +33,7 @@ class GoogleCloudPubSubHandler(logging.Handler):
         :return None:
         """
         try:
-            self._send_message(
+            self._emit_event(
                 {
                     "kind": "log_record",
                     "log_record": self._convert_log_record_to_primitives(record),

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -9,7 +9,6 @@ class GoogleCloudPubSubHandler(logging.Handler):
     """A log handler that publishes log records to a Google Cloud Pub/Sub topic.
 
     :param callable message_sender: the `_send_message` method of the service that instantiated this instance
-    :param octue.cloud.pub_sub.topic.Topic topic: topic to publish log records to
     :param str question_uuid: the UUID of the question to handle log records for
     :param str originator: the SRUID of the service that asked the question these log records are related to
     :param str recipient: the SRUID of the service to send these log records to
@@ -17,9 +16,8 @@ class GoogleCloudPubSubHandler(logging.Handler):
     :return None:
     """
 
-    def __init__(self, message_sender, topic, question_uuid, originator, recipient, timeout=60, *args, **kwargs):
+    def __init__(self, message_sender, question_uuid, originator, recipient, timeout=60, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.topic = topic
         self.question_uuid = question_uuid
         self.originator = originator
         self.recipient = recipient
@@ -38,7 +36,6 @@ class GoogleCloudPubSubHandler(logging.Handler):
                     "kind": "log_record",
                     "log_record": self._convert_log_record_to_primitives(record),
                 },
-                topic=self.topic,
                 originator=self.originator,
                 recipient=self.recipient,
                 attributes={

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -15,10 +15,11 @@ class GoogleCloudPubSubHandler(logging.Handler):
     :return None:
     """
 
-    def __init__(self, message_sender, topic, question_uuid, timeout=60, *args, **kwargs):
+    def __init__(self, message_sender, topic, question_uuid, originator, timeout=60, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.topic = topic
         self.question_uuid = question_uuid
+        self.originator = originator
         self.timeout = timeout
         self._send_message = message_sender
 
@@ -38,6 +39,7 @@ class GoogleCloudPubSubHandler(logging.Handler):
                 attributes={
                     "question_uuid": self.question_uuid,
                     "sender_type": "CHILD",  # The sender type is repeated here as a string to avoid a circular import.
+                    "originator": self.originator,
                 },
             )
 

--- a/octue/cloud/pub_sub/logging.py
+++ b/octue/cloud/pub_sub/logging.py
@@ -12,15 +12,17 @@ class GoogleCloudPubSubHandler(logging.Handler):
     :param str question_uuid: the UUID of the question to handle log records for
     :param str originator: the SRUID of the service that asked the question these log records are related to
     :param str recipient: the SRUID of the service to send these log records to
+    :param octue.cloud.events.counter.EventCounter order: an event counter keeping track of the order of emitted events
     :param float timeout: timeout in seconds for attempting to publish each log record
     :return None:
     """
 
-    def __init__(self, message_sender, question_uuid, originator, recipient, timeout=60, *args, **kwargs):
+    def __init__(self, message_sender, question_uuid, originator, recipient, order, timeout=60, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.question_uuid = question_uuid
         self.originator = originator
         self.recipient = recipient
+        self.order = order
         self.timeout = timeout
         self._send_message = message_sender
 
@@ -38,6 +40,7 @@ class GoogleCloudPubSubHandler(logging.Handler):
                 },
                 originator=self.originator,
                 recipient=self.recipient,
+                order=self.order,
                 attributes={
                     "question_uuid": self.question_uuid,
                     "sender_type": "CHILD",  # The sender type is repeated here as a string to avoid a circular import.

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -14,6 +14,7 @@ from google.api_core import retry
 from google.cloud import pubsub_v1
 
 import octue.exceptions
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.cloud.events.counter import EventCounter
 from octue.cloud.events.validation import raise_if_event_is_invalid
 from octue.cloud.pub_sub import Subscription, Topic
@@ -124,10 +125,10 @@ class Service:
         :return octue.cloud.pub_sub.topic.Topic: the Octue services topic for the project
         """
         if not self._services_topic:
-            topic = Topic(name=self.backend.services_namespace, project_name=self.backend.project_name)
+            topic = Topic(name=OCTUE_SERVICES_PREFIX, project_name=self.backend.project_name)
 
             if not topic.exists():
-                raise octue.exceptions.ServiceNotFound(f"Topic {self.backend.services_namespace!r} cannot be found.")
+                raise octue.exceptions.ServiceNotFound(f"Topic {topic.name!r} cannot be found.")
 
             self._services_topic = topic
 
@@ -158,7 +159,7 @@ class Service:
         logger.info("Starting %r.", self)
 
         subscription = Subscription(
-            name=".".join((self.backend.services_namespace, self._pub_sub_id)),
+            name=".".join((OCTUE_SERVICES_PREFIX, self._pub_sub_id)),
             topic=self.services_topic,
             filter=f'attributes.recipient = "{self.id}" AND attributes.sender_type = "{PARENT_SENDER_TYPE}"',
             expiration_time=None,
@@ -354,7 +355,7 @@ class Service:
             pub_sub_id = convert_service_id_to_pub_sub_form(self.id)
 
             answer_subscription = Subscription(
-                name=".".join((self.backend.services_namespace, pub_sub_id, ANSWERS_NAMESPACE, question_uuid)),
+                name=".".join((OCTUE_SERVICES_PREFIX, pub_sub_id, ANSWERS_NAMESPACE, question_uuid)),
                 topic=self.services_topic,
                 filter=(
                     f'attributes.recipient = "{self.id}" '

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -229,6 +229,7 @@ class Service:
                     topic=self.topic,
                     question_uuid=question_uuid,
                     originator=originator,
+                    recipient=originator,
                 )
             else:
                 analysis_log_handler = None
@@ -257,6 +258,7 @@ class Service:
                 message=result,
                 topic=self.topic,
                 originator=originator,
+                recipient=originator,
                 attributes={"question_uuid": question_uuid, "sender_type": CHILD_SENDER_TYPE},
                 timeout=timeout,
             )
@@ -423,17 +425,19 @@ class Service:
             },
             topic=topic,
             originator=originator,
+            recipient=originator,
             attributes={"question_uuid": question_uuid, "sender_type": CHILD_SENDER_TYPE},
             timeout=timeout,
         )
 
-    def _send_message(self, message, topic, originator, attributes=None, timeout=30):
+    def _send_message(self, message, topic, originator, recipient, attributes=None, timeout=30):
         """Send a JSON-serialised message to the given topic with optional message attributes and increment the
         `messages_published` attribute of the topic by one. This method is thread-safe.
 
         :param dict message: JSON-serialisable data to send as a message
         :param octue.cloud.pub_sub.topic.Topic topic: the Pub/Sub topic to send the message to
         :param str originator: the SRUID of the service that asked the question this event is related to
+        :param str recipient:
         :param dict|None attributes: key-value pairs to attach to the message - the values must be strings or bytes
         :param int|float timeout: the timeout for sending the message in seconds
         :return google.cloud.pubsub_v1.publisher.futures.Future:
@@ -441,7 +445,7 @@ class Service:
         attributes = attributes or {}
         attributes["originator"] = originator
         attributes["sender"] = self.id
-        attributes["recipient"] = originator
+        attributes["recipient"] = recipient
 
         with send_message_lock:
             attributes["sender_sdk_version"] = self._local_sdk_version
@@ -503,6 +507,7 @@ class Service:
             topic=self.topic,
             timeout=timeout,
             originator=self.id,
+            recipient=service_id,
             attributes={
                 "question_uuid": question_uuid,
                 "forward_logs": forward_logs,
@@ -532,6 +537,7 @@ class Service:
             topic=topic,
             timeout=timeout,
             originator=originator,
+            recipient=originator,
             attributes={"question_uuid": question_uuid, "sender_type": CHILD_SENDER_TYPE},
         )
 
@@ -553,6 +559,7 @@ class Service:
             },
             topic=topic,
             originator=originator,
+            recipient=originator,
             timeout=timeout,
             attributes={"question_uuid": question_uuid, "sender_type": CHILD_SENDER_TYPE},
         )
@@ -573,6 +580,7 @@ class Service:
             {"kind": "monitor_message", "data": data},
             topic=topic,
             originator=originator,
+            recipient=originator,
             timeout=timeout,
             attributes={"question_uuid": question_uuid, "sender_type": CHILD_SENDER_TYPE},
         )

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -442,6 +442,7 @@ class Service:
             attributes["message_number"] = topic.messages_published
             attributes["sender"] = self.id
             attributes["recipient"] = get_sruid_from_pub_sub_resource_name(topic.name)
+            attributes["uuid"] = str(uuid.uuid4())
             converted_attributes = {}
 
             for key, value in attributes.items():

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -36,7 +36,7 @@ from octue.utils.threads import RepeatingTimer
 
 logger = logging.getLogger(__name__)
 
-# A lock to ensure only one message can be sent at a time so that the message number is incremented correctly when
+# A lock to ensure only one message can be sent at a time so that the ordering key is incremented correctly when
 # messages are being sent on multiple threads (e.g. via the main thread and a periodic monitor message thread). This
 # avoids 1) messages overwriting each other in the parent's message handler and 2) messages losing their order.
 send_message_lock = threading.Lock()
@@ -439,7 +439,7 @@ class Service:
 
         with send_message_lock:
             attributes["version"] = self._local_sdk_version
-            attributes["message_number"] = topic.messages_published
+            attributes["ordering_key"] = topic.messages_published
             attributes["sender"] = self.id
             attributes["recipient"] = get_sruid_from_pub_sub_resource_name(topic.name)
             attributes["uuid"] = str(uuid.uuid4())

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -405,7 +405,7 @@ class Service:
 
         self._event_handler = GoogleCloudPubSubEventHandler(
             subscription=subscription,
-            receiving_service=self,
+            recipient=self,
             handle_monitor_message=handle_monitor_message,
             record_events=record_messages,
         )
@@ -619,7 +619,7 @@ class Service:
         raise_if_event_is_invalid(
             event=event_for_validation,
             attributes=attributes,
-            receiving_service=self,
+            recipient=self,
             parent_sdk_version=attributes["sender_sdk_version"],
             child_sdk_version=importlib.metadata.version("octue"),
         )

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -453,15 +453,14 @@ class Service:
         :return google.cloud.pubsub_v1.publisher.futures.Future:
         """
         attributes = attributes or {}
+        attributes["uuid"] = str(uuid.uuid4())
         attributes["originator"] = originator
         attributes["sender"] = self.id
+        attributes["sender_sdk_version"] = self._local_sdk_version
         attributes["recipient"] = recipient
 
         with emit_event_lock:
-            attributes["sender_sdk_version"] = self._local_sdk_version
             attributes["order"] = self._events_emitted
-            attributes["uuid"] = str(uuid.uuid4())
-
             converted_attributes = {}
 
             for key, value in attributes.items():

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -242,7 +242,7 @@ class Service:
 
             if forward_logs:
                 analysis_log_handler = GoogleCloudPubSubHandler(
-                    event_emitter=self.emit_event,
+                    event_emitter=self._emit_event,
                     question_uuid=question_uuid,
                     originator=originator,
                     recipient=originator,
@@ -271,7 +271,7 @@ class Service:
             if analysis.output_manifest is not None:
                 result["output_manifest"] = analysis.output_manifest.to_primitive()
 
-            self.emit_event(
+            self._emit_event(
                 event=result,
                 originator=originator,
                 recipient=originator,
@@ -432,7 +432,7 @@ class Service:
         exception = convert_exception_to_primitives()
         exception_message = f"Error in {self!r}: {exception['message']}"
 
-        self.emit_event(
+        self._emit_event(
             {
                 "kind": "exception",
                 "exception_type": exception["type"],
@@ -446,7 +446,7 @@ class Service:
             timeout=timeout,
         )
 
-    def emit_event(self, event, originator, recipient, order, attributes=None, timeout=30):
+    def _emit_event(self, event, originator, recipient, order, attributes=None, timeout=30):
         """Emit a JSON-serialised event as a Pub/Sub message to the services topic with optional message attributes,
         incrementing the `order` argument by one. This method is thread-safe.
 
@@ -517,7 +517,7 @@ class Service:
             input_manifest.use_signed_urls_for_datasets()
             question["input_manifest"] = input_manifest.to_primitive()
 
-        future = self.emit_event(
+        future = self._emit_event(
             event=question,
             timeout=timeout,
             originator=self.id,
@@ -544,7 +544,7 @@ class Service:
         :param float timeout: time in seconds after which to give up sending
         :return None:
         """
-        self.emit_event(
+        self._emit_event(
             {
                 "kind": "delivery_acknowledgement",
                 "datetime": datetime.datetime.utcnow().isoformat(),
@@ -567,7 +567,7 @@ class Service:
         :param float timeout: time in seconds after which to give up sending
         :return None:
         """
-        self.emit_event(
+        self._emit_event(
             {
                 "kind": "heartbeat",
                 "datetime": datetime.datetime.utcnow().isoformat(),
@@ -591,7 +591,7 @@ class Service:
         :param float timeout: time in seconds to retry sending the message
         :return None:
         """
-        self.emit_event(
+        self._emit_event(
             {"kind": "monitor_message", "data": data},
             originator=originator,
             recipient=originator,

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -339,7 +339,6 @@ class Service:
                 name=".".join((self.backend.services_namespace, ANSWERS_NAMESPACE, pub_sub_id, question_uuid)),
                 topic=services_topic,
                 filter=(
-                    f'attributes.sender = "{service_id}" '
                     f'attributes.recipient = "{self.id}" '
                     f'AND attributes.question_uuid = "{question_uuid}" '
                     f'AND attributes.sender_type = "{CHILD_SENDER_TYPE}"'

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -461,7 +461,7 @@ class Service:
         attributes["recipient_revision_tag"] = recipient_revision_tag
 
         with send_message_lock:
-            attributes["version"] = self._local_sdk_version
+            attributes["sender_sdk_version"] = self._local_sdk_version
             attributes["order"] = topic.messages_published
             attributes["uuid"] = str(uuid.uuid4())
 
@@ -617,7 +617,7 @@ class Service:
             event=event_for_validation,
             attributes=attributes,
             receiving_service=self,
-            parent_sdk_version=attributes.get("version"),
+            parent_sdk_version=attributes["sender_sdk_version"],
             child_sdk_version=importlib.metadata.version("octue"),
         )
 
@@ -633,7 +633,7 @@ class Service:
             event,
             attributes["question_uuid"],
             attributes["forward_logs"],
-            attributes["version"],
+            attributes["sender_sdk_version"],
             attributes["save_diagnostics"],
             originator,
         )

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -425,6 +425,11 @@ class Service:
         )
 
     def _get_services_topic(self):
+        """Get the Octue services topic that all events in the project are published to.
+
+        :raise octue.exceptions.ServiceNotFound: if the topic doesn't exist in the project
+        :return octue.cloud.pub_sub.topic.Topic: the Octue services topic for the project
+        """
         topic = Topic(name=self.backend.services_namespace, project_name=self.backend.project_name)
 
         if not topic.exists():
@@ -433,14 +438,14 @@ class Service:
         return topic
 
     def _send_message(self, message, originator, recipient, attributes=None, timeout=30):
-        """Send a JSON-serialised message to the given topic with optional message attributes and increment the
-        `_events_emitted` attribute by one. This method is thread-safe.
+        """Send a JSON-serialised event as a Pub/Sub message to the services topic with optional message attributes,
+        incrementing the `_events_emitted` attribute by one. This method is thread-safe.
 
         :param dict message: JSON-serialisable data to send as a message
         :param str originator: the SRUID of the service that asked the question this event is related to
-        :param str recipient:
-        :param dict|None attributes: key-value pairs to attach to the message - the values must be strings or bytes
-        :param int|float timeout: the timeout for sending the message in seconds
+        :param str recipient: the SRUID of the service the event is intended for
+        :param dict|None attributes: key-value pairs to attach to the event - the values must be strings or bytes
+        :param int|float timeout: the timeout for sending the event in seconds
         :return google.cloud.pubsub_v1.publisher.futures.Future:
         """
         attributes = attributes or {}

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -333,7 +333,7 @@ class Service:
             pub_sub_id = convert_service_id_to_pub_sub_form(self.id)
 
             answer_subscription = Subscription(
-                name=".".join((self.backend.services_namespace, ANSWERS_NAMESPACE, pub_sub_id, question_uuid)),
+                name=".".join((self.backend.services_namespace, pub_sub_id, ANSWERS_NAMESPACE, question_uuid)),
                 topic=self.services_topic,
                 filter=(
                     f'attributes.recipient = "{self.id}" '

--- a/octue/cloud/pub_sub/service.py
+++ b/octue/cloud/pub_sub/service.py
@@ -36,9 +36,9 @@ from octue.utils.threads import RepeatingTimer
 
 logger = logging.getLogger(__name__)
 
-# A lock to ensure only one message can be sent at a time so that the ordering key is incremented correctly when
-# messages are being sent on multiple threads (e.g. via the main thread and a periodic monitor message thread). This
-# avoids 1) messages overwriting each other in the parent's message handler and 2) messages losing their order.
+# A lock to ensure only one message can be sent at a time so that the order is incremented correctly when messages are
+# being sent on multiple threads (e.g. via the main thread and a periodic monitor message thread). This avoids 1)
+# messages overwriting each other in the parent's message handler and 2) messages losing their order.
 send_message_lock = threading.Lock()
 
 DEFAULT_NAMESPACE = "default"
@@ -462,7 +462,7 @@ class Service:
 
         with send_message_lock:
             attributes["version"] = self._local_sdk_version
-            attributes["ordering_key"] = topic.messages_published
+            attributes["order"] = topic.messages_published
             attributes["uuid"] = str(uuid.uuid4())
 
             converted_attributes = {}

--- a/octue/cloud/pub_sub/subscription.py
+++ b/octue/cloud/pub_sub/subscription.py
@@ -13,7 +13,7 @@ from google.pubsub_v1.types.pubsub import (
     UpdateSubscriptionRequest,
 )
 
-from octue.cloud.service_id import OCTUE_SERVICES_NAMESPACE
+from octue import OCTUE_SERVICES_NAMESPACE
 from octue.exceptions import ConflictingSubscriptionType
 
 

--- a/octue/cloud/pub_sub/subscription.py
+++ b/octue/cloud/pub_sub/subscription.py
@@ -13,7 +13,6 @@ from google.pubsub_v1.types.pubsub import (
     UpdateSubscriptionRequest,
 )
 
-from octue import OCTUE_SERVICES_NAMESPACE
 from octue.exceptions import ConflictingSubscriptionType
 
 
@@ -55,11 +54,7 @@ class Subscription:
         push_endpoint=None,
         bigquery_table_id=None,
     ):
-        if not name.startswith(OCTUE_SERVICES_NAMESPACE):
-            self.name = f"{OCTUE_SERVICES_NAMESPACE}.{name}"
-        else:
-            self.name = name
-
+        self.name = name
         self.topic = topic
         self.filter = filter
         self.path = self.generate_subscription_path(project_name or self.topic.project_name, self.name)

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -6,8 +6,6 @@ import google.api_core.exceptions
 from google.cloud.pubsub_v1 import PublisherClient
 from google.pubsub_v1.types.pubsub import Topic as Topic_
 
-from octue import OCTUE_SERVICES_NAMESPACE
-
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +21,7 @@ class Topic:
     """
 
     def __init__(self, name, project_name):
-        if not name.startswith(OCTUE_SERVICES_NAMESPACE):
-            self.name = f"{OCTUE_SERVICES_NAMESPACE}.{name}"
-        else:
-            self.name = name
-
+        self.name = name
         self.project_name = project_name
         self.path = self.generate_topic_path(self.project_name, self.name)
         self.messages_published = 0

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -6,7 +6,7 @@ import google.api_core.exceptions
 from google.cloud.pubsub_v1 import PublisherClient
 from google.pubsub_v1.types.pubsub import Topic as Topic_
 
-from octue.cloud.service_id import OCTUE_SERVICES_NAMESPACE
+from octue import OCTUE_SERVICES_NAMESPACE
 
 
 logger = logging.getLogger(__name__)

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -41,7 +41,7 @@ class Topic:
 
         :return str:
         """
-        return f"<{type(self).__name__}({self.name})>"
+        return f"<{type(self).__name__}(name={self.name!r})>"
 
     def create(self, allow_existing=False):
         """Create a Google Pub/Sub topic that can be published to.

--- a/octue/cloud/pub_sub/topic.py
+++ b/octue/cloud/pub_sub/topic.py
@@ -24,7 +24,6 @@ class Topic:
         self.name = name
         self.project_name = project_name
         self.path = self.generate_topic_path(self.project_name, self.name)
-        self.messages_published = 0
         self._publisher = PublisherClient()
         self._created = False
 

--- a/octue/cloud/service_id.py
+++ b/octue/cloud/service_id.py
@@ -213,7 +213,7 @@ def get_sruid_from_pub_sub_resource_name(name):
     :param str name: the name of the topic or subscription
     :return str: the SRUID of the service revision the topic or subscription is related to
     """
-    _, _, namespace, name, revision_tag, *_ = name.split(".")
+    namespace, name, revision_tag, *_ = name.split(".")
     return f"{namespace}/{name}:{revision_tag.replace('-', '.')}"
 
 

--- a/octue/cloud/service_id.py
+++ b/octue/cloud/service_id.py
@@ -10,9 +10,6 @@ import octue.exceptions
 
 logger = logging.getLogger(__name__)
 
-
-OCTUE_SERVICES_NAMESPACE = "octue.services"
-
 SERVICE_NAMESPACE_AND_NAME_PATTERN = r"([a-z0-9])+(-([a-z0-9])+)*"
 COMPILED_SERVICE_NAMESPACE_AND_NAME_PATTERN = re.compile(SERVICE_NAMESPACE_AND_NAME_PATTERN)
 

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -4,6 +4,8 @@ import os
 
 import yaml
 
+from octue import OCTUE_SERVICES_NAMESPACE
+
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +20,7 @@ class ServiceConfiguration:
     :param str|None app_configuration_path: the path to the app configuration file containing configuration data for the service; if this is `None`, the default application configuration is used
     :param str|None diagnostics_cloud_path: the path to a cloud directory to store diagnostics (this includes the configuration, input values and manifest, and logs)
     :param iter(dict)|None service_registries: the names and endpoints of the registries used to resolve service revisions when asking questions; these should be in priority order (highest priority first)
+    :param str services_namespace: the services namespace to emit and consume events from
     :param str|None directory: if provided, find the app source, twine, and app configuration relative to this directory
     :return None:
     """
@@ -31,11 +34,15 @@ class ServiceConfiguration:
         app_configuration_path=None,
         diagnostics_cloud_path=None,
         service_registries=None,
+        services_namespace=OCTUE_SERVICES_NAMESPACE,
         directory=None,
         **kwargs,
     ):
         self.name = name
         self.namespace = namespace
+        self.diagnostics_cloud_path = diagnostics_cloud_path
+        self.service_registries = service_registries
+        self.services_namespace = services_namespace
 
         if directory:
             directory = os.path.abspath(directory)
@@ -60,9 +67,6 @@ class ServiceConfiguration:
                 self.app_configuration_path = os.path.abspath(app_configuration_path)
             else:
                 self.app_configuration_path = None
-
-        self.diagnostics_cloud_path = diagnostics_cloud_path
-        self.service_registries = service_registries
 
         if kwargs:
             logger.warning(f"The following keyword arguments were not used by {type(self).__name__}: {kwargs!r}.")

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -4,8 +4,6 @@ import os
 
 import yaml
 
-from octue import DEFAULT_OCTUE_SERVICES_NAMESPACE
-
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +18,6 @@ class ServiceConfiguration:
     :param str|None app_configuration_path: the path to the app configuration file containing configuration data for the service; if this is `None`, the default application configuration is used
     :param str|None diagnostics_cloud_path: the path to a cloud directory to store diagnostics (this includes the configuration, input values and manifest, and logs)
     :param iter(dict)|None service_registries: the names and endpoints of the registries used to resolve service revisions when asking questions; these should be in priority order (highest priority first)
-    :param str services_namespace: the services namespace to emit and consume events from
     :param str|None directory: if provided, find the app source, twine, and app configuration relative to this directory
     :return None:
     """
@@ -34,7 +31,6 @@ class ServiceConfiguration:
         app_configuration_path=None,
         diagnostics_cloud_path=None,
         service_registries=None,
-        services_namespace=DEFAULT_OCTUE_SERVICES_NAMESPACE,
         directory=None,
         **kwargs,
     ):
@@ -42,7 +38,6 @@ class ServiceConfiguration:
         self.namespace = namespace
         self.diagnostics_cloud_path = diagnostics_cloud_path
         self.service_registries = service_registries
-        self.services_namespace = services_namespace
 
         if directory:
             directory = os.path.abspath(directory)

--- a/octue/configuration.py
+++ b/octue/configuration.py
@@ -4,7 +4,7 @@ import os
 
 import yaml
 
-from octue import OCTUE_SERVICES_NAMESPACE
+from octue import DEFAULT_OCTUE_SERVICES_NAMESPACE
 
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class ServiceConfiguration:
         app_configuration_path=None,
         diagnostics_cloud_path=None,
         service_registries=None,
-        services_namespace=OCTUE_SERVICES_NAMESPACE,
+        services_namespace=DEFAULT_OCTUE_SERVICES_NAMESPACE,
         directory=None,
         **kwargs,
     ):

--- a/octue/resources/service_backends.py
+++ b/octue/resources/service_backends.py
@@ -36,23 +36,27 @@ class ServiceBackend(ABC):
 
 
 class GCPPubSubBackend(ServiceBackend):
-    """A dataclass containing the details needed to use Google Cloud Platform Pub/Sub as a Service backend.
+    """A dataclass containing the details needed to use Google Cloud Pub/Sub as a Service backend.
 
-    :param str project_name:
+    :param str project_name: the name of the project to use for Pub/Sub
+    :param str services_namespace: the name of the topic to publish/subscribe events to/from
     :return None:
     """
 
-    def __init__(self, project_name):
-        if project_name is None:
-            raise exceptions.CloudLocationNotSpecified(
-                "The project name must be specified for a service to connect to the correct Google Cloud Pub/Sub "
-                f"instance - it's currently {project_name!r}.",
-            )
+    ERROR_MESSAGE = (
+        "`project_name` and `services_namespace` must be specified for a service to connect to the correct service - "
+        "one of these is currently None."
+    )
+
+    def __init__(self, project_name, services_namespace):
+        if project_name is None or services_namespace is None:
+            raise exceptions.CloudLocationNotSpecified(self.ERROR_MESSAGE)
 
         self.project_name = project_name
+        self.services_namespace = services_namespace
 
     def __repr__(self):
-        return f"<{type(self).__name__}(project_name={self.project_name!r})>"
+        return f"<{type(self).__name__}(project_name={self.project_name!r}, services_namespace={self.services_namespace!r})>"
 
 
 AVAILABLE_BACKENDS = {

--- a/octue/resources/service_backends.py
+++ b/octue/resources/service_backends.py
@@ -39,25 +39,19 @@ class GCPPubSubBackend(ServiceBackend):
     """A dataclass containing the details needed to use Google Cloud Pub/Sub as a Service backend.
 
     :param str project_name: the name of the project to use for Pub/Sub
-    :param str services_namespace: the name of the topic to publish/subscribe events to/from
     :return None:
     """
 
-    ERROR_MESSAGE = (
-        "`project_name` and `services_namespace` must be specified for a service to connect to the correct service - "
-        "one of these is currently None."
-    )
-
-    # "octue.services" is repeated here to avoid a circular import.
-    def __init__(self, project_name, services_namespace="octue.services"):
-        if project_name is None or services_namespace is None:
-            raise exceptions.CloudLocationNotSpecified(self.ERROR_MESSAGE)
+    def __init__(self, project_name):
+        if project_name is None:
+            raise exceptions.CloudLocationNotSpecified(
+                "`project_name` must be specified for a service to connect to the correct service - received None."
+            )
 
         self.project_name = project_name
-        self.services_namespace = services_namespace
 
     def __repr__(self):
-        return f"<{type(self).__name__}(project_name={self.project_name!r}, services_namespace={self.services_namespace!r})>"
+        return f"<{type(self).__name__}(project_name={self.project_name!r})>"
 
 
 AVAILABLE_BACKENDS = {

--- a/octue/resources/service_backends.py
+++ b/octue/resources/service_backends.py
@@ -48,7 +48,8 @@ class GCPPubSubBackend(ServiceBackend):
         "one of these is currently None."
     )
 
-    def __init__(self, project_name, services_namespace):
+    # "octue.services" is repeated here to avoid a circular import.
+    def __init__(self, project_name, services_namespace="octue.services"):
         if project_name is None or services_namespace is None:
             raise exceptions.CloudLocationNotSpecified(self.ERROR_MESSAGE)
 

--- a/octue/utils/patches.py
+++ b/octue/utils/patches.py
@@ -14,9 +14,23 @@ class MultiPatcher:
 
         :return list(unittest.mock.MagicMock):
         """
-        return [patch.start() for patch in self.patches]
+        return self.start()
 
     def __exit__(self, *args, **kwargs):
+        """Stop the patches.
+
+        :return None:
+        """
+        self.stop()
+
+    def start(self):
+        """Start the patches and return the mocks they produce.
+
+        :return list(unittest.mock.MagicMock):
+        """
+        return [patch.start() for patch in self.patches]
+
+    def stop(self):
         """Stop the patches.
 
         :return None:

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -29,6 +29,16 @@ resource "google_bigquery_table" "test_table" {
     "mode": "REQUIRED"
   },
   {
+    "name": "uuid",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "originator",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
     "name": "sender",
     "type": "STRING",
     "mode": "REQUIRED"
@@ -39,17 +49,22 @@ resource "google_bigquery_table" "test_table" {
     "mode": "REQUIRED"
   },
   {
+    "name": "sender_sdk_version",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "recipient",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
     "name": "question_uuid",
     "type": "STRING",
     "mode": "REQUIRED"
   },
   {
-    "name": "version",
-    "type": "STRING",
-    "mode": "REQUIRED"
-  },
-  {
-    "name": "ordering_key",
+    "name": "order",
     "type": "STRING",
     "mode": "REQUIRED"
   },

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -9,7 +9,7 @@ resource "google_cloudfunctions2_function" "event_handler" {
     source {
       storage_source {
         bucket = "twined-gcp"
-        object = "event_handler_function_source.zip"
+        object = "event_handler/0.2.0.zip"
       }
     }
   }
@@ -23,12 +23,12 @@ resource "google_cloudfunctions2_function" "event_handler" {
     }
   }
 
-#  event_trigger {
-#    trigger_region = var.region
-#    event_type = "google.cloud.pubsub.topic.v1.messagePublished"
-#    pubsub_topic = google_pubsub_topic.topic.id
-#    retry_policy = "RETRY_POLICY_RETRY"
-#  }
+ event_trigger {
+   trigger_region = var.region
+   event_type = "google.cloud.pubsub.topic.v1.messagePublished"
+   pubsub_topic = google_pubsub_topic.services_topic.id
+   retry_policy = "RETRY_POLICY_RETRY"
+ }
 
 }
 
@@ -38,9 +38,4 @@ resource "google_cloud_run_service_iam_member" "function_invoker" {
   service  = google_cloudfunctions2_function.event_handler.name
   role     = "roles/run.invoker"
   member   = "allUsers"
-}
-
-
-output "function_uri" {
-  value = google_cloudfunctions2_function.event_handler.service_config[0].uri
 }

--- a/terraform/pub_sub.tf
+++ b/terraform/pub_sub.tf
@@ -1,0 +1,3 @@
+resource "google_pubsub_topic" "services_topic" {
+  name = "octue.services"
+}

--- a/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployment.py
+++ b/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployment.py
@@ -13,7 +13,7 @@ from octue.resources import Child
 class TestCloudRunDeployment(TestCase):
     # This is the service ID of the example service deployed to Google Cloud Run.
     child = Child(
-        id="octue/example-service-cloud-run:stream-event",
+        id="octue/example-service-cloud-run:0.4.0",
         backend={"name": "GCPPubSubBackend", "project_name": os.environ["TEST_PROJECT_NAME"]},
     )
 

--- a/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployment.py
+++ b/tests/cloud/deployment/google/cloud_run/test_cloud_run_deployment.py
@@ -13,7 +13,7 @@ from octue.resources import Child
 class TestCloudRunDeployment(TestCase):
     # This is the service ID of the example service deployed to Google Cloud Run.
     child = Child(
-        id="octue/example-service-cloud-run:0.3.2",
+        id="octue/example-service-cloud-run:stream-event",
         backend={"name": "GCPPubSubBackend", "project_name": os.environ["TEST_PROJECT_NAME"]},
     )
 

--- a/tests/cloud/emulators/test_child_emulator.py
+++ b/tests/cloud/emulators/test_child_emulator.py
@@ -2,18 +2,25 @@ import logging
 import os
 
 from octue.cloud import storage
-from octue.cloud.emulators._pub_sub import MockService
+from octue.cloud.emulators._pub_sub import MockService, MockTopic
 from octue.cloud.emulators.child import ChildEmulator, ServicePatcher
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.resources import Manifest
 from octue.resources.service_backends import GCPPubSubBackend
-from tests import MOCK_SERVICE_REVISION_TAG, TEST_BUCKET_NAME, TESTS_DIR
+from tests import MOCK_SERVICE_REVISION_TAG, TEST_BUCKET_NAME, TEST_PROJECT_NAME, TESTS_DIR
 from tests.base import BaseTestCase
 
 
 class TestChildEmulatorAsk(BaseTestCase):
 
     BACKEND = {"name": "GCPPubSubBackend", "project_name": "blah"}
+
+    @classmethod
+    def setUpClass(cls):
+        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+
+        with ServicePatcher():
+            topic.create(allow_existing=True)
 
     def test_representation(self):
         """Test that child emulators are represented correctly."""
@@ -296,6 +303,13 @@ class TestChildEmulatorAsk(BaseTestCase):
 class TestChildEmulatorJSONFiles(BaseTestCase):
 
     TEST_FILES_DIRECTORY = os.path.join(TESTS_DIR, "cloud", "emulators", "valid_child_emulator_files")
+
+    @classmethod
+    def setUpClass(cls):
+        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+
+        with ServicePatcher():
+            topic.create(allow_existing=True)
 
     def test_with_empty_file(self):
         """Test that a child emulator can be instantiated from an empty JSON file (a JSON file with only an empty

--- a/tests/cloud/emulators/test_child_emulator.py
+++ b/tests/cloud/emulators/test_child_emulator.py
@@ -4,6 +4,7 @@ import os
 from octue.cloud import storage
 from octue.cloud.emulators._pub_sub import MockService, MockTopic
 from octue.cloud.emulators.child import ChildEmulator, ServicePatcher
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.cloud.storage import GoogleCloudStorageClient
 from octue.resources import Manifest
 from octue.resources.service_backends import GCPPubSubBackend
@@ -17,7 +18,7 @@ class TestChildEmulatorAsk(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
 
         with ServicePatcher():
             topic.create(allow_existing=True)
@@ -306,7 +307,7 @@ class TestChildEmulatorJSONFiles(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
 
         with ServicePatcher():
             topic.create(allow_existing=True)

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -3,23 +3,12 @@ import math
 import uuid
 from unittest.mock import patch
 
-from octue.cloud.emulators._pub_sub import (
-    SUBSCRIPTIONS,
-    MockMessage,
-    MockService,
-    MockSubscriber,
-    MockSubscription,
-    MockTopic,
-)
+from octue.cloud.emulators._pub_sub import MESSAGES, MockMessage, MockService, MockSubscription, MockTopic
 from octue.cloud.emulators.child import ServicePatcher
 from octue.cloud.pub_sub.events import GoogleCloudPubSubEventHandler
-from octue.cloud.service_id import split_service_id
 from octue.resources.service_backends import GCPPubSubBackend
 from tests import TEST_PROJECT_NAME
 from tests.base import BaseTestCase
-
-
-parent = MockService(service_id="my-org/my-service:1.0.0", backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
 
 def create_mock_topic_and_subscription():
@@ -28,19 +17,27 @@ def create_mock_topic_and_subscription():
     :return (str, octue.cloud.emulators._pub_sub.MockTopic, octue.cloud.emulators._pub_sub.MockSubscription): question UUID, topic, and subscription
     """
     question_uuid = str(uuid.uuid4())
-    topic = MockTopic(name="my-org.my-service.1-0-0", project_name=TEST_PROJECT_NAME)
-    subscription = MockSubscription(name=f"my-org.my-service.1-0-0.answers.{question_uuid}", topic=topic)
 
+    topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+    topic.create(allow_existing=True)
+
+    subscription = MockSubscription(name=f"octue.services.my-org.my-service.1-0-0.answers.{question_uuid}", topic=topic)
     subscription.create()
-    return question_uuid, topic, subscription
+
+    with ServicePatcher():
+        parent = MockService(
+            service_id="my-org/my-service:1.0.0", backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME)
+        )
+
+    return question_uuid, topic, subscription, parent
 
 
 class TestPubSubEventHandler(BaseTestCase):
     def test_timeout(self):
         """Test that a TimeoutError is raised if message handling takes longer than the given timeout."""
-        question_uuid, _, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -53,9 +50,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_in_order_messages_are_handled_in_order(self):
         """Test that messages received in order are handled in order."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -63,7 +60,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 schema={},
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {"event": {"kind": "test"}, "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"}},
@@ -78,6 +75,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         result = event_handler.handle_events()
@@ -90,9 +88,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_out_of_order_messages_are_handled_in_order(self):
         """Test that messages received out of order are handled in order."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -100,7 +98,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 schema={},
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
@@ -128,6 +126,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         result = event_handler.handle_events()
@@ -148,9 +147,9 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that messages received out of order and with the final message (the message that triggers a value to be
         returned) are handled in order.
         """
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -158,7 +157,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 schema={},
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
@@ -186,6 +185,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         result = event_handler.handle_events()
@@ -204,9 +204,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_no_timeout(self):
         """Test that message handling works with no timeout."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -214,7 +214,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 schema={},
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
@@ -237,6 +237,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         result = event_handler.handle_events(timeout=None)
@@ -249,12 +250,11 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_delivery_acknowledgement(self):
         """Test that a delivery acknowledgement message is handled correctly."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
-
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
@@ -273,6 +273,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         result = event_handler.handle_events()
@@ -280,9 +281,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_raised_if_heartbeat_not_received_before_checked(self):
         """Test that an error is raised if a heartbeat isn't received before a heartbeat is first checked for."""
-        question_uuid, _, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
 
         with self.assertRaises(TimeoutError) as error:
@@ -293,9 +294,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_raised_if_heartbeats_stop_being_received(self):
         """Test that an error is raised if heartbeats stop being received within the maximum interval."""
-        question_uuid, _, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
 
         event_handler._last_heartbeat = datetime.datetime.now() - datetime.timedelta(seconds=30)
@@ -307,14 +308,13 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_not_raised_if_heartbeat_has_been_received_in_maximum_allowed_interval(self):
         """Test that an error is not raised if a heartbeat has been received in the maximum allowed interval."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         event_handler._last_heartbeat = datetime.datetime.now()
-
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
@@ -336,6 +336,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         with patch(
@@ -346,9 +347,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_time_since_last_heartbeat_is_none_if_no_heartbeat_received_yet(self):
         """Test that the time since the last heartbeat is `None` if no heartbeat has been received yet."""
-        question_uuid, _, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
 
         self.assertIsNone(event_handler._time_since_last_heartbeat)
@@ -357,13 +358,13 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that the total run time for the message handler is `None` if the `handle_events` method has not been
         called.
         """
-        question_uuid, _, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
         event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
         self.assertIsNone(event_handler.total_run_time)
 
     def test_time_since_missing_message_is_none_if_no_unhandled_missing_messages(self):
         """Test that the `time_since_missing_message` property is `None` if there are no unhandled missing messages."""
-        question_uuid, _, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
         event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
         self.assertIsNone(event_handler.time_since_missing_event)
 
@@ -371,9 +372,9 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that missing messages at the start of the event stream can be skipped if they aren't received after a
         given time period if subsequent messages have been received.
         """
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -382,10 +383,10 @@ class TestPubSubEventHandler(BaseTestCase):
                 skip_missing_events_after=0,
             )
 
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+
         # Simulate the first two messages not being received.
         mock_topic.messages_published = 2
-
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
@@ -412,6 +413,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         result = event_handler.handle_events()
@@ -429,9 +431,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_missing_messages_in_middle_can_skipped(self):
         """Test that missing messages in the middle of the event stream can be skipped."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -440,7 +442,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 skip_missing_events_after=0,
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Send three consecutive messages.
         messages = [
@@ -464,6 +466,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 attributes=message["attributes"],
                 topic=mock_topic,
                 originator=parent.id,
+                recipient=parent.id,
             )
 
         # Simulate missing messages.
@@ -475,6 +478,7 @@ class TestPubSubEventHandler(BaseTestCase):
             attributes={"question_uuid": question_uuid, "sender_type": "CHILD"},
             topic=mock_topic,
             originator=parent.id,
+            recipient=parent.id,
         )
 
         event_handler.handle_events()
@@ -492,9 +496,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_multiple_blocks_of_missing_messages_in_middle_can_skipped(self):
         """Test that multiple blocks of missing messages in the middle of the event stream can be skipped."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -503,7 +507,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 skip_missing_events_after=0,
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Send three consecutive messages.
         messages = [
@@ -523,7 +527,11 @@ class TestPubSubEventHandler(BaseTestCase):
 
         for message in messages:
             child._send_message(
-                message=message["event"], attributes=message["attributes"], topic=mock_topic, originator=parent.id
+                message=message["event"],
+                attributes=message["attributes"],
+                topic=mock_topic,
+                originator=parent.id,
+                recipient=parent.id,
             )
 
         # Simulate missing messages.
@@ -535,6 +543,7 @@ class TestPubSubEventHandler(BaseTestCase):
             attributes={"order": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
             topic=mock_topic,
             originator=parent.id,
+            recipient=parent.id,
         )
 
         # Simulate more missing messages.
@@ -562,7 +571,11 @@ class TestPubSubEventHandler(BaseTestCase):
 
         for message in messages:
             child._send_message(
-                message=message["event"], attributes=message["attributes"], topic=mock_topic, originator=parent.id
+                message=message["event"],
+                attributes=message["attributes"],
+                topic=mock_topic,
+                originator=parent.id,
+                recipient=parent.id,
             )
 
         event_handler.handle_events()
@@ -584,9 +597,9 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_all_messages_missing_apart_from_result(self):
         """Test that the result message is still handled if all other messages are missing."""
-        question_uuid, mock_topic, mock_subscription = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
 
-        with patch("octue.cloud.pub_sub.events.SubscriberClient", MockSubscriber):
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
                 subscription=mock_subscription,
                 receiving_service=parent,
@@ -595,7 +608,7 @@ class TestPubSubEventHandler(BaseTestCase):
                 skip_missing_events_after=0,
             )
 
-        child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
+            child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Simulate missing messages.
         mock_topic.messages_published = 1000
@@ -606,6 +619,7 @@ class TestPubSubEventHandler(BaseTestCase):
             attributes={"question_uuid": question_uuid, "sender_type": "CHILD"},
             topic=mock_topic,
             originator=parent.id,
+            recipient=parent.id,
         )
 
         event_handler.handle_events()
@@ -617,7 +631,7 @@ class TestPubSubEventHandler(BaseTestCase):
 class TestPullAndEnqueueAvailableMessages(BaseTestCase):
     def test_pull_and_enqueue_available_events(self):
         """Test that pulling and enqueuing a message works."""
-        question_uuid, mock_topic, _ = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, _, parent = create_mock_topic_and_subscription()
 
         with ServicePatcher():
             mock_subscription = MockSubscription(
@@ -640,25 +654,17 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
             # Enqueue a mock message for a mock subscription to receive.
             mock_message = {"kind": "test"}
 
-            originator_namespace, originator_name, originator_revision_tag = split_service_id(parent.id)
-
-            SUBSCRIPTIONS[mock_subscription.name] = [
+            MESSAGES[question_uuid] = [
                 MockMessage.from_primitive(
                     mock_message,
                     attributes={
-                        "sender_type": "CHILD",
                         "order": 0,
                         "question_uuid": question_uuid,
+                        "originator": parent.id,
+                        "sender": parent.id,
+                        "sender_type": "CHILD",
                         "sender_sdk_version": "0.50.0",
-                        "originator_namespace": originator_namespace,
-                        "originator_name": originator_name,
-                        "originator_revision_tag": originator_revision_tag,
-                        "sender_namespace": originator_namespace,
-                        "sender_name": originator_name,
-                        "sender_revision_tag": originator_revision_tag,
-                        "recipient_namespace": "my-org",
-                        "recipient_name": "my-service",
-                        "recipient_revision_tag": "1.0.0",
+                        "recipient": "my-org/my-service:1.0.0",
                     },
                 )
             ]
@@ -669,7 +675,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
 
     def test_timeout_error_raised_if_result_message_not_received_in_time(self):
         """Test that a timeout error is raised if a result message is not received in time."""
-        question_uuid, mock_topic, _ = create_mock_topic_and_subscription()
+        question_uuid, mock_topic, _, parent = create_mock_topic_and_subscription()
 
         with ServicePatcher():
             mock_subscription = MockSubscription(
@@ -686,9 +692,6 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
             event_handler._child_sdk_version = "0.1.3"
             event_handler.waiting_events = {}
             event_handler._start_time = 0
-
-            # Create a mock subscription.
-            SUBSCRIPTIONS[mock_subscription.name] = []
 
             with self.assertRaises(TimeoutError):
                 event_handler._pull_and_enqueue_available_events(timeout=1e-6)

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -85,7 +85,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -137,7 +137,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -192,7 +192,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -241,7 +241,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -278,7 +278,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -331,7 +331,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -397,7 +397,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -447,7 +447,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -456,7 +456,7 @@ class TestPubSubEventHandler(BaseTestCase):
             )
 
         # Send a final message.
-        child.emit_event(
+        child._emit_event(
             event={"kind": "finish-test", "order": 5},
             attributes={"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             originator=self.parent.id,
@@ -507,7 +507,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -516,7 +516,7 @@ class TestPubSubEventHandler(BaseTestCase):
             )
 
         # Send another message.
-        child.emit_event(
+        child._emit_event(
             event={"kind": "test", "order": 5},
             attributes={"order": 5, "question_uuid": self.question_uuid, "sender_type": "CHILD"},
             originator=self.parent.id,
@@ -546,7 +546,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child.emit_event(
+            child._emit_event(
                 event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
@@ -585,7 +585,7 @@ class TestPubSubEventHandler(BaseTestCase):
         child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Send the result message.
-        child.emit_event(
+        child._emit_event(
             event={"kind": "finish-test", "order": 1000},
             attributes={"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             originator=self.parent.id,

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from octue.cloud.emulators._pub_sub import MESSAGES, MockMessage, MockService, MockSubscription, MockTopic
 from octue.cloud.emulators.child import ServicePatcher
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.cloud.pub_sub.events import GoogleCloudPubSubEventHandler
 from octue.resources.service_backends import GCPPubSubBackend
 from tests import TEST_PROJECT_NAME
@@ -19,7 +20,7 @@ class TestPubSubEventHandler(BaseTestCase):
         cls.service_patcher.start()
         cls.question_uuid = str(uuid.uuid4())
 
-        cls.topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        cls.topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
         cls.topic.create(allow_existing=True)
 
         cls.subscription = MockSubscription(
@@ -607,7 +608,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
         cls.service_patcher.start()
         cls.question_uuid = str(uuid.uuid4())
 
-        cls.topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        cls.topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
         cls.topic.create(allow_existing=True)
 
         cls.subscription = MockSubscription(

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -11,37 +11,32 @@ from tests import TEST_PROJECT_NAME
 from tests.base import BaseTestCase
 
 
-def create_mock_topic_and_subscription():
-    """Create a question UUID, mock topic, mock subscription, and parent service.
-
-    :return (str, octue.cloud.emulators._pub_sub.MockTopic, octue.cloud.emulators._pub_sub.MockSubscription, octue.cloud.emulators._pub_sub.MockService): question UUID, topic, subscription, and parent service
-    """
-    question_uuid = str(uuid.uuid4())
-
-    topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
-    topic.create(allow_existing=True)
-
-    subscription = MockSubscription(name=f"my-org.my-service.1-0-0.answers.{question_uuid}", topic=topic)
-    subscription.create()
-
-    with ServicePatcher():
-        parent = MockService(
-            service_id="my-org/my-service:1.0.0",
-            backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME),
-        )
-
-    return question_uuid, topic, subscription, parent
-
-
 class TestPubSubEventHandler(BaseTestCase):
-    def test_timeout(self):
-        """Test that a TimeoutError is raised if message handling takes longer than the given timeout."""
-        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
+    @classmethod
+    def setUpClass(cls):
+        cls.question_uuid = str(uuid.uuid4())
+
+        cls.topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        cls.topic.create(allow_existing=True)
+
+        cls.subscription = MockSubscription(
+            name=f"my-org.my-service.1-0-0.answers.{cls.question_uuid}",
+            topic=cls.topic,
+        )
+        cls.subscription.create()
 
         with ServicePatcher():
+            cls.parent = MockService(
+                service_id="my-org/my-service:1.0.0",
+                backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME),
+            )
+
+    def test_timeout(self):
+        """Test that a TimeoutError is raised if message handling takes longer than the given timeout."""
+        with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: message},
                 schema={},
             )
@@ -51,12 +46,10 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_in_order_messages_are_handled_in_order(self):
         """Test that messages received in order are handled in order."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
             )
@@ -64,18 +57,21 @@ class TestPubSubEventHandler(BaseTestCase):
             child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
-            {"event": {"kind": "test"}, "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"}},
-            {"event": {"kind": "test"}, "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"}},
-            {"event": {"kind": "test"}, "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"}},
-            {"event": {"kind": "finish-test"}, "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"}},
+            {"event": {"kind": "test"}, "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"}},
+            {"event": {"kind": "test"}, "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"}},
+            {"event": {"kind": "test"}, "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"}},
+            {
+                "event": {"kind": "finish-test"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
+            },
         ]
 
         for message in messages:
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         result = event_handler.handle_events()
@@ -88,12 +84,10 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_out_of_order_messages_are_handled_in_order(self):
         """Test that messages received out of order are handled in order."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
             )
@@ -103,19 +97,19 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "test", "order": 1},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 2},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 0},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "finish-test", "order": 3},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -124,8 +118,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         result = event_handler.handle_events()
@@ -146,12 +140,10 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that messages received out of order and with the final message (the message that triggers a value to be
         returned) are handled in order.
         """
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
             )
@@ -161,19 +153,19 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "finish-test", "order": 3},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 1},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 2},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 0},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -182,8 +174,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         result = event_handler.handle_events()
@@ -202,12 +194,10 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_no_timeout(self):
         """Test that message handling works with no timeout."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
             )
@@ -217,15 +207,15 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "test", "order": 0},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 1},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "finish-test", "order": 2},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -233,8 +223,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         result = event_handler.handle_events(timeout=None)
@@ -247,20 +237,18 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_delivery_acknowledgement(self):
         """Test that a delivery acknowledgement message is handled correctly."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
-            event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+            event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
             child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
             {
                 "event": {"kind": "delivery_acknowledgement", "datetime": datetime.datetime.utcnow().isoformat()},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "result"},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -268,8 +256,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         result = event_handler.handle_events()
@@ -277,10 +265,8 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_raised_if_heartbeat_not_received_before_checked(self):
         """Test that an error is raised if a heartbeat isn't received before a heartbeat is first checked for."""
-        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
-            event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+            event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
 
         with self.assertRaises(TimeoutError) as error:
             event_handler.handle_events(maximum_heartbeat_interval=0)
@@ -290,10 +276,8 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_raised_if_heartbeats_stop_being_received(self):
         """Test that an error is raised if heartbeats stop being received within the maximum interval."""
-        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
-            event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+            event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
 
         event_handler._last_heartbeat = datetime.datetime.now() - datetime.timedelta(seconds=30)
 
@@ -304,10 +288,8 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_not_raised_if_heartbeat_has_been_received_in_maximum_allowed_interval(self):
         """Test that an error is not raised if a heartbeat has been received in the maximum allowed interval."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
-            event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+            event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
             child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         event_handler._last_heartbeat = datetime.datetime.now()
@@ -318,11 +300,11 @@ class TestPubSubEventHandler(BaseTestCase):
                     "kind": "delivery_acknowledgement",
                     "datetime": datetime.datetime.utcnow().isoformat(),
                 },
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "result"},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -330,8 +312,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         with patch(
@@ -342,10 +324,8 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_time_since_last_heartbeat_is_none_if_no_heartbeat_received_yet(self):
         """Test that the time since the last heartbeat is `None` if no heartbeat has been received yet."""
-        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
-            event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+            event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
 
         self.assertIsNone(event_handler._time_since_last_heartbeat)
 
@@ -353,26 +333,22 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that the total run time for the message handler is `None` if the `handle_events` method has not been
         called.
         """
-        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
-        event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
         self.assertIsNone(event_handler.total_run_time)
 
     def test_time_since_missing_message_is_none_if_no_unhandled_missing_messages(self):
         """Test that the `time_since_missing_message` property is `None` if there are no unhandled missing messages."""
-        question_uuid, _, mock_subscription, parent = create_mock_topic_and_subscription()
-        event_handler = GoogleCloudPubSubEventHandler(subscription=mock_subscription, receiving_service=parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
         self.assertIsNone(event_handler.time_since_missing_event)
 
     def test_missing_messages_at_start_can_be_skipped(self):
         """Test that missing messages at the start of the event stream can be skipped if they aren't received after a
         given time period if subsequent messages have been received.
         """
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
                 skip_missing_events_after=0,
@@ -386,19 +362,19 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "test", "order": 2},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 3},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 4},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "finish-test", "order": 5},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -406,8 +382,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         result = event_handler.handle_events()
@@ -425,12 +401,10 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_missing_messages_in_middle_can_skipped(self):
         """Test that missing messages in the middle of the event stream can be skipped."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
                 skip_missing_events_after=0,
@@ -442,15 +416,15 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "test", "order": 0},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 1},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 2},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -458,8 +432,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         # Simulate missing messages.
@@ -468,9 +442,9 @@ class TestPubSubEventHandler(BaseTestCase):
         # Send a final message.
         child._send_message(
             message={"kind": "finish-test", "order": 5},
-            attributes={"question_uuid": question_uuid, "sender_type": "CHILD"},
-            originator=parent.id,
-            recipient=parent.id,
+            attributes={"question_uuid": self.question_uuid, "sender_type": "CHILD"},
+            originator=self.parent.id,
+            recipient=self.parent.id,
         )
 
         event_handler.handle_events()
@@ -488,12 +462,10 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_multiple_blocks_of_missing_messages_in_middle_can_skipped(self):
         """Test that multiple blocks of missing messages in the middle of the event stream can be skipped."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
                 skip_missing_events_after=0,
@@ -505,15 +477,15 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "test", "order": 0},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 1},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 2},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -521,8 +493,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         # Simulate missing messages.
@@ -531,9 +503,9 @@ class TestPubSubEventHandler(BaseTestCase):
         # Send another message.
         child._send_message(
             message={"kind": "test", "order": 5},
-            attributes={"order": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
-            originator=parent.id,
-            recipient=parent.id,
+            attributes={"order": 5, "question_uuid": self.question_uuid, "sender_type": "CHILD"},
+            originator=self.parent.id,
+            recipient=self.parent.id,
         )
 
         # Simulate more missing messages.
@@ -543,19 +515,19 @@ class TestPubSubEventHandler(BaseTestCase):
         messages = [
             {
                 "event": {"kind": "test", "order": 20},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 21},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "test", "order": 22},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
             {
                 "event": {"kind": "finish-test", "order": 23},
-                "attributes": {"question_uuid": question_uuid, "sender_type": "CHILD"},
+                "attributes": {"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             },
         ]
 
@@ -563,8 +535,8 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                originator=parent.id,
-                recipient=parent.id,
+                originator=self.parent.id,
+                recipient=self.parent.id,
             )
 
         event_handler.handle_events()
@@ -586,12 +558,10 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_all_messages_missing_apart_from_result(self):
         """Test that the result message is still handled if all other messages are missing."""
-        question_uuid, mock_topic, mock_subscription, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
                 skip_missing_events_after=0,
@@ -605,9 +575,9 @@ class TestPubSubEventHandler(BaseTestCase):
         # Send the result message.
         child._send_message(
             message={"kind": "finish-test", "order": 1000},
-            attributes={"question_uuid": question_uuid, "sender_type": "CHILD"},
-            originator=parent.id,
-            recipient=parent.id,
+            attributes={"question_uuid": self.question_uuid, "sender_type": "CHILD"},
+            originator=self.parent.id,
+            recipient=self.parent.id,
         )
 
         event_handler.handle_events()
@@ -617,24 +587,41 @@ class TestPubSubEventHandler(BaseTestCase):
 
 
 class TestPullAndEnqueueAvailableMessages(BaseTestCase):
-    def test_pull_and_enqueue_available_events(self):
-        """Test that pulling and enqueuing a message works."""
-        question_uuid, mock_topic, _, parent = create_mock_topic_and_subscription()
+    @classmethod
+    def setUpClass(cls):
+        cls.question_uuid = str(uuid.uuid4())
+
+        cls.topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        cls.topic.create(allow_existing=True)
+
+        cls.subscription = MockSubscription(
+            name=f"my-org.my-service.1-0-0.answers.{cls.question_uuid}",
+            topic=cls.topic,
+        )
+        cls.subscription.create()
 
         with ServicePatcher():
-            mock_subscription = MockSubscription(
-                name=f"my-org.my-service.1-0-0.answers.{question_uuid}",
-                topic=mock_topic,
+            cls.parent = MockService(
+                service_id="my-org/my-service:1.0.0",
+                backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME),
+            )
+
+    def test_pull_and_enqueue_available_events(self):
+        """Test that pulling and enqueuing a message works."""
+        with ServicePatcher():
+            self.subscription = MockSubscription(
+                name=f"my-org.my-service.1-0-0.answers.{self.question_uuid}",
+                topic=self.topic,
             )
 
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
                 schema={},
             )
 
-            event_handler.question_uuid = question_uuid
+            event_handler.question_uuid = self.question_uuid
             event_handler.child_sruid = "my-org/my-service:1.0.0"
             event_handler._child_sdk_version = "0.1.3"
             event_handler.waiting_events = {}
@@ -642,14 +629,14 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
             # Enqueue a mock message for a mock subscription to receive.
             mock_message = {"kind": "test"}
 
-            MESSAGES[question_uuid] = [
+            MESSAGES[self.question_uuid] = [
                 MockMessage.from_primitive(
                     mock_message,
                     attributes={
                         "order": 0,
-                        "question_uuid": question_uuid,
-                        "originator": parent.id,
-                        "sender": parent.id,
+                        "question_uuid": self.question_uuid,
+                        "originator": self.parent.id,
+                        "sender": self.parent.id,
                         "sender_type": "CHILD",
                         "sender_sdk_version": "0.50.0",
                         "recipient": "my-org/my-service:1.0.0",
@@ -663,17 +650,15 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
 
     def test_timeout_error_raised_if_result_message_not_received_in_time(self):
         """Test that a timeout error is raised if a result message is not received in time."""
-        question_uuid, mock_topic, _, parent = create_mock_topic_and_subscription()
-
         with ServicePatcher():
-            mock_subscription = MockSubscription(
-                name=f"my-org.my-service.1-0-0.answers.{question_uuid}",
-                topic=mock_topic,
+            self.subscription = MockSubscription(
+                name=f"my-org.my-service.1-0-0.answers.{self.question_uuid}",
+                topic=self.topic,
             )
 
             event_handler = GoogleCloudPubSubEventHandler(
-                subscription=mock_subscription,
-                receiving_service=parent,
+                subscription=self.subscription,
+                receiving_service=self.parent,
                 event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             )
 

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -649,7 +649,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
                         "sender_type": "CHILD",
                         "order": 0,
                         "question_uuid": question_uuid,
-                        "version": "0.50.0",
+                        "sender_sdk_version": "0.50.0",
                         "originator_namespace": originator_namespace,
                         "originator_name": originator_name,
                         "originator_revision_tag": originator_revision_tag,

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -84,8 +84,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -136,8 +136,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -191,8 +191,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -240,8 +240,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -277,8 +277,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -330,8 +330,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -396,8 +396,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -446,8 +446,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -455,8 +455,8 @@ class TestPubSubEventHandler(BaseTestCase):
             )
 
         # Send a final message.
-        child._send_message(
-            message={"kind": "finish-test", "order": 5},
+        child.emit_event(
+            event={"kind": "finish-test", "order": 5},
             attributes={"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             originator=self.parent.id,
             recipient=self.parent.id,
@@ -506,8 +506,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -515,8 +515,8 @@ class TestPubSubEventHandler(BaseTestCase):
             )
 
         # Send another message.
-        child._send_message(
-            message={"kind": "test", "order": 5},
+        child.emit_event(
+            event={"kind": "test", "order": 5},
             attributes={"order": 5, "question_uuid": self.question_uuid, "sender_type": "CHILD"},
             originator=self.parent.id,
             recipient=self.parent.id,
@@ -545,8 +545,8 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            child._send_message(
-                message=message["event"],
+            child.emit_event(
+                event=message["event"],
                 attributes=message["attributes"],
                 originator=self.parent.id,
                 recipient=self.parent.id,
@@ -584,8 +584,8 @@ class TestPubSubEventHandler(BaseTestCase):
         child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Send the result message.
-        child._send_message(
-            message={"kind": "finish-test", "order": 1000},
+        child.emit_event(
+            event={"kind": "finish-test", "order": 1000},
             attributes={"question_uuid": self.question_uuid, "sender_type": "CHILD"},
             originator=self.parent.id,
             recipient=self.parent.id,

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -532,7 +532,7 @@ class TestPubSubEventHandler(BaseTestCase):
         # Send another message.
         child._send_message(
             message={"kind": "test", "order": 5},
-            attributes={"ordering_key": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
+            attributes={"order": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
             topic=mock_topic,
             originator=parent.id,
         )
@@ -647,7 +647,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
                     mock_message,
                     attributes={
                         "sender_type": "CHILD",
-                        "ordering_key": 0,
+                        "order": 0,
                         "question_uuid": question_uuid,
                         "version": "0.50.0",
                         "originator_namespace": originator_namespace,

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -12,9 +12,9 @@ from tests.base import BaseTestCase
 
 
 def create_mock_topic_and_subscription():
-    """Create a question UUID, mock topic, and mock subscription.
+    """Create a question UUID, mock topic, mock subscription, and parent service.
 
-    :return (str, octue.cloud.emulators._pub_sub.MockTopic, octue.cloud.emulators._pub_sub.MockSubscription): question UUID, topic, and subscription
+    :return (str, octue.cloud.emulators._pub_sub.MockTopic, octue.cloud.emulators._pub_sub.MockSubscription, octue.cloud.emulators._pub_sub.MockService): question UUID, topic, subscription, and parent service
     """
     question_uuid = str(uuid.uuid4())
 
@@ -26,7 +26,8 @@ def create_mock_topic_and_subscription():
 
     with ServicePatcher():
         parent = MockService(
-            service_id="my-org/my-service:1.0.0", backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME)
+            service_id="my-org/my-service:1.0.0",
+            backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME),
         )
 
     return question_uuid, topic, subscription, parent
@@ -73,7 +74,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -124,7 +124,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -183,7 +182,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -235,7 +233,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -271,7 +268,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -334,7 +330,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -411,7 +406,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -464,7 +458,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -476,7 +469,6 @@ class TestPubSubEventHandler(BaseTestCase):
         child._send_message(
             message={"kind": "finish-test", "order": 5},
             attributes={"question_uuid": question_uuid, "sender_type": "CHILD"},
-            topic=mock_topic,
             originator=parent.id,
             recipient=parent.id,
         )
@@ -529,7 +521,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -541,7 +532,6 @@ class TestPubSubEventHandler(BaseTestCase):
         child._send_message(
             message={"kind": "test", "order": 5},
             attributes={"order": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
-            topic=mock_topic,
             originator=parent.id,
             recipient=parent.id,
         )
@@ -573,7 +563,6 @@ class TestPubSubEventHandler(BaseTestCase):
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
-                topic=mock_topic,
                 originator=parent.id,
                 recipient=parent.id,
             )
@@ -617,7 +606,6 @@ class TestPubSubEventHandler(BaseTestCase):
         child._send_message(
             message={"kind": "finish-test", "order": 1000},
             attributes={"question_uuid": question_uuid, "sender_type": "CHILD"},
-            topic=mock_topic,
             originator=parent.id,
             recipient=parent.id,
         )

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -488,7 +488,7 @@ class TestPubSubEventHandler(BaseTestCase):
         # Send another message.
         child._send_message(
             message={"kind": "test", "order": 5},
-            attributes={"message_number": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
+            attributes={"ordering_key": 5, "question_uuid": question_uuid, "sender_type": "CHILD"},
             topic=mock_topic,
         )
 
@@ -597,7 +597,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
                     mock_message,
                     attributes={
                         "sender_type": "CHILD",
-                        "message_number": 0,
+                        "ordering_key": 0,
                         "question_uuid": question_uuid,
                         "version": "0.50.0",
                     },

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -45,7 +45,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that a TimeoutError is raised if message handling takes longer than the given timeout."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: message},
             schema={},
         )
@@ -57,7 +57,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that messages received in order are handled in order."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
         )
@@ -109,7 +109,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that messages received out of order are handled in order."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
         )
@@ -164,7 +164,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
         )
@@ -217,7 +217,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that message handling works with no timeout."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
         )
@@ -258,7 +258,7 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_delivery_acknowledgement(self):
         """Test that a delivery acknowledgement message is handled correctly."""
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
         child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         messages = [
@@ -290,7 +290,7 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_raised_if_heartbeat_not_received_before_checked(self):
         """Test that an error is raised if a heartbeat isn't received before a heartbeat is first checked for."""
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
 
         with self.assertRaises(TimeoutError) as error:
             event_handler.handle_events(maximum_heartbeat_interval=0)
@@ -300,7 +300,7 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_raised_if_heartbeats_stop_being_received(self):
         """Test that an error is raised if heartbeats stop being received within the maximum interval."""
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
         event_handler._last_heartbeat = datetime.datetime.now() - datetime.timedelta(seconds=30)
 
         with self.assertRaises(TimeoutError) as error:
@@ -310,7 +310,7 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_error_not_raised_if_heartbeat_has_been_received_in_maximum_allowed_interval(self):
         """Test that an error is not raised if a heartbeat has been received in the maximum allowed interval."""
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
         child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
         event_handler._last_heartbeat = datetime.datetime.now()
 
@@ -346,19 +346,19 @@ class TestPubSubEventHandler(BaseTestCase):
 
     def test_time_since_last_heartbeat_is_none_if_no_heartbeat_received_yet(self):
         """Test that the time since the last heartbeat is `None` if no heartbeat has been received yet."""
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
         self.assertIsNone(event_handler._time_since_last_heartbeat)
 
     def test_total_run_time_is_none_if_handle_events_has_not_been_called(self):
         """Test that the total run time for the message handler is `None` if the `handle_events` method has not been
         called.
         """
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
         self.assertIsNone(event_handler.total_run_time)
 
     def test_time_since_missing_message_is_none_if_no_unhandled_missing_messages(self):
         """Test that the `time_since_missing_message` property is `None` if there are no unhandled missing messages."""
-        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, receiving_service=self.parent)
+        event_handler = GoogleCloudPubSubEventHandler(subscription=self.subscription, recipient=self.parent)
         self.assertIsNone(event_handler.time_since_missing_event)
 
     def test_missing_messages_at_start_can_be_skipped(self):
@@ -367,7 +367,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
             skip_missing_events_after=0,
@@ -421,7 +421,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that missing messages in the middle of the event stream can be skipped."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
             skip_missing_events_after=0,
@@ -481,7 +481,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that multiple blocks of missing messages in the middle of the event stream can be skipped."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
             skip_missing_events_after=0,
@@ -575,7 +575,7 @@ class TestPubSubEventHandler(BaseTestCase):
         """Test that the result message is still handled if all other messages are missing."""
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
             skip_missing_events_after=0,
@@ -638,7 +638,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
 
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
             schema={},
         )
@@ -679,7 +679,7 @@ class TestPullAndEnqueueAvailableMessages(BaseTestCase):
 
         event_handler = GoogleCloudPubSubEventHandler(
             subscription=self.subscription,
-            receiving_service=self.parent,
+            recipient=self.parent,
             event_handlers={"test": lambda message: None, "finish-test": lambda message: "This is the result."},
         )
 

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -21,7 +21,7 @@ def create_mock_topic_and_subscription():
     topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
     topic.create(allow_existing=True)
 
-    subscription = MockSubscription(name=f"octue.services.my-org.my-service.1-0-0.answers.{question_uuid}", topic=topic)
+    subscription = MockSubscription(name=f"my-org.my-service.1-0-0.answers.{question_uuid}", topic=topic)
     subscription.create()
 
     with ServicePatcher():

--- a/tests/cloud/pub_sub/test_events.py
+++ b/tests/cloud/pub_sub/test_events.py
@@ -120,7 +120,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            mock_topic.messages_published = message["event"]["order"]
+            child._events_emitted = message["event"]["order"]
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
@@ -179,7 +179,7 @@ class TestPubSubEventHandler(BaseTestCase):
         ]
 
         for message in messages:
-            mock_topic.messages_published = message["event"]["order"]
+            child._events_emitted = message["event"]["order"]
             child._send_message(
                 message=message["event"],
                 attributes=message["attributes"],
@@ -386,7 +386,7 @@ class TestPubSubEventHandler(BaseTestCase):
             child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Simulate the first two messages not being received.
-        mock_topic.messages_published = 2
+        child._events_emitted = 2
 
         messages = [
             {
@@ -470,7 +470,7 @@ class TestPubSubEventHandler(BaseTestCase):
             )
 
         # Simulate missing messages.
-        mock_topic.messages_published = 5
+        child._events_emitted = 5
 
         # Send a final message.
         child._send_message(
@@ -535,7 +535,7 @@ class TestPubSubEventHandler(BaseTestCase):
             )
 
         # Simulate missing messages.
-        mock_topic.messages_published = 5
+        child._events_emitted = 5
 
         # Send another message.
         child._send_message(
@@ -547,7 +547,7 @@ class TestPubSubEventHandler(BaseTestCase):
         )
 
         # Simulate more missing messages.
-        mock_topic.messages_published = 20
+        child._events_emitted = 20
 
         # Send more consecutive messages.
         messages = [
@@ -611,7 +611,7 @@ class TestPubSubEventHandler(BaseTestCase):
             child = MockService(backend=GCPPubSubBackend(project_name=TEST_PROJECT_NAME))
 
         # Simulate missing messages.
-        mock_topic.messages_published = 1000
+        child._events_emitted = 1000
 
         # Send the result message.
         child._send_message(

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -17,11 +17,11 @@ class NonJSONSerialisable:
 class TestGoogleCloudPubSubHandler(BaseTestCase):
     def test_emit(self):
         """Test the log message is published when `GoogleCloudPubSubHandler.emit` is called."""
-        topic = MockTopic(name="world", project_name="blah")
+        topic = MockTopic(name="octue.my-service.3-3-3", project_name="blah")
         topic.create()
 
         question_uuid = "96d69278-44ac-4631-aeea-c90fb08a1b2b"
-        subscription = MockSubscription(name=f"world.answers.{question_uuid}", topic=topic)
+        subscription = MockSubscription(name=f"octue.my-service.3-3-3.answers.{question_uuid}", topic=topic)
         subscription.create()
 
         log_record = makeLogRecord({"msg": "Starting analysis."})
@@ -33,6 +33,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
             message_sender=service._send_message,
             topic=topic,
             question_uuid=question_uuid,
+            originator=service.id,
         ).emit(log_record)
 
         self.assertEqual(
@@ -44,7 +45,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
         """Test that non-JSON-serialisable arguments to log messages are converted to their string representation
         before being serialised and published to the Pub/Sub topic.
         """
-        topic = MockTopic(name="world-1", project_name="blah")
+        topic = MockTopic(name="octue.my-service.3-3-4", project_name="blah")
         topic.create()
 
         non_json_serialisable_thing = NonJSONSerialisable()
@@ -65,6 +66,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
                 message_sender=service._send_message,
                 topic=topic,
                 question_uuid="question-uuid",
+                originator=service.id,
             ).emit(record)
 
         self.assertEqual(

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from octue.cloud.emulators._pub_sub import MESSAGES, MockService, MockTopic
 from octue.cloud.emulators.child import ServicePatcher
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.cloud.events.counter import EventCounter
 from octue.cloud.pub_sub.logging import GoogleCloudPubSubHandler
 from octue.resources.service_backends import GCPPubSubBackend
@@ -27,7 +28,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
         :return None:
         """
         cls.service_patcher.start()
-        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
         topic.create(allow_existing=True)
 
     @classmethod

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -45,7 +45,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
         service = MockService(backend=GCPPubSubBackend(project_name="blah"))
 
         GoogleCloudPubSubHandler(
-            message_sender=service._send_message,
+            event_emitter=service.emit_event,
             question_uuid=question_uuid,
             originator="another/service:1.0.0",
             recipient="another/service:1.0.0",
@@ -75,7 +75,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
 
         with patch("octue.cloud.emulators._pub_sub.MockPublisher.publish") as mock_publish:
             GoogleCloudPubSubHandler(
-                message_sender=service._send_message,
+                event_emitter=service.emit_event,
                 question_uuid="question-uuid",
                 originator="another/service:1.0.0",
                 recipient="another/service:1.0.0",

--- a/tests/cloud/pub_sub/test_logging.py
+++ b/tests/cloud/pub_sub/test_logging.py
@@ -46,7 +46,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
         service = MockService(backend=GCPPubSubBackend(project_name="blah"))
 
         GoogleCloudPubSubHandler(
-            event_emitter=service.emit_event,
+            event_emitter=service._emit_event,
             question_uuid=question_uuid,
             originator="another/service:1.0.0",
             recipient="another/service:1.0.0",
@@ -76,7 +76,7 @@ class TestGoogleCloudPubSubHandler(BaseTestCase):
 
         with patch("octue.cloud.emulators._pub_sub.MockPublisher.publish") as mock_publish:
             GoogleCloudPubSubHandler(
-                event_emitter=service.emit_event,
+                event_emitter=service._emit_event,
                 question_uuid="question-uuid",
                 originator="another/service:1.0.0",
                 recipient="another/service:1.0.0",

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -326,7 +326,7 @@ class TestService(BaseTestCase):
             with self.service_patcher:
                 child.serve()
                 subscription, _ = parent.ask(service_id=child.id, input_values={}, subscribe_to_logs=True)
-                parent.wait_for_answer(subscription)
+                parent.wait_for_answer(subscription, timeout=10)
 
         error_logged = False
 

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -115,6 +115,14 @@ class TestService(BaseTestCase):
         self.assertFalse(future.returned)
         self.assertFalse(subscriber.closed)
 
+    def test_missing_services_topic_results_in_error(self):
+        """Test that an error is raised if the services topic doesn't exist."""
+        service = MockService(backend=BACKEND)
+
+        with patch("octue.cloud.emulators._pub_sub.TOPICS", set()):
+            with self.assertRaises(exceptions.ServiceNotFound):
+                service.services_topic
+
     def test_ask_unregistered_service_revision_when_service_registries_specified_results_in_error(self):
         """Test that an error is raised if attempting to ask an unregistered service a question when service registries
         are being used.
@@ -549,7 +557,7 @@ class TestService(BaseTestCase):
 
         for i in range(5):
             subscription, _ = parent.ask(service_id=child.id, input_values={})
-            answers.append(parent.wait_for_answer(subscription, timeout=3600))
+            answers.append(parent.wait_for_answer(subscription))
 
         for answer in answers:
             self.assertEqual(

--- a/tests/cloud/pub_sub/test_service.py
+++ b/tests/cloud/pub_sub/test_service.py
@@ -21,6 +21,7 @@ from octue.cloud.emulators._pub_sub import (
 )
 from octue.cloud.emulators.child import ServicePatcher
 from octue.cloud.emulators.cloud_storage import mock_generate_signed_url
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.cloud.pub_sub.service import Service
 from octue.exceptions import InvalidMonitorMessage
 from octue.resources import Analysis, Datafile, Dataset, Manifest
@@ -49,7 +50,7 @@ class TestService(BaseTestCase):
         :return None:
         """
         cls.service_patcher.start()
-        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
         topic.create(allow_existing=True)
 
     @classmethod

--- a/tests/cloud/pub_sub/test_subscription.py
+++ b/tests/cloud/pub_sub/test_subscription.py
@@ -17,13 +17,7 @@ class TestSubscription(BaseTestCase):
 
     def test_repr(self):
         """Test that subscriptions are represented correctly."""
-        self.assertEqual(repr(self.subscription), "<Subscription(name='octue.services.world', filter=None)>")
-
-    def test_namespace_only_in_name_once(self):
-        """Test that the subscription's namespace only appears in its name once, even if it is repeated."""
-        self.assertEqual(self.subscription.name, "octue.services.world")
-        subscription_with_repeated_namespace = Subscription(name="octue.services.world", topic=self.topic)
-        self.assertEqual(subscription_with_repeated_namespace.name, "octue.services.world")
+        self.assertEqual(repr(self.subscription), "<Subscription(name='world', filter=None)>")
 
     def test_create_without_allow_existing_when_subscription_already_exists(self):
         """Test that an error is raised when trying to create a subscription that already exists and `allow_existing` is

--- a/tests/cloud/pub_sub/test_topic.py
+++ b/tests/cloud/pub_sub/test_topic.py
@@ -10,7 +10,7 @@ class TestTopic(BaseTestCase):
     def test_repr(self):
         """Test that Topics are represented correctly."""
         topic = Topic(name="world", project_name="my-project")
-        self.assertEqual(repr(topic), "<Topic(world)>")
+        self.assertEqual(repr(topic), "<Topic(name='world')>")
 
     def test_create(self):
         """Test that a topic can be created and that it's marked as having its creation triggered locally."""

--- a/tests/cloud/pub_sub/test_topic.py
+++ b/tests/cloud/pub_sub/test_topic.py
@@ -10,15 +10,7 @@ class TestTopic(BaseTestCase):
     def test_repr(self):
         """Test that Topics are represented correctly."""
         topic = Topic(name="world", project_name="my-project")
-        self.assertEqual(repr(topic), "<Topic(octue.services.world)>")
-
-    def test_namespace_only_in_name_once(self):
-        """Test that the topic's namespace only appears in its name once, even if it is repeated."""
-        topic = Topic(name="world", project_name="my-project")
-        self.assertEqual(topic.name, "octue.services.world")
-
-        topic_with_repeated_namespace = Topic(name="octue.services.world", project_name="my-project")
-        self.assertEqual(topic_with_repeated_namespace.name, "octue.services.world")
+        self.assertEqual(repr(topic), "<Topic(world)>")
 
     def test_create(self):
         """Test that a topic can be created and that it's marked as having its creation triggered locally."""

--- a/tests/cloud/test_service_id.py
+++ b/tests/cloud/test_service_id.py
@@ -84,7 +84,6 @@ class TestConvertServiceIDToPubSubForm(unittest.TestCase):
             ("octue/my-service", "octue.my-service"),
             ("octue/my-service:0.1.7", "octue.my-service.0-1-7"),
             ("my-service:3.1.9", "my-service.3-1-9"),
-            ("octue.services.octue/my-service:0.1.7", "octue.services.octue.my-service.0-1-7"),
         )
 
         for service_id, pub_sub_service_id in service_ids:
@@ -95,7 +94,7 @@ class TestConvertServiceIDToPubSubForm(unittest.TestCase):
 class TestGetSRUIDFromPubSubResourceName(unittest.TestCase):
     def test_get_sruid_from_pub_sub_resource_name(self):
         """Test that an SRUID can be extracted from a Pub/Sub resource name."""
-        sruid = get_sruid_from_pub_sub_resource_name("octue.services.octue.example-service-cloud-run.0-3-2")
+        sruid = get_sruid_from_pub_sub_resource_name("octue.example-service-cloud-run.0-3-2")
         self.assertEqual(sruid, "octue/example-service-cloud-run:0.3.2")
 
 

--- a/tests/cloud/test_service_id.py
+++ b/tests/cloud/test_service_id.py
@@ -10,6 +10,7 @@ import octue.exceptions
 from octue.cloud.service_id import (
     convert_service_id_to_pub_sub_form,
     get_default_sruid,
+    get_sruid_from_pub_sub_resource_name,
     get_sruid_parts,
     raise_if_revision_not_registered,
     split_service_id,
@@ -89,6 +90,13 @@ class TestConvertServiceIDToPubSubForm(unittest.TestCase):
         for service_id, pub_sub_service_id in service_ids:
             with self.subTest(service_id=service_id, pub_sub_service_id=pub_sub_service_id):
                 self.assertEqual(convert_service_id_to_pub_sub_form(service_id), pub_sub_service_id)
+
+
+class TestGetSRUIDFromPubSubResourceName(unittest.TestCase):
+    def test_get_sruid_from_pub_sub_resource_name(self):
+        """Test that an SRUID can be extracted from a Pub/Sub resource name."""
+        sruid = get_sruid_from_pub_sub_resource_name("octue.services.octue.example-service-cloud-run.0-3-2")
+        self.assertEqual(sruid, "octue/example-service-cloud-run:0.3.2")
 
 
 class TestValidateSRUID(unittest.TestCase):

--- a/tests/data/events.json
+++ b/tests/data/events.json
@@ -5,7 +5,7 @@
       "kind": "delivery_acknowledgement"
     },
     "attributes": {
-      "message_number": "0",
+      "ordering_key": "0",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -39,7 +39,7 @@
       }
     },
     "attributes": {
-      "message_number": "1",
+      "ordering_key": "1",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -73,7 +73,7 @@
       }
     },
     "attributes": {
-      "message_number": "2",
+      "ordering_key": "2",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -107,7 +107,7 @@
       }
     },
     "attributes": {
-      "message_number": "3",
+      "ordering_key": "3",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -141,7 +141,7 @@
       }
     },
     "attributes": {
-      "message_number": "4",
+      "ordering_key": "4",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -175,7 +175,7 @@
       }
     },
     "attributes": {
-      "message_number": "5",
+      "ordering_key": "5",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -204,7 +204,7 @@
       "output_values": [1, 2, 3, 4, 5]
     },
     "attributes": {
-      "message_number": "6",
+      "ordering_key": "6",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",
@@ -217,7 +217,7 @@
       "kind": "heartbeat"
     },
     "attributes": {
-      "message_number": "7",
+      "ordering_key": "7",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
       "sender_type": "CHILD",
       "version": "0.51.0",

--- a/tests/data/events.json
+++ b/tests/data/events.json
@@ -5,11 +5,13 @@
       "kind": "delivery_acknowledgement"
     },
     "attributes": {
-      "ordering_key": "0",
+      "order": "0",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -39,11 +41,13 @@
       }
     },
     "attributes": {
-      "ordering_key": "1",
+      "order": "1",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -73,11 +77,13 @@
       }
     },
     "attributes": {
-      "ordering_key": "2",
+      "order": "2",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -107,11 +113,13 @@
       }
     },
     "attributes": {
-      "ordering_key": "3",
+      "order": "3",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -141,11 +149,13 @@
       }
     },
     "attributes": {
-      "ordering_key": "4",
+      "order": "4",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -175,11 +185,13 @@
       }
     },
     "attributes": {
-      "ordering_key": "5",
+      "order": "5",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -204,11 +216,13 @@
       "output_values": [1, 2, 3, 4, 5]
     },
     "attributes": {
-      "ordering_key": "6",
+      "order": "6",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   },
   {
@@ -217,11 +231,13 @@
       "kind": "heartbeat"
     },
     "attributes": {
-      "ordering_key": "7",
+      "order": "7",
       "question_uuid": "d45c7e99-d610-413b-8130-dd6eef46dda6",
+      "originator": "octue/test-service:1.0.0",
+      "sender": "octue/test-service:1.0.0",
       "sender_type": "CHILD",
-      "version": "0.51.0",
-      "sender": "octue/test-service:1.0.0"
+      "sender_sdk_version": "0.51.0",
+      "recipient": "octue/another-service:3.2.1"
     }
   }
 ]

--- a/tests/resources/test_child.py
+++ b/tests/resources/test_child.py
@@ -10,6 +10,7 @@ from google.auth.exceptions import DefaultCredentialsError
 
 from octue.cloud.emulators._pub_sub import MockAnalysis, MockService, MockTopic
 from octue.cloud.emulators.child import ServicePatcher
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.resources.child import Child
 from octue.resources.service_backends import GCPPubSubBackend
 from tests import MOCK_SERVICE_REVISION_TAG, TEST_PROJECT_NAME
@@ -41,7 +42,7 @@ class TestChild(BaseTestCase):
         :return None:
         """
         cls.service_patcher.start()
-        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
         topic.create(allow_existing=True)
 
     @classmethod

--- a/tests/resources/test_service_backends.py
+++ b/tests/resources/test_service_backends.py
@@ -16,9 +16,16 @@ class TestServiceBackends(BaseTestCase):
 
     def test_repr(self):
         """Test the representation displays as expected."""
-        self.assertEqual(repr(GCPPubSubBackend(project_name="hello")), "<GCPPubSubBackend(project_name='hello')>")
+        self.assertEqual(
+            repr(GCPPubSubBackend(project_name="hello", services_namespace="world")),
+            "<GCPPubSubBackend(project_name='hello', services_namespace='world')>",
+        )
 
-    def test_error_raised_if_project_name_is_none(self):
-        """Test that an error is raised if the project name is not given during `GCPPubSubBackend` instantiation."""
-        with self.assertRaises(CloudLocationNotSpecified):
-            GCPPubSubBackend(project_name=None)
+    def test_error_raised_if_project_name_or_services_namespace_is_none(self):
+        """Test that an error is raised if the project name or services namespace aren't given during `GCPPubSubBackend`
+        instantiation.
+        """
+        for project_name, services_namespace in (("hello", None), (None, "world")):
+            with self.subTest(project_name=project_name, services_namespace=services_namespace):
+                with self.assertRaises(CloudLocationNotSpecified):
+                    GCPPubSubBackend(project_name=project_name, services_namespace=services_namespace)

--- a/tests/resources/test_service_backends.py
+++ b/tests/resources/test_service_backends.py
@@ -16,16 +16,9 @@ class TestServiceBackends(BaseTestCase):
 
     def test_repr(self):
         """Test the representation displays as expected."""
-        self.assertEqual(
-            repr(GCPPubSubBackend(project_name="hello", services_namespace="world")),
-            "<GCPPubSubBackend(project_name='hello', services_namespace='world')>",
-        )
+        self.assertEqual(repr(GCPPubSubBackend(project_name="hello")), "<GCPPubSubBackend(project_name='hello')>")
 
-    def test_error_raised_if_project_name_or_services_namespace_is_none(self):
-        """Test that an error is raised if the project name or services namespace aren't given during `GCPPubSubBackend`
-        instantiation.
-        """
-        for project_name, services_namespace in (("hello", None), (None, "world")):
-            with self.subTest(project_name=project_name, services_namespace=services_namespace):
-                with self.assertRaises(CloudLocationNotSpecified):
-                    GCPPubSubBackend(project_name=project_name, services_namespace=services_namespace)
+    def test_error_raised_if_project_name_is_none(self):
+        """Test that an error is raised if the project name isn't given during `GCPPubSubBackend` instantiation."""
+        with self.assertRaises(CloudLocationNotSpecified):
+            GCPPubSubBackend(project_name=None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -474,6 +474,6 @@ class TestDeployCommand(BaseTestCase):
 
             self.assertIsNone(result.exception)
             self.assertEqual(result.exit_code, 0)
-            self.assertEqual(subscription.call_args.kwargs["topic"].name, "octue.services.octue.example-service.3-5-0")
+            self.assertEqual(subscription.call_args.kwargs["topic"].name, "octue.example-service.3-5-0")
             self.assertEqual(subscription.call_args.kwargs["name"], "octue.example-service.3-5-0-peter-rabbit")
             self.assertEqual(subscription.call_args.kwargs["push_endpoint"], "https://example.com/endpoint")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from octue.cli import octue_cli
 from octue.cloud import storage
 from octue.cloud.emulators._pub_sub import MockService, MockTopic
 from octue.cloud.emulators.child import ServicePatcher
+from octue.cloud.events import OCTUE_SERVICES_PREFIX
 from octue.configuration import AppConfiguration, ServiceConfiguration
 from octue.resources import Dataset
 from octue.utils.patches import MultiPatcher
@@ -194,7 +195,7 @@ class TestStartCommand(BaseTestCase):
             },
         )
 
-        topic = MockTopic(name="octue.services", project_name=TEST_PROJECT_NAME)
+        topic = MockTopic(name=OCTUE_SERVICES_PREFIX, project_name=TEST_PROJECT_NAME)
 
         with ServicePatcher():
             topic.create(allow_existing=True)


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#639](https://github.com/octue/octue-sdk-python/pull/639))

**IMPORTANT:** There are 4 breaking changes.

### New features
- 💥 **BREAKING CHANGE:** Publish events and subscribe to them with a single `octue.services` topic per workspace

### Enhancements
- 💥 **BREAKING CHANGE:** Add mandatory originator, sender, recipient, and UUID event attributes
- Make `Topic`'s representation consistent with `Subscription`'s
- Add string representation to `MockMessageWrapper`

### Fixes
- Only update earliest waiting event number in event handler if there are waiting messages
- Fix race condition in event emission order by factoring `order` out of `Topic` and into new `EventCounter` class
- Avoid silently failing if `question_uuid` attribute missing

### Operations
- Add `octue.services` topic to terraform config
- Update bigquery table and event handler cloud function

### Refactoring
- 💥 **BREAKING CHANGE:** Rename `message_number` to `order`
- 💥 **BREAKING CHANGE:** Rename `version` attribute to `sender_sdk_version`
- Rename `receiving_service` to `recipient`
- Rename `Service._send_message` to `Service._emit_event`

### Testing
- Test `get_sruid_from_pub_sub_resource_name`
- Simplify `GoogleCloudPubSubHandler` tests
- Simplify pub/sub event handler tests
- Factor out service patching to start of test classes

---
# Upgrade instructions
Update all services in your services network to use this version of `octue` or later (`0.53.0`+).
<!--- END AUTOGENERATED NOTES --->